### PR TITLE
[codex] Fix deployed login API and DB write config

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,4 +1,5 @@
 app = "tdf-hq"
+primary_region = "gru"
 
 [build]
   dockerfile = "tdf-hq/Dockerfile"

--- a/memory/2026-07-09.md
+++ b/memory/2026-07-09.md
@@ -1,0 +1,7 @@
+# 2026-07-09
+
+- Investigated the deployed `tdf-app.pages.dev/login` "Internal server error" shown during username/password login.
+- Found the likely frontend cause: when `VITE_API_BASE` is absent in the Cloudflare Pages bundle, auth/session/shared API clients post to same-origin `/login` instead of the Fly backend.
+- Added a shared UI API-base resolver that keeps explicit `VITE_API_BASE` first, preserves same-origin behavior for local/unknown hosts, and falls back to `https://tdf-hq.fly.dev` only for `tdf-app.pages.dev` and its preview subdomains.
+- Confirmed the live Fly backend also returned `500` on `/login`; Fly/Postgres metadata showed the `tdf_hq` database defaulted sessions to `default_transaction_read_only=on` even on the primary. Backend config now adds a libpq session option to force `default_transaction_read_only=off`, and `fly.toml` pins the app primary region to the Postgres primary region `gru`.
+- Verified with focused Jest tests, UI typecheck, and production UI build.

--- a/tdf-hq-ui/src/api/auth.ts
+++ b/tdf-hq-ui/src/api/auth.ts
@@ -1,9 +1,9 @@
 import type { components } from './generated/types';
 import type { SignupRole } from '../constants/roles';
 import { extractErrorDetails } from './errorMessage';
-import { env } from '../utils/env';
+import { resolveApiBase } from '../config/apiBase';
 
-const API_BASE = env.read('VITE_API_BASE') ?? '';
+const API_BASE = resolveApiBase();
 const SERVICE_STARTING_MESSAGE = 'El servicio está arrancando. Intenta de nuevo en unos segundos.';
 const AUTH_NETWORK_ERROR_MESSAGE = 'No se pudo conectar con el servicio. Revisa tu conexión e inténtalo de nuevo.';
 const RETRYABLE_UNAVAILABLE_STATUS = 503;

--- a/tdf-hq-ui/src/api/client.ts
+++ b/tdf-hq-ui/src/api/client.ts
@@ -2,9 +2,9 @@ import { logger } from '../utils/logger';
 import { buildAuthorizationHeader } from './authHeader';
 import { extractErrorDetails } from './errorMessage';
 import { isSessionAuthFailureMessage, notifyAuthSessionExpired } from '../session/authEvents';
-import { env } from '../utils/env';
+import { resolveApiBase } from '../config/apiBase';
 
-const API_BASE = env.read('VITE_API_BASE') ?? '';
+const API_BASE = resolveApiBase();
 export const API_BASE_URL = API_BASE;
 const ABSOLUTE_URL_PATTERN = /^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//;
 

--- a/tdf-hq-ui/src/api/generated/client.ts
+++ b/tdf-hq-ui/src/api/generated/client.ts
@@ -1,14 +1,14 @@
 // API client for user role management
 import type { components } from './types';
 import { buildAuthorizationHeader } from '../authHeader';
-import { env } from '../../utils/env';
+import { resolveApiBase } from '../../config/apiBase';
 
 export type Role = components['schemas']['Role'];
 export type UserSummary = components['schemas']['UserRoleSummary'];
 type RoleInput = Role | (string & Record<never, never>);
 export type UserRoleUpdate = { roles: RoleInput[] };
 
-const API_BASE = env.read('VITE_API_BASE') ?? '';
+const API_BASE = resolveApiBase();
 const ABSOLUTE_URL_PATTERN = /^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//;
 
 const isJsonContentType = (contentType: string): boolean => /[/+]json(?:;|$)/i.test(contentType);

--- a/tdf-hq-ui/src/api/session.ts
+++ b/tdf-hq-ui/src/api/session.ts
@@ -1,7 +1,7 @@
 import type { components } from './generated/types';
-import { env } from '../utils/env';
+import { resolveApiBase } from '../config/apiBase';
 
-const API_BASE = env.read('VITE_API_BASE') ?? '';
+const API_BASE = resolveApiBase();
 
 export type SessionResponseDTO = components['schemas']['SessionResponse'];
 

--- a/tdf-hq-ui/src/config/apiBase.test.ts
+++ b/tdf-hq-ui/src/config/apiBase.test.ts
@@ -1,0 +1,36 @@
+import { jest } from '@jest/globals';
+
+const envReadMock = jest.fn<(key: string) => string | undefined>(() => undefined);
+
+jest.unstable_mockModule('../utils/env', () => ({
+  env: {
+    read: envReadMock,
+  },
+}));
+
+const { DEFAULT_DEPLOYED_API_BASE, resolveApiBase } = await import('./apiBase');
+
+describe('resolveApiBase', () => {
+  beforeEach(() => {
+    envReadMock.mockReset().mockReturnValue(undefined);
+  });
+
+  it('uses an explicit VITE_API_BASE and normalizes trailing slashes', () => {
+    envReadMock.mockReturnValue('  https://api.tdf.test///  ');
+
+    expect(resolveApiBase({ hostname: 'tdf-app.pages.dev' })).toBe('https://api.tdf.test');
+  });
+
+  it('falls back to the Fly backend on the public Cloudflare Pages host', () => {
+    expect(resolveApiBase({ hostname: 'tdf-app.pages.dev' })).toBe(DEFAULT_DEPLOYED_API_BASE);
+  });
+
+  it('falls back to the Fly backend on Cloudflare Pages preview hosts', () => {
+    expect(resolveApiBase({ hostname: 'preview.tdf-app.pages.dev' })).toBe(DEFAULT_DEPLOYED_API_BASE);
+  });
+
+  it('keeps same-origin requests for local and unknown hosts without VITE_API_BASE', () => {
+    expect(resolveApiBase({ hostname: 'localhost' })).toBe('');
+    expect(resolveApiBase({ hostname: 'example.com' })).toBe('');
+  });
+});

--- a/tdf-hq-ui/src/config/apiBase.ts
+++ b/tdf-hq-ui/src/config/apiBase.ts
@@ -1,0 +1,25 @@
+import { env } from '../utils/env';
+
+export const DEFAULT_DEPLOYED_API_BASE = 'https://tdf-hq.fly.dev';
+
+const stripTrailingSlash = (value: string): string => value.replace(/\/+$/, '');
+
+const isTdfPagesHost = (hostname: string): boolean => {
+  const normalized = hostname.trim().toLowerCase();
+  return normalized === 'tdf-app.pages.dev' || normalized.endsWith('.tdf-app.pages.dev');
+};
+
+export const resolveApiBase = (
+  options: { envValue?: string | null; hostname?: string | null } = {},
+): string => {
+  const configured = options.envValue ?? env.read('VITE_API_BASE');
+  if (typeof configured === 'string' && configured.trim() !== '') {
+    return stripTrailingSlash(configured.trim());
+  }
+
+  const hostname =
+    options.hostname ??
+    (typeof window !== 'undefined' ? window.location.hostname : '');
+
+  return hostname && isTdfPagesHost(hostname) ? DEFAULT_DEPLOYED_API_BASE : '';
+};

--- a/tdf-hq/src/TDF/Config.hs
+++ b/tdf-hq/src/TDF/Config.hs
@@ -132,7 +132,8 @@ ragEmbeddingDim cfg = fromMaybe 1536 (openAiEmbedDimensions (openAiEmbedModel cf
 
 dbConnString :: AppConfig -> String
 dbConnString cfg =
-  ensureReadWriteTargetSession (fromMaybe keywordStyle (dbConnUrl cfg))
+  ensureReadWriteSessionOptions $
+    ensureReadWriteTargetSession (fromMaybe keywordStyle (dbConnUrl cfg))
   where
     keywordStyle =
       appendKeywordOption "sslmode" (dbSslMode cfg) $
@@ -515,6 +516,27 @@ ensureReadWriteTargetSession rawConn
         Nothing -> False
     hasTargetSessionAttrsKeyword conn =
       any ("target_session_attrs=" `isPrefixOf`) (words conn)
+    isPostgresUrl conn =
+      "postgresql://" `isPrefixOf` conn || "postgres://" `isPrefixOf` conn
+
+ensureReadWriteSessionOptions :: String -> String
+ensureReadWriteSessionOptions rawConn
+  | isPostgresUrl normalized && hasOptionsUrlParam rawConn = rawConn
+  | isPostgresUrl normalized =
+      rawConn
+        <> if '?' `elem` rawConn
+             then "&options=-c%20default_transaction_read_only%3Doff"
+             else "?options=-c%20default_transaction_read_only%3Doff"
+  | hasOptionsKeyword normalized = rawConn
+  | otherwise = rawConn <> " options='-c default_transaction_read_only=off'"
+  where
+    normalized = map toLower rawConn
+    hasOptionsUrlParam conn =
+      case extractConnUrlParam "options" conn of
+        Just _ -> True
+        Nothing -> False
+    hasOptionsKeyword conn =
+      any ("options=" `isPrefixOf`) (words conn)
     isPostgresUrl conn =
       "postgresql://" `isPrefixOf` conn || "postgres://" `isPrefixOf` conn
 

--- a/tdf-hq/test/Spec.hs
+++ b/tdf-hq/test/Spec.hs
@@ -2793,7 +2793,7 @@ main = hspec $ do
                 ]
                 $ do
                     cfg <- loadConfig
-                    dbConnString cfg `shouldBe` "host=127.0.0.1 port=5432 user=postgres password=postgres dbname=tdf_hq target_session_attrs=read-write"
+                    dbConnString cfg `shouldBe` "host=127.0.0.1 port=5432 user=postgres password=postgres dbname=tdf_hq target_session_attrs=read-write options='-c default_transaction_read_only=off'"
 
         it "requires keyword target_session_attrs to be a standalone connection option" $
             withEnvOverrides
@@ -2815,7 +2815,8 @@ main = hspec $ do
                         `shouldBe`
                             "host=tdf-hq-db.flycast port=5432 user=tdf_hq password=secret "
                                 <> "dbname=tdf_hq_target_session_attrs=debug "
-                                <> "target_session_attrs=read-write"
+                                <> "target_session_attrs=read-write "
+                                <> "options='-c default_transaction_read_only=off'"
 
         it "keeps fallback connection URL aliases from shaping complete DB_* settings" $
             withEnvOverrides
@@ -2833,7 +2834,7 @@ main = hspec $ do
                 ]
                 $ do
                     cfg <- loadConfig
-                    dbConnString cfg `shouldBe` "host=tdf-hq-db.flycast port=5432 user=tdf_hq password=secret dbname=tdf_hq target_session_attrs=read-write"
+                    dbConnString cfg `shouldBe` "host=tdf-hq-db.flycast port=5432 user=tdf_hq password=secret dbname=tdf_hq target_session_attrs=read-write options='-c default_transaction_read_only=off'"
 
         it "ignores sslmode from DATABASE_URL when DB_* vars stay authoritative" $
             withEnvOverrides
@@ -2850,7 +2851,7 @@ main = hspec $ do
                 ]
                 $ do
                     cfg <- loadConfig
-                    dbConnString cfg `shouldBe` "host=tdf-hq-db.flycast port=5432 user=tdf_hq password=secret dbname=tdf_hq target_session_attrs=read-write"
+                    dbConnString cfg `shouldBe` "host=tdf-hq-db.flycast port=5432 user=tdf_hq password=secret dbname=tdf_hq target_session_attrs=read-write options='-c default_transaction_read_only=off'"
 
         it "prefers explicit PGSSLMODE when DB_* vars stay authoritative" $
             withEnvOverrides
@@ -2867,7 +2868,7 @@ main = hspec $ do
                 ]
                 $ do
                     cfg <- loadConfig
-                    dbConnString cfg `shouldBe` "host=tdf-hq-db.flycast port=5432 user=tdf_hq password=secret dbname=tdf_hq sslmode=disable target_session_attrs=read-write"
+                    dbConnString cfg `shouldBe` "host=tdf-hq-db.flycast port=5432 user=tdf_hq password=secret dbname=tdf_hq sslmode=disable target_session_attrs=read-write options='-c default_transaction_read_only=off'"
 
         it "rejects malformed keyword sslmode values before building ambiguous DB connection strings" $
             withEnvOverrides
@@ -2938,7 +2939,7 @@ main = hspec $ do
                 ]
                 $ do
                     cfg <- loadConfig
-                    dbConnString cfg `shouldBe` "postgresql://flyuser:flypass@db.fly.internal:5432/tdf_hq?target_session_attrs=read-write"
+                    dbConnString cfg `shouldBe` "postgresql://flyuser:flypass@db.fly.internal:5432/tdf_hq?target_session_attrs=read-write&options=-c%20default_transaction_read_only%3Doff"
 
         it "applies explicit DB sslmode to DATABASE_URL fallback connection strings" $ do
             let baseUrl = "postgresql://flyuser:flypass@db.fly.internal:5432/tdf_hq"
@@ -2966,7 +2967,7 @@ main = hspec $ do
                     cfg <- loadConfig
                     dbConnString cfg
                         `shouldBe`
-                            baseUrl <> "?sslmode=require&target_session_attrs=read-write"
+                            baseUrl <> "?sslmode=require&target_session_attrs=read-write&options=-c%20default_transaction_read_only%3Doff"
 
             withEnvOverrides
                 (withoutKeywordDb (baseUrl <> "?sslmode=require") (Just "disable"))
@@ -2995,7 +2996,7 @@ main = hspec $ do
                     cfg <- loadConfig
                     dbConnString cfg
                         `shouldBe`
-                            "postgresql://flyuser:flypass@db.fly.internal:5432/tdf_hq?target_session_attrs=read-write"
+                            "postgresql://flyuser:flypass@db.fly.internal:5432/tdf_hq?target_session_attrs=read-write&options=-c%20default_transaction_read_only%3Doff"
 
         it "rejects conflicting connection URL aliases before choosing a DB fallback target" $
             withEnvOverrides
@@ -3039,7 +3040,7 @@ main = hspec $ do
                 ]
                 $ do
                     cfg <- loadConfig
-                    dbConnString cfg `shouldBe` "postgresql://flyuser:flypass@db.fly.internal:5432/tdf_hq?target_session_attrs=read-write"
+                    dbConnString cfg `shouldBe` "postgresql://flyuser:flypass@db.fly.internal:5432/tdf_hq?target_session_attrs=read-write&options=-c%20default_transaction_read_only%3Doff"
 
         it "falls back to standard PG* env vars when DB_* vars are not configured" $
             withEnvOverrides
@@ -3060,7 +3061,7 @@ main = hspec $ do
                 ]
                 $ do
                     cfg <- loadConfig
-                    dbConnString cfg `shouldBe` "host=pg.fly.internal port=6543 user=flyuser password=flypass dbname=flydb target_session_attrs=read-write"
+                    dbConnString cfg `shouldBe` "host=pg.fly.internal port=6543 user=flyuser password=flypass dbname=flydb target_session_attrs=read-write options='-c default_transaction_read_only=off'"
 
         it "rejects conflicting keyword DB aliases instead of silently choosing a fallback" $ do
             let completeKeywordDb =
@@ -3120,7 +3121,7 @@ main = hspec $ do
                 ]
                 $ do
                     cfg <- loadConfig
-                    dbConnString cfg `shouldBe` "postgresql://flyuser:flypass@db.fly.internal:5432/tdf_hq?sslmode=require&target_session_attrs=read-write"
+                    dbConnString cfg `shouldBe` "postgresql://flyuser:flypass@db.fly.internal:5432/tdf_hq?sslmode=require&target_session_attrs=read-write&options=-c%20default_transaction_read_only%3Doff"
 
         it "requires target_session_attrs to be an actual non-blank URL query parameter" $ do
             let baseUrl = "postgresql://flyuser:flypass@db.fly.internal:5432/tdf_hq"
@@ -3151,6 +3152,7 @@ main = hspec $ do
                         `shouldBe` baseUrl
                             <> "?application_name=target_session_attrs=debug"
                             <> "&target_session_attrs=read-write"
+                            <> "&options=-c%20default_transaction_read_only%3Doff"
 
             withEnvOverrides
                 (withoutKeywordDb (baseUrl <> "?target_session_attrs="))


### PR DESCRIPTION
## What changed

- Added a shared frontend API-base resolver so `tdf-app.pages.dev` falls back to `https://tdf-hq.fly.dev` when `VITE_API_BASE` is missing.
- Routed auth, session, shared API, and generated role clients through that resolver.
- Forced backend Postgres sessions to request writeable transactions with `default_transaction_read_only=off`.
- Set Fly `primary_region = "gru"` to match the current Postgres primary region.
- Logged the incident/debugging context in `memory/2026-07-09.md`.

## Why

The live Pages bundle did not contain `VITE_API_BASE` or the Fly backend host, so login could fall back to same-origin behavior. The live Fly backend also returned `500` on `/login`; Fly/Postgres metadata showed the database defaulting sessions to read-only even on the primary.

## Validation

- `npm test --workspace=tdf-hq-ui -- --runTestsByPath src/config/apiBase.test.ts src/api/client.test.ts src/api/generated/client.test.ts src/session/SessionContext.test.ts`
- `npm run typecheck --workspace=tdf-hq-ui`
- `npm run build --workspace=tdf-hq-ui`
- `flyctl config validate`
- `cabal test --test-options='--match /loadConfig/'` still has 4 pre-existing unrelated expectation failures; DB connection config cases in that group pass.
- Full `cabal test` still has existing unrelated failures across Drive/Calendar/Trials/admin specs.