### PR TITLE
David Celaya report

### DIFF
--- a/memory/2026-07-13.md
+++ b/memory/2026-07-13.md
@@ -1,0 +1,9 @@
+# 2026-07-13
+
+- Añadido el reporte de cuenta para David Celaya en `tdf-hq-ui` con ruta `/finanzas/reporte-david-celaya`, PDF descargable y tabla de bloques de trabajo basada en cuatro capturas de cámara.
+- Los bloques se consolidaron desde timestamps visibles en las fotos: 2026-07-09 14:35:10 a 20:43:50 y 2026-07-10 17:37:28 a 23:50:32.
+- Se agregó tarifa de estudio de USD 25/h, prorrateada por segundo, para calcular el importe facturable total.
+- Luego se ajustó el criterio a redondeo al entero más cercano por bloque; con los bloques actuales el total facturable quedó en USD 300.
+- Finalmente se dejó el desglose con descuento explícito: 1 hora en el primer bloque y 2 horas en el segundo, para un total facturable de USD 225.
+- Se añadió un cierre con total descontado acumulado: 3 horas y USD 75.
+- Se validó con `npm run typecheck --workspace=tdf-hq-ui` y la prueba `davidCelayaReport.test.ts`.

--- a/memory/2026-07-13.md
+++ b/memory/2026-07-13.md
@@ -6,4 +6,5 @@
 - Luego se ajustó el criterio a redondeo al entero más cercano por bloque; con los bloques actuales el total facturable quedó en USD 300.
 - Finalmente se dejó el desglose con descuento explícito: 1 hora en el primer bloque y 2 horas en el segundo, para un total facturable de USD 225.
 - Se añadió un cierre con total descontado acumulado: 3 horas y USD 75.
+- Se generalizó la lógica a un creador de reportes de cuenta en UI con bloques editables, PDF descargable y preset de ejemplo.
 - Se validó con `npm run typecheck --workspace=tdf-hq-ui` y la prueba `davidCelayaReport.test.ts`.

--- a/tdf-hq-ui/src/components/SidebarNav.tsx
+++ b/tdf-hq-ui/src/components/SidebarNav.tsx
@@ -198,6 +198,7 @@ export const NAV_GROUPS: NavGroup[] = [
       { label: 'Reservas equipo', path: '/operacion/reservas-equipo' },
       { label: 'Pagos', path: '/finanzas/pagos' },
       { label: 'Reporte Esteban', path: '/finanzas/reporte-esteban-munoz' },
+      { label: 'Reporte David', path: '/finanzas/reporte-david-celaya' },
     ],
   },
   {

--- a/tdf-hq-ui/src/components/SidebarNav.tsx
+++ b/tdf-hq-ui/src/components/SidebarNav.tsx
@@ -197,6 +197,7 @@ export const NAV_GROUPS: NavGroup[] = [
       { label: 'Órdenes tienda', path: '/operacion/ordenes-marketplace' },
       { label: 'Reservas equipo', path: '/operacion/reservas-equipo' },
       { label: 'Pagos', path: '/finanzas/pagos' },
+      { label: 'Creador de reportes', path: '/finanzas/creador-reporte-cuenta' },
       { label: 'Reporte Esteban', path: '/finanzas/reporte-esteban-munoz' },
       { label: 'Reporte David', path: '/finanzas/reporte-david-celaya' },
     ],

--- a/tdf-hq-ui/src/features/finance/davidCelayaReport.test.ts
+++ b/tdf-hq-ui/src/features/finance/davidCelayaReport.test.ts
@@ -1,0 +1,61 @@
+import {
+  DAVID_CELAYA_REPORT_SOURCE,
+  buildDavidCelayaReport,
+  buildDavidCelayaReportPdfBlob,
+  buildDavidCelayaReportPdfSource,
+  formatDateLabel,
+  formatDuration,
+} from './davidCelayaReport';
+
+describe('David Celaya account report', () => {
+  it('builds two work blocks from the provided camera timestamps', () => {
+    const report = buildDavidCelayaReport();
+
+    expect(report.source.personName).toBe('David Celaya');
+    expect(report.workBlocks).toHaveLength(2);
+    expect(report.workBlocks.map((block) => block.durationSeconds)).toEqual([22_120, 22_384]);
+    expect(report.workBlocks.map((block) => block.billableHours)).toEqual([6, 6]);
+    expect(report.workBlocks.map((block) => block.discountHours)).toEqual([1, 2]);
+    expect(report.workBlocks.map((block) => block.netBillableHours)).toEqual([5, 4]);
+    expect(report.workBlocks.map((block) => block.billableCents)).toEqual([12_500, 10_000]);
+    expect(report.totalDurationSeconds).toBe(44_504);
+    expect(report.totalBillableHours).toBe(9);
+    expect(report.totalBillableCents).toBe(22_500);
+    expect(report.totalDiscountHours).toBe(3);
+    expect(report.totalDiscountCents).toBe(7_500);
+    expect(report.averageDurationSeconds).toBe(22_252);
+    expect(report.evidenceCount).toBe(4);
+    expect(report.firstStart?.getFullYear()).toBe(2026);
+    expect(report.firstStart?.getMonth()).toBe(6);
+    expect(report.firstStart?.getDate()).toBe(9);
+    expect(report.firstStart?.getHours()).toBe(14);
+    expect(report.firstStart?.getMinutes()).toBe(35);
+    expect(report.lastEnd?.getFullYear()).toBe(2026);
+    expect(report.lastEnd?.getMonth()).toBe(6);
+    expect(report.lastEnd?.getDate()).toBe(10);
+    expect(report.lastEnd?.getHours()).toBe(23);
+    expect(report.lastEnd?.getMinutes()).toBe(50);
+  });
+
+  it('keeps the source dates and helper formatting stable', () => {
+    expect(DAVID_CELAYA_REPORT_SOURCE.workBlocks[0]?.date).toBe('2026-07-09');
+    expect(DAVID_CELAYA_REPORT_SOURCE.workBlocks[1]?.endTime).toBe('23:50:32');
+    expect(formatDateLabel('2026-07-10')).toBe('10 de julio de 2026');
+    expect(formatDuration(44_504)).toBe('12h 21m 44s');
+  });
+
+  it('generates a downloadable PDF document with the account summary', () => {
+    const report = buildDavidCelayaReport();
+    const pdf = buildDavidCelayaReportPdfBlob(report);
+    const source = buildDavidCelayaReportPdfSource(report);
+
+    expect(pdf.type).toBe('application/pdf');
+    expect(source.startsWith('%PDF-1.4')).toBe(true);
+    expect(source).toContain('Reporte de cuenta');
+    expect(source).toContain('David Celaya');
+    expect(source).toContain('Bloques de trabajo');
+    expect(source).toContain('$225,00');
+    expect(source).toContain('$75,00');
+    expect(source).toContain('descuento explicito');
+  });
+});

--- a/tdf-hq-ui/src/features/finance/davidCelayaReport.ts
+++ b/tdf-hq-ui/src/features/finance/davidCelayaReport.ts
@@ -12,6 +12,15 @@ export interface WorkBlockSource {
   discountReason: string;
 }
 
+export type CustomFieldValueType = 'text' | 'number' | 'date' | 'currency';
+
+export interface CustomFieldSource {
+  id: string;
+  label: string;
+  value: string;
+  type?: CustomFieldValueType;
+}
+
 export interface DavidCelayaReportOptions {
   asOfDate?: Date | string;
 }
@@ -22,6 +31,7 @@ export interface WorkAccountReportSource {
   periodLabel: string;
   hourlyRateCents: number;
   notes: string;
+  customFields?: CustomFieldSource[];
   workBlocks: WorkBlockSource[];
 }
 
@@ -36,6 +46,7 @@ export const DAVID_CELAYA_REPORT_SOURCE: WorkAccountReportSource = {
   hourlyRateCents: 2_500,
   notes:
     'Los bloques se tomaron de los timestamps visibles en las capturas compartidas. La tarifa aplicada es de USD 25 por hora; cada bloque se redondea al entero más cercano y además registra un descuento explícito.',
+  customFields: [],
   workBlocks: [
     {
       id: 'work-block-1',
@@ -164,6 +175,10 @@ export interface WorkBlockRow extends WorkBlockSource {
   discountLabel: string;
 }
 
+export interface CustomFieldRow extends Omit<CustomFieldSource, 'type'> {
+  type: CustomFieldValueType;
+}
+
 const calculateBillableHours = (durationSeconds: number) => Math.round(durationSeconds / 3600);
 
 const calculateBillableCents = (billableHours: number, hourlyRateCents: number) => billableHours * hourlyRateCents;
@@ -209,6 +224,10 @@ export const buildWorkAccountReport = (
   const evidenceCount = workBlocks.length * 2;
   const firstStart = workBlocks[0]?.startDateTime ?? null;
   const lastEnd = workBlocks[workBlocks.length - 1]?.endDateTime ?? null;
+  const customFields = (source.customFields ?? []).map((field) => ({
+    ...field,
+    type: field.type ?? 'text',
+  })) satisfies CustomFieldRow[];
 
   return {
     source: {
@@ -216,6 +235,7 @@ export const buildWorkAccountReport = (
       cutoffDate,
     },
     workBlocks,
+    customFields,
     totalDurationSeconds,
     totalBillableCents,
     totalBillableHours,
@@ -556,6 +576,20 @@ const buildPdfContentStream = (report: ReturnType<typeof buildWorkAccountReport>
     wrapped(lineText, PDF.marginX, y, PDF.contentWidth, { size: 10, maxLines: 2 });
     y -= 18;
   });
+
+  if ((report.customFields?.length ?? 0) > 0) {
+    sectionTitle('Campos personalizados');
+    table(
+      [
+        { label: 'Campo', width: 190 },
+        { label: 'Valor', width: 338 },
+      ],
+      report.customFields.map((field): PdfRow => [
+        { text: field.label, bold: true },
+        field.value,
+      ]),
+    );
+  }
 
   pages.push(commands);
   return pages.map((pageCommands) => pageCommands.join('\n'));

--- a/tdf-hq-ui/src/features/finance/davidCelayaReport.ts
+++ b/tdf-hq-ui/src/features/finance/davidCelayaReport.ts
@@ -1,0 +1,587 @@
+export type ReportDate = `${number}-${number}-${number}`;
+
+export interface WorkBlockSource {
+  id: string;
+  date: ReportDate;
+  startTime: string;
+  endTime: string;
+  startPhotoLabel: string;
+  endPhotoLabel: string;
+  description: string;
+  discountHours: number;
+  discountReason: string;
+}
+
+export interface DavidCelayaReportOptions {
+  asOfDate?: Date | string;
+}
+
+export const DAVID_CELAYA_REPORT_SOURCE = {
+  personName: 'David Celaya',
+  reportTitle: 'Reporte de cuenta',
+  periodLabel: '9 y 10 de julio de 2026',
+  hourlyRateCents: 2_500,
+  notes:
+    'Los bloques se tomaron de los timestamps visibles en las capturas compartidas. La tarifa aplicada es de USD 25 por hora; cada bloque se redondea al entero más cercano y además registra un descuento explícito.',
+  workBlocks: [
+    {
+      id: 'work-block-1',
+      date: '2026-07-09',
+      startTime: '14:35:10',
+      endTime: '20:43:50',
+      startPhotoLabel: 'Foto 1',
+      endPhotoLabel: 'Foto 2',
+      description: 'Bloque continuo en el estudio con supervisión de consola y trabajo operativo.',
+      discountHours: 1,
+      discountReason: 'Descuento explícito de 1 hora en el primer bloque.',
+    },
+    {
+      id: 'work-block-2',
+      date: '2026-07-10',
+      startTime: '17:37:28',
+      endTime: '23:50:32',
+      startPhotoLabel: 'Foto 3',
+      endPhotoLabel: 'Foto 4',
+      description: 'Bloque nocturno con presencia sostenida en el estudio y monitoreo de sesión.',
+      discountHours: 2,
+      discountReason: 'Descuento explícito de 2 horas en el segundo bloque.',
+    },
+  ] satisfies WorkBlockSource[],
+} as const;
+
+const MONTH_NAMES = [
+  'enero',
+  'febrero',
+  'marzo',
+  'abril',
+  'mayo',
+  'junio',
+  'julio',
+  'agosto',
+  'septiembre',
+  'octubre',
+  'noviembre',
+  'diciembre',
+] as const;
+
+const parseReportDate = (value: ReportDate) => {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) throw new Error(`Invalid report date: ${value}`);
+  const year = Number.parseInt(match[1]!, 10);
+  const month = Number.parseInt(match[2]!, 10);
+  const day = Number.parseInt(match[3]!, 10);
+  if (!Number.isSafeInteger(year) || month < 1 || month > 12 || day < 1 || day > 31) {
+    throw new Error(`Invalid report date: ${value}`);
+  }
+  return { year, month, day };
+};
+
+const toLocalIsoDate = (date: Date) => {
+  if (Number.isNaN(date.getTime())) throw new Error('Invalid report date');
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}` as ReportDate;
+};
+
+const normalizeReportDate = (date: Date | string = new Date()) => {
+  if (typeof date !== 'string') return toLocalIsoDate(date);
+  if (!/^(\d{4})-(\d{2})-(\d{2})$/.test(date)) throw new Error(`Invalid report date: ${date}`);
+  return date as ReportDate;
+};
+
+const parseLocalDateTime = (date: ReportDate, time: string) => {
+  const parsed = parseReportDate(date);
+  if (!/^(\d{2}):(\d{2}):(\d{2})$/.test(time)) {
+    throw new Error(`Invalid report time: ${time}`);
+  }
+  return new Date(`${parsed.year}-${String(parsed.month).padStart(2, '0')}-${String(parsed.day).padStart(2, '0')}T${time}`);
+};
+
+export const formatDateLabel = (isoDate: string) => {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDate);
+  if (!match) return isoDate;
+  const year = Number.parseInt(match[1]!, 10);
+  const month = Number.parseInt(match[2]!, 10);
+  const day = Number.parseInt(match[3]!, 10);
+  if (!Number.isSafeInteger(year) || month < 1 || month > 12 || day < 1 || day > 31) {
+    return isoDate;
+  }
+  return `${day} de ${MONTH_NAMES[month - 1]} de ${year}`;
+};
+
+export const formatDateTimeLabel = (date: Date) =>
+  new Intl.DateTimeFormat('es-EC', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+
+export const formatDuration = (totalSeconds: number) => {
+  const sign = totalSeconds < 0 ? '-' : '';
+  const absolute = Math.abs(totalSeconds);
+  const hours = Math.floor(absolute / 3600);
+  const minutes = Math.floor((absolute % 3600) / 60);
+  const seconds = absolute % 60;
+  return `${sign}${hours}h ${minutes}m ${seconds}s`;
+};
+
+const formatShortDateLabel = (isoDate: string) => {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDate);
+  if (!match) return isoDate;
+  const day = Number.parseInt(match[3]!, 10);
+  const month = Number.parseInt(match[2]!, 10);
+  const shortMonths = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic'] as const;
+  return `${day} ${shortMonths[month - 1]} ${match[1]}`;
+};
+
+export interface WorkBlockRow extends WorkBlockSource {
+  startDateTime: Date;
+  endDateTime: Date;
+  durationSeconds: number;
+  startLabel: string;
+  endLabel: string;
+  durationLabel: string;
+  billableHours: number;
+  netBillableHours: number;
+  billableCents: number;
+  billableLabel: string;
+  discountLabel: string;
+}
+
+const calculateBillableHours = (durationSeconds: number) => Math.round(durationSeconds / 3600);
+
+const calculateBillableCents = (billableHours: number, hourlyRateCents: number) => billableHours * hourlyRateCents;
+
+export const buildDavidCelayaReport = (options: DavidCelayaReportOptions = {}) => {
+  const lastWorkBlock = DAVID_CELAYA_REPORT_SOURCE.workBlocks[DAVID_CELAYA_REPORT_SOURCE.workBlocks.length - 1]!;
+  const cutoffDate = normalizeReportDate(options.asOfDate ?? lastWorkBlock.date);
+  const workBlocks = DAVID_CELAYA_REPORT_SOURCE.workBlocks.map((block) => {
+    const startDateTime = parseLocalDateTime(block.date, block.startTime);
+    const endDateTime = parseLocalDateTime(block.date, block.endTime);
+    if (Number.isNaN(startDateTime.getTime()) || Number.isNaN(endDateTime.getTime())) {
+      throw new Error(`Invalid work block: ${block.id}`);
+    }
+    const durationSeconds = Math.max(0, Math.round((endDateTime.getTime() - startDateTime.getTime()) / 1000));
+    const billableHours = calculateBillableHours(durationSeconds);
+    const netBillableHours = Math.max(0, billableHours - block.discountHours);
+    const billableCents = calculateBillableCents(netBillableHours, DAVID_CELAYA_REPORT_SOURCE.hourlyRateCents);
+    return {
+      ...block,
+      startDateTime,
+      endDateTime,
+      durationSeconds,
+      startLabel: formatDateTimeLabel(startDateTime),
+      endLabel: formatDateTimeLabel(endDateTime),
+      durationLabel: formatDuration(durationSeconds),
+      billableHours,
+      netBillableHours,
+      billableCents,
+      billableLabel: formatCurrency(billableCents),
+      discountLabel: `${block.discountHours}h de descuento`,
+    } satisfies WorkBlockRow;
+  });
+
+  const totalDurationSeconds = workBlocks.reduce((total, block) => total + block.durationSeconds, 0);
+  const totalBillableCents = workBlocks.reduce((total, block) => total + block.billableCents, 0);
+  const totalBillableHours = workBlocks.reduce((total, block) => total + block.netBillableHours, 0);
+  const totalDiscountHours = workBlocks.reduce((total, block) => total + block.discountHours, 0);
+  const totalDiscountCents = totalDiscountHours * DAVID_CELAYA_REPORT_SOURCE.hourlyRateCents;
+  const averageDurationSeconds = workBlocks.length > 0 ? Math.round(totalDurationSeconds / workBlocks.length) : 0;
+  const evidenceCount = workBlocks.length * 2;
+  const firstStart = workBlocks[0]?.startDateTime ?? null;
+  const lastEnd = workBlocks[workBlocks.length - 1]?.endDateTime ?? null;
+
+  return {
+    source: {
+      ...DAVID_CELAYA_REPORT_SOURCE,
+      cutoffDate,
+    },
+    workBlocks,
+    totalDurationSeconds,
+    totalBillableCents,
+    totalBillableHours,
+    totalDiscountHours,
+    totalDiscountCents,
+    averageDurationSeconds,
+    evidenceCount,
+    firstStart,
+    lastEnd,
+  };
+};
+
+export type DavidCelayaReport = ReturnType<typeof buildDavidCelayaReport>;
+
+export const DAVID_CELAYA_REPORT_PDF_FILENAME = 'reporte-david-celaya.pdf';
+
+export const formatCurrency = (cents: number) =>
+  new Intl.NumberFormat('es-EC', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+  }).format(cents / 100).replace('USD', '$');
+
+const normalizePdfText = (value: string) =>
+  value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^\x20-\x7E]/g, ' ');
+
+const escapePdfString = (value: string) =>
+  normalizePdfText(value).replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)');
+
+const escapePdfStringForWidth = (value: string) => normalizePdfText(value);
+
+const wrapPdfText = (text: string, maxChars: number) => {
+  const words = text.split(/\s+/).filter(Boolean);
+  const lines: string[] = [];
+  let current = '';
+
+  words.forEach((word) => {
+    const next = current ? `${current} ${word}` : word;
+    if (next.length > maxChars && current) {
+      lines.push(current);
+      current = word;
+    } else {
+      current = next;
+    }
+  });
+
+  if (current) lines.push(current);
+  return lines.length > 0 ? lines : [''];
+};
+
+type PdfAlign = 'left' | 'right' | 'center';
+
+interface PdfColumn {
+  label: string;
+  width: number;
+  align?: PdfAlign;
+}
+
+interface PdfCell {
+  text: string;
+  bold?: boolean;
+}
+
+type PdfRow = (string | PdfCell)[];
+
+const PDF = {
+  pageWidth: 612,
+  pageHeight: 792,
+  marginX: 42,
+  marginBottom: 46,
+  contentWidth: 528,
+  headerTop: 748,
+  colors: {
+    ink: [0.12, 0.13, 0.16],
+    muted: [0.42, 0.45, 0.5],
+    line: [0.82, 0.84, 0.88],
+    softLine: [0.9, 0.91, 0.94],
+    panel: [0.96, 0.97, 0.99],
+    dark: [0.08, 0.09, 0.12],
+    blue: [0.15, 0.28, 0.75],
+    green: [0.12, 0.56, 0.27],
+    white: [1, 1, 1],
+  },
+} as const;
+
+const color = (rgb: readonly number[]) => rgb.join(' ');
+
+const textWidthEstimate = (value: string, fontSize: number, bold = false) =>
+  escapePdfStringForWidth(value).length * fontSize * (bold ? 0.55 : 0.5);
+
+const buildPdfContentStream = (report: DavidCelayaReport) => {
+  const pages: string[][] = [];
+  let commands: string[] = [];
+  let y: number = PDF.headerTop;
+  let pageNumber = 0;
+
+  const push = (command: string) => commands.push(command);
+
+  const newPage = () => {
+    if (commands.length > 0) pages.push(commands);
+    commands = [];
+    pageNumber += 1;
+    y = PDF.headerTop;
+    push(`${color(PDF.colors.dark)} rg 0 742 612 50 re f`);
+    push(`${color(PDF.colors.white)} rg`);
+    push(`BT /F2 15 Tf 42 765 Td (TDF RECORDS) Tj ET`);
+    push(`BT /F1 8 Tf 42 752 Td (Reporte de cuenta / pagina ${pageNumber}) Tj ET`);
+    y = 720;
+  };
+
+  const ensureSpace = (height: number) => {
+    if (y - height < PDF.marginBottom) newPage();
+  };
+
+  const rect = (
+    x: number,
+    top: number,
+    width: number,
+    height: number,
+    options: { fill?: readonly number[]; stroke?: readonly number[] } = {},
+  ) => {
+    if (options.fill) {
+      push(`${color(options.fill)} rg ${x} ${top - height} ${width} ${height} re f`);
+    }
+    if (options.stroke) {
+      push(`${color(options.stroke)} RG ${x} ${top - height} ${width} ${height} re S`);
+    }
+  };
+
+  const line = (x1: number, y1: number, x2: number, y2: number, stroke: readonly number[] = PDF.colors.line) => {
+    push(`${color(stroke)} RG ${x1} ${y1} m ${x2} ${y2} l S`);
+  };
+
+  const text = (
+    value: string,
+    x: number,
+    baseline: number,
+    options: {
+      size?: number;
+      bold?: boolean;
+      fill?: readonly number[];
+      align?: PdfAlign;
+      width?: number;
+    } = {},
+  ) => {
+    const size = options.size ?? 9;
+    const font = options.bold ? 'F2' : 'F1';
+    const fill = options.fill ?? PDF.colors.ink;
+    const align = options.align ?? 'left';
+    const estimated = textWidthEstimate(value, size, Boolean(options.bold));
+    const offset =
+      align === 'right' && options.width
+        ? Math.max(options.width - estimated, 0)
+        : align === 'center' && options.width
+          ? Math.max((options.width - estimated) / 2, 0)
+          : 0;
+    push(`${color(fill)} rg BT /${font} ${size} Tf ${x + offset} ${baseline} Td (${escapePdfString(value)}) Tj ET`);
+  };
+
+  const wrapped = (
+    value: string,
+    x: number,
+    baseline: number,
+    width: number,
+    options: { size?: number; bold?: boolean; fill?: readonly number[]; maxLines?: number } = {},
+  ) => {
+    const size = options.size ?? 9;
+    const maxChars = Math.max(10, Math.floor(width / (size * 0.5)));
+    const lines = wrapPdfText(value, maxChars).slice(0, options.maxLines ?? 6);
+    lines.forEach((lineText, index) => {
+      text(lineText, x, baseline - index * (size + 3), options);
+    });
+    return lines.length;
+  };
+
+  const sectionTitle = (title: string, subtitle?: string) => {
+    ensureSpace(subtitle ? 44 : 28);
+    text(title, PDF.marginX, y, { size: 13, bold: true });
+    y -= 15;
+    if (subtitle) {
+      wrapped(subtitle, PDF.marginX, y, PDF.contentWidth, { size: 8, fill: PDF.colors.muted, maxLines: 2 });
+      y -= 18;
+    } else {
+      y -= 5;
+    }
+    line(PDF.marginX, y, PDF.marginX + PDF.contentWidth, y, PDF.colors.softLine);
+    y -= 12;
+  };
+
+  const summaryBox = (
+    label: string,
+    value: string,
+    x: number,
+    top: number,
+    width: number,
+    tone: 'blue' | 'green',
+  ) => {
+    const toneColor = tone === 'blue' ? PDF.colors.blue : PDF.colors.green;
+    rect(x, top, width, 58, { fill: PDF.colors.panel, stroke: PDF.colors.softLine });
+    text(label, x + 10, top - 20, { size: 8, fill: PDF.colors.muted });
+    text(value, x + 10, top - 42, { size: 13, bold: true, fill: toneColor });
+  };
+
+  const table = (columns: PdfColumn[], rows: PdfRow[]) => {
+    const headerHeight = 22;
+    ensureSpace(headerHeight + 24);
+    rect(PDF.marginX, y, PDF.contentWidth, headerHeight, { fill: PDF.colors.dark });
+    let x = PDF.marginX;
+    columns.forEach((column) => {
+      text(column.label, x + 7, y - 14, {
+        size: 7.5,
+        bold: true,
+        fill: PDF.colors.white,
+        align: column.align,
+        width: column.width - 14,
+      });
+      x += column.width;
+    });
+    y -= headerHeight;
+
+    rows.forEach((row, rowIndex) => {
+      const cellLines = row.map((raw, cellIndex) => {
+        const cell = typeof raw === 'string' ? { text: raw } : raw;
+        const column = columns[cellIndex]!;
+        const size = cell.bold ? 8.5 : 8;
+        const maxChars = Math.max(8, Math.floor((column.width - 14) / (size * 0.5)));
+        return wrapPdfText(cell.text, maxChars).slice(0, 4);
+      });
+      const lineCount = Math.max(...cellLines.map((lines) => lines.length), 1);
+      const rowHeight = Math.max(24, 10 + lineCount * 10);
+      ensureSpace(rowHeight);
+      if (rowIndex % 2 === 1) {
+        rect(PDF.marginX, y, PDF.contentWidth, rowHeight, { fill: [0.985, 0.988, 0.995] });
+      }
+      line(PDF.marginX, y - rowHeight, PDF.marginX + PDF.contentWidth, y - rowHeight, PDF.colors.softLine);
+
+      x = PDF.marginX;
+      row.forEach((raw, cellIndex) => {
+        const cell = typeof raw === 'string' ? { text: raw } : raw;
+        const column = columns[cellIndex]!;
+        const lines = cellLines[cellIndex]!;
+        lines.forEach((lineText, lineIndex) => {
+          text(lineText, x + 7, y - 15 - lineIndex * 10, {
+            size: cell.bold ? 8.5 : 8,
+            bold: Boolean(cell.bold),
+            fill: PDF.colors.ink,
+            align: column.align,
+            width: column.width - 14,
+          });
+        });
+        x += column.width;
+      });
+      y -= rowHeight;
+    });
+    y -= 18;
+  };
+
+  newPage();
+
+  text('Reporte de cuenta', PDF.marginX, y, { size: 24, bold: true });
+  text(`Cliente: ${report.source.personName}`, PDF.marginX, y - 20, { size: 10, fill: PDF.colors.muted });
+  text(`Periodo: ${report.source.periodLabel}`, PDF.marginX, y - 34, { size: 10, fill: PDF.colors.muted });
+  rect(382, y + 2, 188, 64, { fill: [0.93, 0.95, 0.99], stroke: [0.74, 0.81, 0.95] });
+  text('Importe total', 394, y - 18, { size: 8, bold: true, fill: PDF.colors.blue });
+  text(formatCurrency(report.totalBillableCents), 394, y - 43, { size: 18, bold: true, fill: PDF.colors.blue });
+  text('USD 25/h + descuento explicito por bloque', 394, y - 56, { size: 7.5, fill: PDF.colors.muted });
+  y -= 98;
+
+  sectionTitle(
+    'Resumen ejecutivo',
+    'Se registran dos jornadas continuas en estudio. Las capturas visibles se usaron como referencia para abrir y cerrar cada bloque.',
+  );
+
+  const gap = 8;
+  const boxWidth = (PDF.contentWidth - gap * 4) / 5;
+  const boxTop = y;
+  summaryBox('Bloques', String(report.workBlocks.length), PDF.marginX, boxTop, boxWidth, 'blue');
+  summaryBox('Capturas', String(report.evidenceCount), PDF.marginX + boxWidth + gap, boxTop, boxWidth, 'blue');
+  summaryBox('Total', formatCurrency(report.totalBillableCents), PDF.marginX + (boxWidth + gap) * 2, boxTop, boxWidth, 'green');
+  summaryBox(
+    'Horas netas',
+    `${report.totalBillableHours}h`,
+    PDF.marginX + (boxWidth + gap) * 3,
+    boxTop,
+    boxWidth,
+    'green',
+  );
+  summaryBox(
+    'Corte',
+    report.source.cutoffDate,
+    PDF.marginX + (boxWidth + gap) * 4,
+    boxTop,
+    boxWidth,
+    'blue',
+  );
+  y -= 82;
+
+  sectionTitle('Bloques de trabajo', report.source.notes);
+  table(
+    [
+      { label: 'Fecha', width: 58 },
+      { label: 'Inicio', width: 108 },
+      { label: 'Fin', width: 108 },
+      { label: 'Base', width: 44, align: 'right' },
+      { label: 'Desc.', width: 44, align: 'right' },
+      { label: 'Neto', width: 44, align: 'right' },
+      { label: 'Importe', width: 58, align: 'right' },
+      { label: 'Nota', width: 64 },
+    ],
+    report.workBlocks.map((block): PdfRow => [
+      { text: formatShortDateLabel(block.date), bold: true },
+      `${block.startLabel} (${block.startPhotoLabel})`,
+      `${block.endLabel} (${block.endPhotoLabel})`,
+      { text: `${block.billableHours}h`, bold: true },
+      { text: `-${block.discountHours}h`, bold: true },
+      { text: `${block.netBillableHours}h`, bold: true },
+      { text: block.billableLabel, bold: true },
+      { text: block.description, bold: false },
+    ]),
+  );
+
+  sectionTitle('Cierre');
+  const closingLines = [
+    `Primer registro: ${report.firstStart ? formatDateTimeLabel(report.firstStart) : 'N/D'}.`,
+    `Último cierre: ${report.lastEnd ? formatDateTimeLabel(report.lastEnd) : 'N/D'}.`,
+    `Horas netas facturables: ${report.totalBillableHours}h.`,
+    `Descuento acumulado: ${report.totalDiscountHours}h = ${formatCurrency(report.totalDiscountCents)}.`,
+    `Tarifa aplicada: ${formatCurrency(report.source.hourlyRateCents)} por hora con descuento explicito por bloque.`,
+  ];
+  closingLines.forEach((lineText) => {
+    wrapped(lineText, PDF.marginX, y, PDF.contentWidth, { size: 10, maxLines: 2 });
+    y -= 18;
+  });
+
+  pages.push(commands);
+  return pages.map((pageCommands) => pageCommands.join('\n'));
+};
+
+const buildPdfDocument = (contentStreams: string[]) => {
+  const pageCount = contentStreams.length;
+  const pageObjectStart = 3;
+  const contentObjectStart = pageObjectStart + pageCount;
+  const fontObjectStart = contentObjectStart + pageCount;
+  const fontRegularId = fontObjectStart;
+  const fontBoldId = fontObjectStart + 1;
+  const pageIds = Array.from({ length: pageCount }, (_, index) => pageObjectStart + index);
+  const contentIds = Array.from({ length: pageCount }, (_, index) => contentObjectStart + index);
+  const objects = [
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    `<< /Type /Pages /Kids [${pageIds.map((id) => `${id} 0 R`).join(' ')}] /Count ${pageCount} >>`,
+    ...pageIds.map((_, index) =>
+      `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 ${fontRegularId} 0 R /F2 ${fontBoldId} 0 R >> >> /Contents ${contentIds[index]} 0 R >>`,
+    ),
+    ...contentStreams.map((contentStream) =>
+      `<< /Length ${contentStream.length} >>\nstream\n${contentStream}\nendstream`,
+    ),
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>',
+  ];
+
+  let pdf = '%PDF-1.4\n';
+  const offsets: number[] = [];
+  objects.forEach((object, index) => {
+    offsets.push(pdf.length);
+    pdf += `${index + 1} 0 obj\n${object}\nendobj\n`;
+  });
+
+  const xrefOffset = pdf.length;
+  pdf += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+  offsets.forEach((offset) => {
+    pdf += `${String(offset).padStart(10, '0')} 00000 n \n`;
+  });
+  pdf += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`;
+  return pdf;
+};
+
+export const buildDavidCelayaReportPdfSource = (report: DavidCelayaReport = buildDavidCelayaReport()) =>
+  buildPdfDocument(buildPdfContentStream(report));
+
+export const buildDavidCelayaReportPdfBlob = (report: DavidCelayaReport = buildDavidCelayaReport()) =>
+  new Blob([buildDavidCelayaReportPdfSource(report)], { type: 'application/pdf' });

--- a/tdf-hq-ui/src/features/finance/davidCelayaReport.ts
+++ b/tdf-hq-ui/src/features/finance/davidCelayaReport.ts
@@ -16,7 +16,20 @@ export interface DavidCelayaReportOptions {
   asOfDate?: Date | string;
 }
 
-export const DAVID_CELAYA_REPORT_SOURCE = {
+export interface WorkAccountReportSource {
+  personName: string;
+  reportTitle: string;
+  periodLabel: string;
+  hourlyRateCents: number;
+  notes: string;
+  workBlocks: WorkBlockSource[];
+}
+
+export interface WorkAccountReportOptions {
+  asOfDate?: Date | string;
+}
+
+export const DAVID_CELAYA_REPORT_SOURCE: WorkAccountReportSource = {
   personName: 'David Celaya',
   reportTitle: 'Reporte de cuenta',
   periodLabel: '9 y 10 de julio de 2026',
@@ -47,7 +60,7 @@ export const DAVID_CELAYA_REPORT_SOURCE = {
       discountReason: 'Descuento explícito de 2 horas en el segundo bloque.',
     },
   ] satisfies WorkBlockSource[],
-} as const;
+};
 
 const MONTH_NAMES = [
   'enero',
@@ -155,10 +168,13 @@ const calculateBillableHours = (durationSeconds: number) => Math.round(durationS
 
 const calculateBillableCents = (billableHours: number, hourlyRateCents: number) => billableHours * hourlyRateCents;
 
-export const buildDavidCelayaReport = (options: DavidCelayaReportOptions = {}) => {
-  const lastWorkBlock = DAVID_CELAYA_REPORT_SOURCE.workBlocks[DAVID_CELAYA_REPORT_SOURCE.workBlocks.length - 1]!;
+export const buildWorkAccountReport = (
+  source: WorkAccountReportSource,
+  options: WorkAccountReportOptions = {},
+) => {
+  const lastWorkBlock = source.workBlocks[source.workBlocks.length - 1]!;
   const cutoffDate = normalizeReportDate(options.asOfDate ?? lastWorkBlock.date);
-  const workBlocks = DAVID_CELAYA_REPORT_SOURCE.workBlocks.map((block) => {
+  const workBlocks = source.workBlocks.map((block) => {
     const startDateTime = parseLocalDateTime(block.date, block.startTime);
     const endDateTime = parseLocalDateTime(block.date, block.endTime);
     if (Number.isNaN(startDateTime.getTime()) || Number.isNaN(endDateTime.getTime())) {
@@ -167,7 +183,7 @@ export const buildDavidCelayaReport = (options: DavidCelayaReportOptions = {}) =
     const durationSeconds = Math.max(0, Math.round((endDateTime.getTime() - startDateTime.getTime()) / 1000));
     const billableHours = calculateBillableHours(durationSeconds);
     const netBillableHours = Math.max(0, billableHours - block.discountHours);
-    const billableCents = calculateBillableCents(netBillableHours, DAVID_CELAYA_REPORT_SOURCE.hourlyRateCents);
+    const billableCents = calculateBillableCents(netBillableHours, source.hourlyRateCents);
     return {
       ...block,
       startDateTime,
@@ -188,7 +204,7 @@ export const buildDavidCelayaReport = (options: DavidCelayaReportOptions = {}) =
   const totalBillableCents = workBlocks.reduce((total, block) => total + block.billableCents, 0);
   const totalBillableHours = workBlocks.reduce((total, block) => total + block.netBillableHours, 0);
   const totalDiscountHours = workBlocks.reduce((total, block) => total + block.discountHours, 0);
-  const totalDiscountCents = totalDiscountHours * DAVID_CELAYA_REPORT_SOURCE.hourlyRateCents;
+  const totalDiscountCents = totalDiscountHours * source.hourlyRateCents;
   const averageDurationSeconds = workBlocks.length > 0 ? Math.round(totalDurationSeconds / workBlocks.length) : 0;
   const evidenceCount = workBlocks.length * 2;
   const firstStart = workBlocks[0]?.startDateTime ?? null;
@@ -196,7 +212,7 @@ export const buildDavidCelayaReport = (options: DavidCelayaReportOptions = {}) =
 
   return {
     source: {
-      ...DAVID_CELAYA_REPORT_SOURCE,
+      ...source,
       cutoffDate,
     },
     workBlocks,
@@ -211,6 +227,9 @@ export const buildDavidCelayaReport = (options: DavidCelayaReportOptions = {}) =
     lastEnd,
   };
 };
+
+export const buildDavidCelayaReport = (options: DavidCelayaReportOptions = {}) =>
+  buildWorkAccountReport(DAVID_CELAYA_REPORT_SOURCE, options);
 
 export type DavidCelayaReport = ReturnType<typeof buildDavidCelayaReport>;
 
@@ -294,7 +313,7 @@ const color = (rgb: readonly number[]) => rgb.join(' ');
 const textWidthEstimate = (value: string, fontSize: number, bold = false) =>
   escapePdfStringForWidth(value).length * fontSize * (bold ? 0.55 : 0.5);
 
-const buildPdfContentStream = (report: DavidCelayaReport) => {
+const buildPdfContentStream = (report: ReturnType<typeof buildWorkAccountReport>) => {
   const pages: string[][] = [];
   let commands: string[] = [];
   let y: number = PDF.headerTop;
@@ -580,8 +599,14 @@ const buildPdfDocument = (contentStreams: string[]) => {
   return pdf;
 };
 
-export const buildDavidCelayaReportPdfSource = (report: DavidCelayaReport = buildDavidCelayaReport()) =>
+export const buildWorkAccountReportPdfSource = (report: ReturnType<typeof buildWorkAccountReport>) =>
   buildPdfDocument(buildPdfContentStream(report));
 
+export const buildWorkAccountReportPdfBlob = (report: ReturnType<typeof buildWorkAccountReport>) =>
+  new Blob([buildWorkAccountReportPdfSource(report)], { type: 'application/pdf' });
+
+export const buildDavidCelayaReportPdfSource = (report: DavidCelayaReport = buildDavidCelayaReport()) =>
+  buildWorkAccountReportPdfSource(report);
+
 export const buildDavidCelayaReportPdfBlob = (report: DavidCelayaReport = buildDavidCelayaReport()) =>
-  new Blob([buildDavidCelayaReportPdfSource(report)], { type: 'application/pdf' });
+  buildWorkAccountReportPdfBlob(report);

--- a/tdf-hq-ui/src/features/finance/workAccountReport.test.ts
+++ b/tdf-hq-ui/src/features/finance/workAccountReport.test.ts
@@ -1,0 +1,48 @@
+import {
+  buildWorkAccountReport,
+  buildWorkAccountReportPdfSource,
+  formatCurrency,
+  type WorkAccountReportSource,
+} from './davidCelayaReport';
+
+describe('work account report builder', () => {
+  const source: WorkAccountReportSource = {
+    personName: 'Cliente Prueba',
+    reportTitle: 'Reporte de cuenta',
+    periodLabel: 'julio 2026',
+    hourlyRateCents: 3_000,
+    notes: 'Generado desde el sistema.',
+    workBlocks: [
+      {
+        id: 'block-a',
+        date: '2026-07-12',
+        startTime: '10:00:00',
+        endTime: '12:20:00',
+        startPhotoLabel: 'Inicio',
+        endPhotoLabel: 'Fin',
+        description: 'Bloque de prueba.',
+        discountHours: 1,
+        discountReason: 'Descuento de prueba.',
+      },
+    ],
+  };
+
+  it('builds a custom report from system input', () => {
+    const report = buildWorkAccountReport(source, { asOfDate: '2026-07-12' });
+
+    expect(report.source.personName).toBe('Cliente Prueba');
+    expect(report.totalBillableHours).toBe(1);
+    expect(report.totalDiscountHours).toBe(1);
+    expect(report.totalBillableCents).toBe(3_000);
+    expect(report.workBlocks[0]?.billableLabel).toBe(formatCurrency(3_000));
+  });
+
+  it('generates a PDF for a custom report', () => {
+    const report = buildWorkAccountReport(source, { asOfDate: '2026-07-12' });
+    const pdf = buildWorkAccountReportPdfSource(report);
+
+    expect(pdf).toContain('Cliente Prueba');
+    expect(pdf).toContain('Descuento acumulado');
+    expect(pdf).toContain('$30,00');
+  });
+});

--- a/tdf-hq-ui/src/features/finance/workAccountReport.test.ts
+++ b/tdf-hq-ui/src/features/finance/workAccountReport.test.ts
@@ -12,6 +12,9 @@ describe('work account report builder', () => {
     periodLabel: 'julio 2026',
     hourlyRateCents: 3_000,
     notes: 'Generado desde el sistema.',
+    customFields: [
+      { id: 'field-1', label: 'Propósito', value: 'Ensayo y acompañamiento.' },
+    ],
     workBlocks: [
       {
         id: 'block-a',
@@ -31,6 +34,7 @@ describe('work account report builder', () => {
     const report = buildWorkAccountReport(source, { asOfDate: '2026-07-12' });
 
     expect(report.source.personName).toBe('Cliente Prueba');
+    expect(report.customFields).toHaveLength(1);
     expect(report.totalBillableHours).toBe(1);
     expect(report.totalDiscountHours).toBe(1);
     expect(report.totalBillableCents).toBe(3_000);
@@ -42,6 +46,7 @@ describe('work account report builder', () => {
     const pdf = buildWorkAccountReportPdfSource(report);
 
     expect(pdf).toContain('Cliente Prueba');
+    expect(pdf).toContain('Proposito');
     expect(pdf).toContain('Descuento acumulado');
     expect(pdf).toContain('$30,00');
   });

--- a/tdf-hq-ui/src/pages/CourseRegistrationsAdminPage.test.tsx
+++ b/tdf-hq-ui/src/pages/CourseRegistrationsAdminPage.test.tsx
@@ -2789,6 +2789,7 @@ describe('CourseRegistrationsAdminPage', () => {
     listRegistrationsMock.mockResolvedValue(buildRegistrations(8, (index) => ({
       crAdminNotes: index < 2 ? 'Beca aprobada por coordinación.' : null,
     })));
+    const sharedCreatedAtLabel = formatTimestampForDisplay('2030-01-02T03:04:05.000Z', '-');
 
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -2810,7 +2811,7 @@ describe('CourseRegistrationsAdminPage', () => {
       expect(container.querySelector('[data-testid="course-registration-current-view-summary"]')).toBeNull();
       expect(container.textContent).not.toContain('Vista actual');
       expect(container.textContent).toContain(
-        'Beatmaking 101 · Pendiente de pago. Misma fecha de registro: 1/1/2030, 10:04:05 PM. Mostrando 2 de 8 inscripciones cargadas.',
+        `Beatmaking 101 · Pendiente de pago. Misma fecha de registro: ${sharedCreatedAtLabel}. Mostrando 2 de 8 inscripciones cargadas.`,
       );
       expect(countOccurrences(container, 'Beatmaking 101 · Pendiente de pago')).toBe(1);
       expect(container.textContent).toContain('Mostrando 2 de 8 inscripciones cargadas.');

--- a/tdf-hq-ui/src/pages/DavidCelayaReportPage.tsx
+++ b/tdf-hq-ui/src/pages/DavidCelayaReportPage.tsx
@@ -1,0 +1,315 @@
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Grid,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import DownloadIcon from '@mui/icons-material/Download';
+import EventNoteIcon from '@mui/icons-material/EventNote';
+import PhotoLibraryIcon from '@mui/icons-material/PhotoLibrary';
+import PrintIcon from '@mui/icons-material/Print';
+import ScheduleIcon from '@mui/icons-material/Schedule';
+import PageShell from '../components/PageShell';
+import {
+  DAVID_CELAYA_REPORT_PDF_FILENAME,
+  buildDavidCelayaReport,
+  buildDavidCelayaReportPdfBlob,
+  formatDateLabel,
+  formatDateTimeLabel,
+  formatDuration,
+  formatCurrency,
+} from '../features/finance/davidCelayaReport';
+
+const tableSx = {
+  minWidth: 860,
+  '& thead th': {
+    bgcolor: 'action.hover',
+    color: 'text.secondary',
+    fontSize: 12,
+    fontWeight: 800,
+    textTransform: 'uppercase',
+  },
+  '& tbody td': {
+    verticalAlign: 'top',
+  },
+  '& tbody tr:last-of-type td': {
+    borderBottom: 0,
+  },
+} as const;
+
+function Section({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children: ReactNode;
+}) {
+  return (
+    <Paper variant="outlined" sx={{ p: { xs: 2, md: 2.5 }, borderRadius: 2 }}>
+      <Stack spacing={2}>
+        <Box>
+          <Typography variant="h6" fontWeight={850}>{title}</Typography>
+          {subtitle && <Typography color="text.secondary">{subtitle}</Typography>}
+        </Box>
+        {children}
+      </Stack>
+    </Paper>
+  );
+}
+
+function Metric({
+  icon,
+  label,
+  value,
+  caption,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: string;
+  caption?: string;
+}) {
+  return (
+    <Box
+      sx={{
+        height: '100%',
+        minHeight: 96,
+        p: 2,
+        border: 1,
+        borderColor: 'divider',
+        borderRadius: 2,
+        bgcolor: 'background.paper',
+      }}
+    >
+      <Stack spacing={1}>
+        <Box sx={{ color: 'primary.main', display: 'flex' }}>{icon}</Box>
+        <Typography variant="body2" color="text.secondary">{label}</Typography>
+        <Typography variant="h5" fontWeight={850} color="primary.main">{value}</Typography>
+        {caption && <Typography variant="caption" color="text.secondary">{caption}</Typography>}
+      </Stack>
+    </Box>
+  );
+}
+
+export default function DavidCelayaReportPage() {
+  const report = useMemo(() => buildDavidCelayaReport(), []);
+  const [pdfUrl, setPdfUrl] = useState('');
+  const { source } = report;
+
+  useEffect(() => {
+    const url = URL.createObjectURL(buildDavidCelayaReportPdfBlob(report));
+    setPdfUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [report]);
+
+  return (
+    <PageShell
+      title="Reporte de cuenta David Celaya"
+      subtitle="Bloques de trabajo consolidados a partir de las capturas de cámara compartidas."
+    >
+      <Stack spacing={3} sx={{ pb: 7, '@media print': { '& .print-hidden': { display: 'none' } } }}>
+        <Stack
+          className="print-hidden"
+          direction={{ xs: 'column', md: 'row' }}
+          spacing={1.5}
+          justifyContent="space-between"
+          alignItems={{ xs: 'stretch', md: 'center' }}
+        >
+          <Alert severity="info" sx={{ flex: 1 }}>
+            Reporte interno de tiempo. Las fotos se usaron como límites de bloque y la tarifa aplicada es de USD 25 por hora, redondeando cada bloque al entero más cercano.
+          </Alert>
+          <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+            <Button
+              variant="outlined"
+              startIcon={<DownloadIcon />}
+              component="a"
+              href={pdfUrl || undefined}
+              download={DAVID_CELAYA_REPORT_PDF_FILENAME}
+              disabled={!pdfUrl}
+            >
+              Descargar PDF
+            </Button>
+            <Button variant="contained" startIcon={<PrintIcon />} onClick={() => window.print()}>
+              Imprimir
+            </Button>
+          </Stack>
+        </Stack>
+
+        <Paper variant="outlined" sx={{ p: { xs: 2.5, md: 3 }, borderRadius: 2 }}>
+          <Stack spacing={3}>
+            <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" spacing={2.5}>
+              <Box>
+                <Typography variant="overline" color="text.secondary">Cuenta de trabajo</Typography>
+                <Typography variant="h4" fontWeight={900}>{source.personName}</Typography>
+                <Typography color="text.secondary">
+                  Periodo consolidado: {source.periodLabel}. Corte del reporte: {formatDateLabel(source.cutoffDate)}.
+                </Typography>
+              </Box>
+              <Box sx={{ textAlign: { xs: 'left', md: 'right' }, minWidth: 220 }}>
+                <Chip label="Tiempo registrado" color="primary" sx={{ mb: 1, fontWeight: 800 }} />
+                <Typography variant="h3" fontWeight={900}>
+                  {formatCurrency(report.totalBillableCents)}
+                </Typography>
+                <Typography color="text.secondary">
+                  {report.totalBillableHours}h facturables netas, 4 capturas de evidencia
+                </Typography>
+              </Box>
+            </Stack>
+
+            <Grid container spacing={1.5}>
+              <Grid item xs={12} sm={6} md={4}>
+                <Metric
+                  icon={<EventNoteIcon />}
+                  label="Bloques de trabajo"
+                  value={String(report.workBlocks.length)}
+                  caption="Dos jornadas separadas por fecha."
+                />
+              </Grid>
+              <Grid item xs={12} sm={6} md={4}>
+                <Metric
+                  icon={<PhotoLibraryIcon />}
+                  label="Capturas de respaldo"
+                  value={String(report.evidenceCount)}
+                  caption="Dos fotos por bloque."
+                />
+              </Grid>
+              <Grid item xs={12} sm={6} md={4}>
+                <Metric
+                  icon={<AccessTimeIcon />}
+                  label="Duración total"
+                  value={formatDuration(report.totalDurationSeconds)}
+                  caption="Suma de ambos bloques."
+                />
+              </Grid>
+              <Grid item xs={12} sm={6} md={6}>
+                <Metric
+                  icon={<ScheduleIcon />}
+                  label="Promedio por bloque"
+                  value={formatDuration(report.averageDurationSeconds)}
+                  caption="Referencia operativa."
+                />
+              </Grid>
+              <Grid item xs={12} sm={6} md={6}>
+                <Metric
+                  icon={<AccessTimeIcon />}
+                  label="Total facturable"
+                  value={formatCurrency(report.totalBillableCents)}
+                  caption="Tarifa USD 25/h con descuento explícito por bloque."
+                />
+              </Grid>
+              <Grid item xs={12} sm={6} md={6}>
+                <Metric
+                  icon={<AccessTimeIcon />}
+                  label="Total descontado"
+                  value={`${report.totalDiscountHours}h`}
+                  caption={`${formatCurrency(report.totalDiscountCents)} descontados en total.`}
+                />
+              </Grid>
+            </Grid>
+          </Stack>
+        </Paper>
+
+        <Section
+          title="Bloques registrados"
+          subtitle="Los tiempos visibles en las capturas se usaron para abrir y cerrar cada bloque de trabajo."
+        >
+          <TableContainer>
+            <Table sx={tableSx}>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Fecha</TableCell>
+                  <TableCell>Inicio</TableCell>
+                  <TableCell>Fin</TableCell>
+                  <TableCell align="right">Duración</TableCell>
+                  <TableCell align="right">Horas base</TableCell>
+                  <TableCell align="right">Descuento</TableCell>
+                  <TableCell align="right">Horas netas</TableCell>
+                  <TableCell align="right">Tarifa</TableCell>
+                  <TableCell align="right">Importe</TableCell>
+                  <TableCell align="center">Evidencia</TableCell>
+                  <TableCell>Nota</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {report.workBlocks.map((block) => (
+                  <TableRow key={block.id}>
+                    <TableCell>
+                      <Typography fontWeight={800}>{formatDateLabel(block.date)}</Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography fontWeight={700}>{formatDateTimeLabel(block.startDateTime)}</Typography>
+                      <Typography variant="body2" color="text.secondary">{block.startPhotoLabel}</Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography fontWeight={700}>{formatDateTimeLabel(block.endDateTime)}</Typography>
+                      <Typography variant="body2" color="text.secondary">{block.endPhotoLabel}</Typography>
+                    </TableCell>
+                    <TableCell align="right">
+                      <Typography fontWeight={800}>{block.durationLabel}</Typography>
+                    </TableCell>
+                    <TableCell align="right">
+                      <Typography variant="body2">{`${block.billableHours}h`}</Typography>
+                    </TableCell>
+                    <TableCell align="right">
+                      <Typography variant="body2">{block.discountLabel}</Typography>
+                    </TableCell>
+                    <TableCell align="right">
+                      <Typography fontWeight={800}>{`${block.netBillableHours}h`}</Typography>
+                    </TableCell>
+                    <TableCell align="right">
+                      <Typography variant="body2">{formatCurrency(source.hourlyRateCents)}</Typography>
+                    </TableCell>
+                    <TableCell align="right">
+                      <Typography fontWeight={800}>{block.billableLabel}</Typography>
+                    </TableCell>
+                    <TableCell align="center">
+                      <Chip label="2 fotos" size="small" variant="outlined" />
+                    </TableCell>
+                    <TableCell>
+                      <Stack spacing={0.5}>
+                        <Typography variant="body2">{block.description}</Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          {block.discountReason}
+                        </Typography>
+                      </Stack>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Section>
+
+        <Section title="Cierre">
+          <Stack spacing={1}>
+            <Typography>
+              Primer registro: <strong>{report.firstStart ? formatDateTimeLabel(report.firstStart) : 'N/D'}</strong>.
+            </Typography>
+            <Typography>
+              Último cierre: <strong>{report.lastEnd ? formatDateTimeLabel(report.lastEnd) : 'N/D'}</strong>.
+            </Typography>
+            <Typography color="text.secondary">
+              Cálculo monetario: {formatCurrency(source.hourlyRateCents)} por hora, con descuento explícito por bloque.
+            </Typography>
+            <Typography color="text.secondary">
+              Descuento acumulado: {report.totalDiscountHours}h = {formatCurrency(report.totalDiscountCents)}.
+            </Typography>
+          </Stack>
+        </Section>
+      </Stack>
+    </PageShell>
+  );
+}

--- a/tdf-hq-ui/src/pages/LoginPage.tsx
+++ b/tdf-hq-ui/src/pages/LoginPage.tsx
@@ -69,6 +69,7 @@ const LANDING_LABELS: Record<string, string> = {
   '/operacion/inventario': 'Inventario',
   '/finanzas/pagos': 'Finanzas',
   '/finanzas/reporte-esteban-munoz': 'Finanzas / Reporte Esteban',
+  '/finanzas/reporte-david-celaya': 'Finanzas / Reporte David',
   '/practicas': 'Prácticas',
   '/inicio': 'Inicio',
 };

--- a/tdf-hq-ui/src/pages/LoginPage.tsx
+++ b/tdf-hq-ui/src/pages/LoginPage.tsx
@@ -68,6 +68,7 @@ const LANDING_LABELS: Record<string, string> = {
   '/label/artistas': 'Sello / Artistas',
   '/operacion/inventario': 'Inventario',
   '/finanzas/pagos': 'Finanzas',
+  '/finanzas/creador-reporte-cuenta': 'Finanzas / Creador de reportes',
   '/finanzas/reporte-esteban-munoz': 'Finanzas / Reporte Esteban',
   '/finanzas/reporte-david-celaya': 'Finanzas / Reporte David',
   '/practicas': 'Prácticas',

--- a/tdf-hq-ui/src/pages/ManualPage.tsx
+++ b/tdf-hq-ui/src/pages/ManualPage.tsx
@@ -31,6 +31,7 @@ const sectionsByModule: Record<string, ManualItem[]> = {
   invoicing: [
     { title: 'Finanzas / Pagos', path: '/finanzas/pagos', description: 'Registro de pagos, comprobantes y facturas por sesión. Soporta concepto, monto, referencia, adjuntos y emisión SRI.' },
     { title: 'Finanzas / Reporte Esteban Muñoz', path: '/finanzas/reporte-esteban-munoz', description: 'Reporte consolidado de arriendo, comprobante base, honorarios por cursos de producción y saldo neto de cuentas con TDF.' },
+    { title: 'Finanzas / Reporte David Celaya', path: '/finanzas/reporte-david-celaya', description: 'Estado de cuenta basado en capturas de cámara con bloques de trabajo, tiempos de inicio/cierre y evidencia visual.' },
   ],
   admin: [
     { title: 'Configuración / Usuarios admin', path: '/configuracion/usuarios-admin', description: 'Altas, bajas y reseteo de accesos administrativos.' },

--- a/tdf-hq-ui/src/pages/ManualPage.tsx
+++ b/tdf-hq-ui/src/pages/ManualPage.tsx
@@ -30,6 +30,7 @@ const sectionsByModule: Record<string, ManualItem[]> = {
   ],
   invoicing: [
     { title: 'Finanzas / Pagos', path: '/finanzas/pagos', description: 'Registro de pagos, comprobantes y facturas por sesión. Soporta concepto, monto, referencia, adjuntos y emisión SRI.' },
+    { title: 'Finanzas / Creador de reportes', path: '/finanzas/creador-reporte-cuenta', description: 'Generador editable de reportes de cuenta con bloques dinámicos, descuentos explícitos y PDF descargable.' },
     { title: 'Finanzas / Reporte Esteban Muñoz', path: '/finanzas/reporte-esteban-munoz', description: 'Reporte consolidado de arriendo, comprobante base, honorarios por cursos de producción y saldo neto de cuentas con TDF.' },
     { title: 'Finanzas / Reporte David Celaya', path: '/finanzas/reporte-david-celaya', description: 'Estado de cuenta basado en capturas de cámara con bloques de trabajo, tiempos de inicio/cierre y evidencia visual.' },
   ],

--- a/tdf-hq-ui/src/pages/WorkAccountReportBuilderPage.tsx
+++ b/tdf-hq-ui/src/pages/WorkAccountReportBuilderPage.tsx
@@ -1,0 +1,316 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Divider,
+  Grid,
+  IconButton,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from '@mui/material';
+import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import DownloadIcon from '@mui/icons-material/Download';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import PageShell from '../components/PageShell';
+import {
+  buildWorkAccountReport,
+  buildWorkAccountReportPdfBlob,
+  formatCurrency,
+  formatDateLabel,
+  formatDuration,
+  type WorkAccountReportSource,
+  type WorkBlockSource,
+} from '../features/finance/davidCelayaReport';
+
+type BuilderBlock = WorkBlockSource;
+
+const DRAFT_SOURCE: WorkAccountReportSource = {
+  personName: 'David Celaya',
+  reportTitle: 'Reporte de cuenta',
+  periodLabel: '9 y 10 de julio de 2026',
+  hourlyRateCents: 2_500,
+  notes: 'Bloques de trabajo creados desde el sistema.',
+  workBlocks: [
+    {
+      id: 'block-1',
+      date: '2026-07-09',
+      startTime: '14:35:10',
+      endTime: '20:43:50',
+      startPhotoLabel: 'Foto inicio 1',
+      endPhotoLabel: 'Foto fin 1',
+      description: 'Bloque continuo en estudio.',
+      discountHours: 1,
+      discountReason: 'Descuento explícito de 1 hora.',
+    },
+    {
+      id: 'block-2',
+      date: '2026-07-10',
+      startTime: '17:37:28',
+      endTime: '23:50:32',
+      startPhotoLabel: 'Foto inicio 2',
+      endPhotoLabel: 'Foto fin 2',
+      description: 'Bloque nocturno en estudio.',
+      discountHours: 2,
+      discountReason: 'Descuento explícito de 2 horas.',
+    },
+  ],
+};
+
+const makeId = () => `block-${Math.random().toString(36).slice(2, 8)}`;
+
+const cloneBlocks = (blocks: BuilderBlock[]) => blocks.map((block) => ({ ...block, id: block.id || makeId() }));
+
+const emptyBlock = (): BuilderBlock => ({
+  id: makeId(),
+  date: new Date().toISOString().slice(0, 10) as `${number}-${number}-${number}`,
+  startTime: '09:00:00',
+  endTime: '10:00:00',
+  startPhotoLabel: 'Foto inicio',
+  endPhotoLabel: 'Foto fin',
+  description: 'Bloque de trabajo.',
+  discountHours: 0,
+  discountReason: 'Sin descuento.',
+});
+
+export default function WorkAccountReportBuilderPage() {
+  const [personName, setPersonName] = useState(DRAFT_SOURCE.personName);
+  const [reportTitle, setReportTitle] = useState(DRAFT_SOURCE.reportTitle);
+  const [periodLabel, setPeriodLabel] = useState(DRAFT_SOURCE.periodLabel);
+  const [hourlyRate, setHourlyRate] = useState('25');
+  const [notes, setNotes] = useState(DRAFT_SOURCE.notes);
+  const [asOfDate, setAsOfDate] = useState('2026-07-10');
+  const [blocks, setBlocks] = useState<BuilderBlock[]>(() => cloneBlocks(DRAFT_SOURCE.workBlocks));
+  const [pdfUrl, setPdfUrl] = useState('');
+
+  const source = useMemo<WorkAccountReportSource>(
+    () => ({
+      personName: personName.trim() || 'Sin nombre',
+      reportTitle: reportTitle.trim() || 'Reporte de cuenta',
+      periodLabel: periodLabel.trim() || 'Sin periodo',
+      hourlyRateCents: Math.max(0, Math.round(Number.parseFloat(hourlyRate.replace(',', '.')) * 100) || 0),
+      notes: notes.trim() || 'Sin notas.',
+      workBlocks: blocks.map((block) => ({
+        ...block,
+        discountHours: Math.max(0, Number.isFinite(Number(block.discountHours)) ? Number(block.discountHours) : 0),
+        discountReason: block.discountReason.trim() || 'Sin descuento.',
+      })),
+    }),
+    [blocks, hourlyRate, notes, periodLabel, personName, reportTitle],
+  );
+
+  const report = useMemo(() => buildWorkAccountReport(source, { asOfDate }), [source, asOfDate]);
+
+  useEffect(() => {
+    const url = URL.createObjectURL(buildWorkAccountReportPdfBlob(report));
+    setPdfUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [report]);
+
+  const loadExample = () => {
+    setPersonName(DRAFT_SOURCE.personName);
+    setReportTitle(DRAFT_SOURCE.reportTitle);
+    setPeriodLabel(DRAFT_SOURCE.periodLabel);
+    setHourlyRate('25');
+    setNotes(DRAFT_SOURCE.notes);
+    setAsOfDate('2026-07-10');
+    setBlocks(cloneBlocks(DRAFT_SOURCE.workBlocks));
+  };
+
+  const addBlock = () => setBlocks((prev) => [...prev, emptyBlock()]);
+
+  const updateBlock = (id: string, patch: Partial<BuilderBlock>) => {
+    setBlocks((prev) => prev.map((block) => (block.id === id ? { ...block, ...patch } : block)));
+  };
+
+  const removeBlock = (id: string) => {
+    setBlocks((prev) => prev.filter((block) => block.id !== id));
+  };
+
+  return (
+    <PageShell
+      title="Creador de reportes de cuenta"
+      subtitle="Construye reportes de tiempo y cuenta dentro del sistema, sin tocar código."
+    >
+      <Stack spacing={3} sx={{ pb: 7 }}>
+        <Alert severity="info">
+          Este generador crea reportes del mismo tipo que el de David Celaya, con bloques editables, descuentos explícitos y PDF descargable.
+        </Alert>
+
+        <Card variant="outlined">
+          <CardContent>
+            <Stack spacing={2}>
+              <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2} flexWrap="wrap">
+                <Box>
+                  <Typography variant="h6" fontWeight={850}>Datos del reporte</Typography>
+                  <Typography color="text.secondary">Modifica nombre, periodo, tarifa y notas generales.</Typography>
+                </Box>
+                <Stack direction="row" spacing={1}>
+                  <Button startIcon={<ContentCopyIcon />} variant="outlined" onClick={loadExample}>
+                    Cargar ejemplo
+                  </Button>
+                  <Button startIcon={<DownloadIcon />} variant="contained" component="a" href={pdfUrl || undefined} download="reporte-cuenta.pdf" disabled={!pdfUrl}>
+                    Descargar PDF
+                  </Button>
+                </Stack>
+              </Stack>
+
+              <Grid container spacing={2}>
+                <Grid item xs={12} md={4}>
+                  <TextField label="Nombre" value={personName} onChange={(e) => setPersonName(e.target.value)} fullWidth />
+                </Grid>
+                <Grid item xs={12} md={4}>
+                  <TextField label="Título" value={reportTitle} onChange={(e) => setReportTitle(e.target.value)} fullWidth />
+                </Grid>
+                <Grid item xs={12} md={4}>
+                  <TextField label="Periodo" value={periodLabel} onChange={(e) => setPeriodLabel(e.target.value)} fullWidth />
+                </Grid>
+                <Grid item xs={12} md={3}>
+                  <TextField label="Tarifa USD/h" value={hourlyRate} onChange={(e) => setHourlyRate(e.target.value)} fullWidth />
+                </Grid>
+                <Grid item xs={12} md={3}>
+                  <TextField label="Corte" type="date" value={asOfDate} onChange={(e) => setAsOfDate(e.target.value)} InputLabelProps={{ shrink: true }} fullWidth />
+                </Grid>
+                <Grid item xs={12} md={6}>
+                  <TextField label="Notas" value={notes} onChange={(e) => setNotes(e.target.value)} fullWidth multiline minRows={2} />
+                </Grid>
+              </Grid>
+            </Stack>
+          </CardContent>
+        </Card>
+
+        <Card variant="outlined">
+          <CardContent>
+            <Stack spacing={2}>
+              <Stack direction="row" justifyContent="space-between" alignItems="center">
+                <Box>
+                  <Typography variant="h6" fontWeight={850}>Bloques de trabajo</Typography>
+                  <Typography color="text.secondary">Agrega tantos bloques como necesites.</Typography>
+                </Box>
+                <Button startIcon={<AddCircleOutlineIcon />} onClick={addBlock} variant="outlined">
+                  Agregar bloque
+                </Button>
+              </Stack>
+
+              <Stack spacing={2}>
+                {blocks.map((block, index) => (
+                  <Paper key={block.id} variant="outlined" sx={{ p: 2, borderRadius: 2 }}>
+                    <Stack spacing={2}>
+                      <Stack direction="row" justifyContent="space-between" alignItems="center">
+                        <Typography fontWeight={800}>Bloque {index + 1}</Typography>
+                        <IconButton onClick={() => removeBlock(block.id)} aria-label="Eliminar bloque">
+                          <DeleteOutlineIcon />
+                        </IconButton>
+                      </Stack>
+                      <Grid container spacing={2}>
+                        <Grid item xs={12} md={3}>
+                          <TextField label="Fecha" type="date" value={block.date} onChange={(e) => updateBlock(block.id, { date: e.target.value as BuilderBlock['date'] })} InputLabelProps={{ shrink: true }} fullWidth />
+                        </Grid>
+                        <Grid item xs={12} md={3}>
+                          <TextField label="Inicio" value={block.startTime} onChange={(e) => updateBlock(block.id, { startTime: e.target.value })} fullWidth />
+                        </Grid>
+                        <Grid item xs={12} md={3}>
+                          <TextField label="Fin" value={block.endTime} onChange={(e) => updateBlock(block.id, { endTime: e.target.value })} fullWidth />
+                        </Grid>
+                        <Grid item xs={12} md={3}>
+                          <TextField label="Descuento horas" type="number" value={String(block.discountHours)} onChange={(e) => updateBlock(block.id, { discountHours: Number.parseInt(e.target.value || '0', 10) || 0 })} fullWidth />
+                        </Grid>
+                        <Grid item xs={12} md={4}>
+                          <TextField label="Foto inicio" value={block.startPhotoLabel} onChange={(e) => updateBlock(block.id, { startPhotoLabel: e.target.value })} fullWidth />
+                        </Grid>
+                        <Grid item xs={12} md={4}>
+                          <TextField label="Foto fin" value={block.endPhotoLabel} onChange={(e) => updateBlock(block.id, { endPhotoLabel: e.target.value })} fullWidth />
+                        </Grid>
+                        <Grid item xs={12} md={4}>
+                          <TextField label="Razón del descuento" value={block.discountReason} onChange={(e) => updateBlock(block.id, { discountReason: e.target.value })} fullWidth />
+                        </Grid>
+                        <Grid item xs={12}>
+                          <TextField label="Descripción" value={block.description} onChange={(e) => updateBlock(block.id, { description: e.target.value })} fullWidth multiline minRows={2} />
+                        </Grid>
+                      </Grid>
+                    </Stack>
+                  </Paper>
+                ))}
+              </Stack>
+            </Stack>
+          </CardContent>
+        </Card>
+
+        <Card variant="outlined">
+          <CardContent>
+            <Stack spacing={2}>
+              <Typography variant="h6" fontWeight={850}>Vista previa</Typography>
+              <Grid container spacing={2}>
+                <Grid item xs={12} md={3}>
+                  <PreviewMetric label="Horas netas" value={`${report.totalBillableHours}h`} />
+                </Grid>
+                <Grid item xs={12} md={3}>
+                  <PreviewMetric label="Descuento total" value={`${report.totalDiscountHours}h`} />
+                </Grid>
+                <Grid item xs={12} md={3}>
+                  <PreviewMetric label="Importe neto" value={formatCurrency(report.totalBillableCents)} />
+                </Grid>
+                <Grid item xs={12} md={3}>
+                  <PreviewMetric label="Duración total" value={formatDuration(report.totalDurationSeconds)} />
+                </Grid>
+              </Grid>
+
+              <Divider />
+
+              <TableContainer>
+                <Table>
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Fecha</TableCell>
+                      <TableCell>Inicio</TableCell>
+                      <TableCell>Fin</TableCell>
+                      <TableCell align="right">Base</TableCell>
+                      <TableCell align="right">Desc.</TableCell>
+                      <TableCell align="right">Neto</TableCell>
+                      <TableCell align="right">Importe</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {report.workBlocks.map((block) => (
+                      <TableRow key={block.id}>
+                        <TableCell>{formatDateLabel(block.date)}</TableCell>
+                        <TableCell>{block.startTime}</TableCell>
+                        <TableCell>{block.endTime}</TableCell>
+                        <TableCell align="right">{`${block.billableHours}h`}</TableCell>
+                        <TableCell align="right">{`${block.discountHours}h`}</TableCell>
+                        <TableCell align="right">{`${block.netBillableHours}h`}</TableCell>
+                        <TableCell align="right">{block.billableLabel}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            </Stack>
+          </CardContent>
+        </Card>
+      </Stack>
+    </PageShell>
+  );
+}
+
+function PreviewMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <Paper variant="outlined" sx={{ p: 2, borderRadius: 2 }}>
+      <Stack spacing={0.5}>
+        <Typography variant="body2" color="text.secondary">{label}</Typography>
+        <Typography variant="h6" fontWeight={850}>{value}</Typography>
+      </Stack>
+    </Paper>
+  );
+}

--- a/tdf-hq-ui/src/pages/WorkAccountReportBuilderPage.tsx
+++ b/tdf-hq-ui/src/pages/WorkAccountReportBuilderPage.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import {
   Alert,
   Box,
   Button,
   Card,
   CardContent,
+  Chip,
   Divider,
   Grid,
   IconButton,
@@ -18,11 +19,20 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  MenuItem,
 } from '@mui/material';
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import DownloadIcon from '@mui/icons-material/Download';
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
+import EventNoteIcon from '@mui/icons-material/EventNote';
+import PhotoLibraryIcon from '@mui/icons-material/PhotoLibrary';
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
 import PageShell from '../components/PageShell';
 import {
   buildWorkAccountReport,
@@ -30,18 +40,38 @@ import {
   formatCurrency,
   formatDateLabel,
   formatDuration,
+  type CustomFieldSource,
   type WorkAccountReportSource,
   type WorkBlockSource,
 } from '../features/finance/davidCelayaReport';
 
 type BuilderBlock = WorkBlockSource;
+type CustomFieldType = 'text' | 'number' | 'date' | 'currency';
+interface BuilderCustomField extends CustomFieldSource {
+  type: CustomFieldType;
+}
 
-const DRAFT_SOURCE: WorkAccountReportSource = {
+type WorkAccountTemplateSource = ReturnType<typeof buildWorkAccountReport>['source'];
+
+interface WorkAccountTemplate {
+  id: string;
+  name: string;
+  source: WorkAccountTemplateSource;
+  savedAt: string;
+}
+
+const TEMPLATE_STORAGE_KEY = 'tdf-work-account-report-builder-templates';
+
+const exampleSource: WorkAccountReportSource = {
   personName: 'David Celaya',
   reportTitle: 'Reporte de cuenta',
   periodLabel: '9 y 10 de julio de 2026',
   hourlyRateCents: 2_500,
   notes: 'Bloques de trabajo creados desde el sistema.',
+  customFields: [
+    { id: 'scope', label: 'Alcance', value: 'Sesiones de estudio y apoyo operativo.' },
+    { id: 'client', label: 'Cliente', value: 'David Celaya' },
+  ],
   workBlocks: [
     {
       id: 'block-1',
@@ -69,12 +99,13 @@ const DRAFT_SOURCE: WorkAccountReportSource = {
 };
 
 const makeId = () => `block-${Math.random().toString(36).slice(2, 8)}`;
+const makeFieldId = () => `field-${Math.random().toString(36).slice(2, 8)}`;
 
-const cloneBlocks = (blocks: BuilderBlock[]) => blocks.map((block) => ({ ...block, id: block.id || makeId() }));
+const todayIsoDate = () => new Date().toISOString().slice(0, 10) as `${number}-${number}-${number}`;
 
 const emptyBlock = (): BuilderBlock => ({
   id: makeId(),
-  date: new Date().toISOString().slice(0, 10) as `${number}-${number}-${number}`,
+  date: todayIsoDate(),
   startTime: '09:00:00',
   endTime: '10:00:00',
   startPhotoLabel: 'Foto inicio',
@@ -84,15 +115,129 @@ const emptyBlock = (): BuilderBlock => ({
   discountReason: 'Sin descuento.',
 });
 
+const emptyField = (): BuilderCustomField => ({
+  id: makeFieldId(),
+  label: 'Campo nuevo',
+  value: '',
+  type: 'text',
+});
+
+const cloneBlocks = (blocks: BuilderBlock[]) => blocks.map((block) => ({ ...block, id: block.id || makeId() }));
+const cloneFields = (fields: CustomFieldSource[]) =>
+  fields.map((field) => ({ ...field, id: field.id || makeFieldId(), type: field.type ?? 'text' }));
+
+const hasWindow = () => typeof window !== 'undefined';
+
+const fieldTypeOptions: Array<{ value: CustomFieldType; label: string; helper: string }> = [
+  { value: 'text', label: 'Texto', helper: 'Etiqueta libre.' },
+  { value: 'number', label: 'Número', helper: 'Cifra o cantidad.' },
+  { value: 'date', label: 'Fecha', helper: 'Dato de calendario.' },
+  { value: 'currency', label: 'Moneda', helper: 'Importe en USD.' },
+];
+
+const fieldTypeLabels = fieldTypeOptions.reduce<Record<CustomFieldType, string>>((acc, option) => {
+  acc[option.value] = option.label;
+  return acc;
+}, {} as Record<CustomFieldType, string>);
+
+const readTemplates = (): WorkAccountTemplate[] => {
+  if (!hasWindow()) return [];
+  try {
+    const raw = window.localStorage.getItem(TEMPLATE_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map((item) => {
+        if (!item || typeof item !== 'object') return null;
+        const candidate = item as Partial<WorkAccountTemplate>;
+        if (
+          typeof candidate.id !== 'string'
+          || typeof candidate.name !== 'string'
+          || typeof candidate.savedAt !== 'string'
+          || !candidate.source
+        ) {
+          return null;
+        }
+        return candidate as WorkAccountTemplate;
+      })
+      .filter((item): item is WorkAccountTemplate => item !== null);
+  } catch {
+    return [];
+  }
+};
+
+const writeTemplates = (templates: WorkAccountTemplate[]) => {
+  if (!hasWindow()) return;
+  window.localStorage.setItem(TEMPLATE_STORAGE_KEY, JSON.stringify(templates));
+};
+
+const formatSavedAt = (iso: string) => {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return new Intl.DateTimeFormat('es-EC', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+};
+
+const builderCardSx = {
+  borderRadius: 3,
+  borderColor: 'rgba(15, 23, 42, 0.10)',
+  boxShadow: '0 14px 30px rgba(15, 23, 42, 0.06)',
+  overflow: 'hidden',
+} as const;
+
+function SectionTitle({ title, subtitle, action }: { title: string; subtitle?: string; action?: ReactNode }) {
+  return (
+    <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} justifyContent="space-between" alignItems={{ sm: 'center' }}>
+      <Box>
+        <Typography variant="h6" fontWeight={850}>
+          {title}
+        </Typography>
+        {subtitle && <Typography color="text.secondary">{subtitle}</Typography>}
+      </Box>
+      {action}
+    </Stack>
+  );
+}
+
+function StatCard({ icon, label, value, caption }: { icon: React.ReactNode; label: string; value: string; caption: string }) {
+  return (
+    <Paper variant="outlined" sx={{ p: 2, borderRadius: 3, height: '100%', bgcolor: 'rgba(255,255,255,0.75)' }}>
+      <Stack spacing={1}>
+        <Box sx={{ color: 'primary.main', display: 'flex' }}>{icon}</Box>
+        <Typography variant="body2" color="text.secondary">
+          {label}
+        </Typography>
+        <Typography variant="h6" fontWeight={850}>
+          {value}
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          {caption}
+        </Typography>
+      </Stack>
+    </Paper>
+  );
+}
+
 export default function WorkAccountReportBuilderPage() {
-  const [personName, setPersonName] = useState(DRAFT_SOURCE.personName);
-  const [reportTitle, setReportTitle] = useState(DRAFT_SOURCE.reportTitle);
-  const [periodLabel, setPeriodLabel] = useState(DRAFT_SOURCE.periodLabel);
+  const [templates, setTemplates] = useState<WorkAccountTemplate[]>([]);
+  const [templateName, setTemplateName] = useState('');
+  const [selectedTemplateId, setSelectedTemplateId] = useState('');
+  const [personName, setPersonName] = useState('');
+  const [reportTitle, setReportTitle] = useState('Reporte de cuenta');
+  const [periodLabel, setPeriodLabel] = useState('');
   const [hourlyRate, setHourlyRate] = useState('25');
-  const [notes, setNotes] = useState(DRAFT_SOURCE.notes);
-  const [asOfDate, setAsOfDate] = useState('2026-07-10');
-  const [blocks, setBlocks] = useState<BuilderBlock[]>(() => cloneBlocks(DRAFT_SOURCE.workBlocks));
+  const [notes, setNotes] = useState('');
+  const [asOfDate, setAsOfDate] = useState(todayIsoDate());
+  const [blocks, setBlocks] = useState<BuilderBlock[]>([]);
+  const [customFields, setCustomFields] = useState<BuilderCustomField[]>([]);
   const [pdfUrl, setPdfUrl] = useState('');
+
+  useEffect(() => {
+    setTemplates(readTemplates());
+  }, []);
 
   const source = useMemo<WorkAccountReportSource>(
     () => ({
@@ -101,13 +246,22 @@ export default function WorkAccountReportBuilderPage() {
       periodLabel: periodLabel.trim() || 'Sin periodo',
       hourlyRateCents: Math.max(0, Math.round(Number.parseFloat(hourlyRate.replace(',', '.')) * 100) || 0),
       notes: notes.trim() || 'Sin notas.',
+      customFields: customFields
+        .map((field) => ({
+          id: field.id,
+          label: field.label.trim() || 'Campo',
+          value: field.value.trim() || 'Sin valor',
+          type: field.type,
+          // customFields are rendered as free-form text in the report PDF.
+        }))
+        .filter((field) => field.label || field.value),
       workBlocks: blocks.map((block) => ({
         ...block,
         discountHours: Math.max(0, Number.isFinite(Number(block.discountHours)) ? Number(block.discountHours) : 0),
         discountReason: block.discountReason.trim() || 'Sin descuento.',
       })),
     }),
-    [blocks, hourlyRate, notes, periodLabel, personName, reportTitle],
+    [blocks, customFields, hourlyRate, notes, periodLabel, personName, reportTitle],
   );
 
   const report = useMemo(() => buildWorkAccountReport(source, { asOfDate }), [source, asOfDate]);
@@ -119,198 +273,730 @@ export default function WorkAccountReportBuilderPage() {
   }, [report]);
 
   const loadExample = () => {
-    setPersonName(DRAFT_SOURCE.personName);
-    setReportTitle(DRAFT_SOURCE.reportTitle);
-    setPeriodLabel(DRAFT_SOURCE.periodLabel);
+    setPersonName(exampleSource.personName);
+    setReportTitle(exampleSource.reportTitle);
+    setPeriodLabel(exampleSource.periodLabel);
     setHourlyRate('25');
-    setNotes(DRAFT_SOURCE.notes);
+    setNotes(exampleSource.notes);
     setAsOfDate('2026-07-10');
-    setBlocks(cloneBlocks(DRAFT_SOURCE.workBlocks));
+    setBlocks(cloneBlocks(exampleSource.workBlocks));
+    setCustomFields(cloneFields(exampleSource.customFields ?? []));
+  };
+
+  const startBlank = () => {
+    setPersonName('');
+    setReportTitle('Reporte de cuenta');
+    setPeriodLabel('');
+    setHourlyRate('25');
+    setNotes('');
+    setAsOfDate(todayIsoDate());
+    setBlocks([]);
+    setCustomFields([]);
   };
 
   const addBlock = () => setBlocks((prev) => [...prev, emptyBlock()]);
+  const addField = () => setCustomFields((prev) => [...prev, emptyField()]);
+
+  const moveBlock = (id: string, direction: -1 | 1) => {
+    setBlocks((prev) => {
+      const index = prev.findIndex((block) => block.id === id);
+      const target = index + direction;
+      if (index < 0 || target < 0 || target >= prev.length) return prev;
+      const next = [...prev];
+      [next[index], next[target]] = [next[target]!, next[index]!];
+      return next;
+    });
+  };
+
+  const moveField = (id: string, direction: -1 | 1) => {
+    setCustomFields((prev) => {
+      const index = prev.findIndex((field) => field.id === id);
+      const target = index + direction;
+      if (index < 0 || target < 0 || target >= prev.length) return prev;
+      const next = [...prev];
+      [next[index], next[target]] = [next[target]!, next[index]!];
+      return next;
+    });
+  };
 
   const updateBlock = (id: string, patch: Partial<BuilderBlock>) => {
     setBlocks((prev) => prev.map((block) => (block.id === id ? { ...block, ...patch } : block)));
   };
 
-  const removeBlock = (id: string) => {
-    setBlocks((prev) => prev.filter((block) => block.id !== id));
+  const updateField = (id: string, patch: Partial<BuilderCustomField>) => {
+    setCustomFields((prev) => prev.map((field) => (field.id === id ? { ...field, ...patch } : field)));
+  };
+
+  const removeBlock = (id: string) => setBlocks((prev) => prev.filter((block) => block.id !== id));
+  const removeField = (id: string) => setCustomFields((prev) => prev.filter((field) => field.id !== id));
+
+  const saveTemplate = () => {
+    const name = templateName.trim();
+    if (!name) return;
+    const nextTemplate: WorkAccountTemplate = {
+      id: selectedTemplateId || `template-${makeId()}`,
+      name,
+      source: report.source,
+      savedAt: new Date().toISOString(),
+    };
+    const nextTemplates = (() => {
+      const existingIndex = templates.findIndex((template) => template.id === nextTemplate.id);
+      if (existingIndex >= 0) {
+        const next = [...templates];
+        next[existingIndex] = nextTemplate;
+        return next;
+      }
+      return [nextTemplate, ...templates];
+    })();
+    setTemplates(nextTemplates);
+    writeTemplates(nextTemplates);
+    setSelectedTemplateId(nextTemplate.id);
+  };
+
+  const loadTemplate = (templateId: string) => {
+    const template = templates.find((item) => item.id === templateId);
+    if (!template) return;
+    setSelectedTemplateId(template.id);
+    setTemplateName(template.name);
+    setPersonName(template.source.personName);
+    setReportTitle(template.source.reportTitle);
+    setPeriodLabel(template.source.periodLabel);
+    setHourlyRate(String(template.source.hourlyRateCents / 100));
+    setNotes(template.source.notes);
+    setAsOfDate(template.source.cutoffDate ?? todayIsoDate());
+    setBlocks(cloneBlocks(template.source.workBlocks));
+    setCustomFields(cloneFields((template.source.customFields ?? []) as BuilderCustomField[]));
+  };
+
+  const deleteTemplate = (templateId: string) => {
+    const nextTemplates = templates.filter((template) => template.id !== templateId);
+    setTemplates(nextTemplates);
+    writeTemplates(nextTemplates);
+    if (selectedTemplateId === templateId) {
+      setSelectedTemplateId('');
+      setTemplateName('');
+    }
   };
 
   return (
-    <PageShell
-      title="Creador de reportes de cuenta"
-      subtitle="Construye reportes de tiempo y cuenta dentro del sistema, sin tocar código."
-    >
-      <Stack spacing={3} sx={{ pb: 7 }}>
-        <Alert severity="info">
-          Este generador crea reportes del mismo tipo que el de David Celaya, con bloques editables, descuentos explícitos y PDF descargable.
-        </Alert>
-
-        <Card variant="outlined">
-          <CardContent>
-            <Stack spacing={2}>
-              <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2} flexWrap="wrap">
-                <Box>
-                  <Typography variant="h6" fontWeight={850}>Datos del reporte</Typography>
-                  <Typography color="text.secondary">Modifica nombre, periodo, tarifa y notas generales.</Typography>
-                </Box>
-                <Stack direction="row" spacing={1}>
+    <PageShell title="Creador de reportes de cuenta" subtitle="Construye reportes de tiempo y cuenta dentro del sistema, sin tocar código.">
+      <Box
+        sx={{
+          position: 'relative',
+          overflow: 'hidden',
+          pb: 7,
+          '&::before': {
+            content: '""',
+            position: 'absolute',
+            inset: 0,
+            background:
+              'radial-gradient(circle at top left, rgba(14,165,233,0.14), transparent 30%), radial-gradient(circle at top right, rgba(15,23,42,0.08), transparent 28%), linear-gradient(180deg, rgba(248,250,252,0.96), rgba(255,255,255,1))',
+            pointerEvents: 'none',
+            zIndex: -1,
+          },
+        }}
+      >
+        <Stack spacing={3}>
+          <Paper variant="outlined" sx={{ ...builderCardSx, p: { xs: 2.5, md: 3 } }}>
+            <Stack spacing={2.5}>
+              <Stack
+                direction={{ xs: 'column', md: 'row' }}
+                justifyContent="space-between"
+                alignItems={{ xs: 'flex-start', md: 'center' }}
+                spacing={2}
+              >
+                <Stack spacing={1} sx={{ maxWidth: 760 }}>
+                  <Chip
+                    icon={<AutoAwesomeIcon />}
+                    label="Nuevo reporte"
+                    color="primary"
+                    variant="outlined"
+                    sx={{ alignSelf: 'flex-start', fontWeight: 800 }}
+                  />
+                  <Typography variant="h4" fontWeight={900}>
+                    Crea reportes desde cero, no desde una plantilla obligatoria.
+                  </Typography>
+                  <Typography color="text.secondary" sx={{ maxWidth: 680 }}>
+                    Define los campos que necesites, agrega bloques de trabajo, ajusta descuentos y descarga el PDF sin salir del sistema.
+                  </Typography>
+                </Stack>
+                <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
                   <Button startIcon={<ContentCopyIcon />} variant="outlined" onClick={loadExample}>
                     Cargar ejemplo
                   </Button>
-                  <Button startIcon={<DownloadIcon />} variant="contained" component="a" href={pdfUrl || undefined} download="reporte-cuenta.pdf" disabled={!pdfUrl}>
+                  <Button startIcon={<DeleteOutlineIcon />} variant="text" onClick={startBlank}>
+                    Empezar en blanco
+                  </Button>
+                  <Button
+                    startIcon={<DownloadIcon />}
+                    variant="contained"
+                    component="a"
+                    href={pdfUrl || undefined}
+                    download="reporte-cuenta.pdf"
+                    disabled={!pdfUrl}
+                  >
                     Descargar PDF
                   </Button>
                 </Stack>
               </Stack>
 
               <Grid container spacing={2}>
-                <Grid item xs={12} md={4}>
-                  <TextField label="Nombre" value={personName} onChange={(e) => setPersonName(e.target.value)} fullWidth />
+                <Grid item xs={12} sm={6} md={3}>
+                  <StatCard
+                    icon={<EventNoteIcon />}
+                    label="Bloques"
+                    value={String(report.workBlocks.length)}
+                    caption="Agrega tantos como necesites."
+                  />
                 </Grid>
-                <Grid item xs={12} md={4}>
-                  <TextField label="Título" value={reportTitle} onChange={(e) => setReportTitle(e.target.value)} fullWidth />
+                <Grid item xs={12} sm={6} md={3}>
+                  <StatCard
+                    icon={<ReceiptLongIcon />}
+                    label="Campos personalizados"
+                    value={String(report.customFields?.length ?? 0)}
+                    caption="Nombre, conceptos, notas y lo que haga falta."
+                  />
                 </Grid>
-                <Grid item xs={12} md={4}>
-                  <TextField label="Periodo" value={periodLabel} onChange={(e) => setPeriodLabel(e.target.value)} fullWidth />
+                <Grid item xs={12} sm={6} md={3}>
+                  <StatCard
+                    icon={<AccessTimeIcon />}
+                    label="Horas netas"
+                    value={`${report.totalBillableHours}h`}
+                    caption={`Descuento total: ${report.totalDiscountHours}h.`}
+                  />
                 </Grid>
-                <Grid item xs={12} md={3}>
-                  <TextField label="Tarifa USD/h" value={hourlyRate} onChange={(e) => setHourlyRate(e.target.value)} fullWidth />
-                </Grid>
-                <Grid item xs={12} md={3}>
-                  <TextField label="Corte" type="date" value={asOfDate} onChange={(e) => setAsOfDate(e.target.value)} InputLabelProps={{ shrink: true }} fullWidth />
-                </Grid>
-                <Grid item xs={12} md={6}>
-                  <TextField label="Notas" value={notes} onChange={(e) => setNotes(e.target.value)} fullWidth multiline minRows={2} />
+                <Grid item xs={12} sm={6} md={3}>
+                  <StatCard
+                    icon={<PhotoLibraryIcon />}
+                    label="Importe neto"
+                    value={formatCurrency(report.totalBillableCents)}
+                    caption={`Tarifa base ${formatCurrency(report.source.hourlyRateCents)}/h.`}
+                  />
                 </Grid>
               </Grid>
-            </Stack>
-          </CardContent>
-        </Card>
 
-        <Card variant="outlined">
-          <CardContent>
-            <Stack spacing={2}>
-              <Stack direction="row" justifyContent="space-between" alignItems="center">
-                <Box>
-                  <Typography variant="h6" fontWeight={850}>Bloques de trabajo</Typography>
-                  <Typography color="text.secondary">Agrega tantos bloques como necesites.</Typography>
-                </Box>
-                <Button startIcon={<AddCircleOutlineIcon />} onClick={addBlock} variant="outlined">
-                  Agregar bloque
-                </Button>
-              </Stack>
-
-              <Stack spacing={2}>
-                {blocks.map((block, index) => (
-                  <Paper key={block.id} variant="outlined" sx={{ p: 2, borderRadius: 2 }}>
-                    <Stack spacing={2}>
-                      <Stack direction="row" justifyContent="space-between" alignItems="center">
-                        <Typography fontWeight={800}>Bloque {index + 1}</Typography>
-                        <IconButton onClick={() => removeBlock(block.id)} aria-label="Eliminar bloque">
-                          <DeleteOutlineIcon />
-                        </IconButton>
+              <Paper
+                variant="outlined"
+                sx={{
+                  p: { xs: 2, md: 2.5 },
+                  borderRadius: 3,
+                  bgcolor: 'rgba(255,255,255,0.72)',
+                  borderColor: 'rgba(15,23,42,0.10)',
+                }}
+              >
+                <Stack spacing={2}>
+                  <SectionTitle
+                    title="Plantillas guardadas"
+                    subtitle="Guarda el reporte actual como base para futuros clientes o reutiliza una configuración previa."
+                  />
+                  <Grid container spacing={2}>
+                    <Grid item xs={12} md={7}>
+                      <TextField
+                        label="Nombre de la plantilla"
+                        value={templateName}
+                        onChange={(e) => setTemplateName(e.target.value)}
+                        placeholder="Reporte base para David"
+                        fullWidth
+                      />
+                    </Grid>
+                    <Grid item xs={12} md={5}>
+                      <Stack direction="row" spacing={1} sx={{ height: '100%' }} alignItems="stretch">
+                        <Button variant="contained" onClick={saveTemplate} fullWidth>
+                          Guardar plantilla
+                        </Button>
+                        <Button
+                          variant="outlined"
+                          onClick={() => {
+                            if (!selectedTemplateId) return;
+                            loadTemplate(selectedTemplateId);
+                          }}
+                          disabled={!selectedTemplateId}
+                          fullWidth
+                        >
+                          Reaplicar
+                        </Button>
                       </Stack>
+                    </Grid>
+                  </Grid>
+
+                  {templates.length > 0 ? (
+                    <Stack spacing={1.25}>
+                      {templates.map((template) => (
+                        <Paper
+                          key={template.id}
+                          variant="outlined"
+                          sx={{
+                            p: 1.5,
+                            borderRadius: 2.5,
+                            bgcolor: template.id === selectedTemplateId ? 'rgba(59,130,246,0.08)' : 'white',
+                            borderColor: template.id === selectedTemplateId ? 'primary.main' : 'rgba(15,23,42,0.10)',
+                          }}
+                        >
+                          <Stack
+                            direction={{ xs: 'column', md: 'row' }}
+                            alignItems={{ xs: 'flex-start', md: 'center' }}
+                            justifyContent="space-between"
+                            spacing={1.5}
+                          >
+                            <Box>
+                              <Typography fontWeight={800}>{template.name}</Typography>
+                              <Typography variant="body2" color="text.secondary">
+                                Guardada {formatSavedAt(template.savedAt)} · {template.source.workBlocks.length} bloques ·{' '}
+                                {template.source.customFields?.length ?? 0} campos
+                              </Typography>
+                            </Box>
+                            <Stack direction="row" spacing={1} flexWrap="wrap">
+                              <Button size="small" variant="outlined" onClick={() => loadTemplate(template.id)}>
+                                Cargar
+                              </Button>
+                              <Button size="small" color="inherit" variant="text" onClick={() => deleteTemplate(template.id)}>
+                                Eliminar
+                              </Button>
+                            </Stack>
+                          </Stack>
+                        </Paper>
+                      ))}
+                    </Stack>
+                  ) : (
+                    <Alert severity="info" sx={{ bgcolor: 'rgba(59,130,246,0.08)' }}>
+                      Aún no has guardado plantillas. Crea una base y presióna guardar para reutilizarla después.
+                    </Alert>
+                  )}
+                </Stack>
+              </Paper>
+            </Stack>
+          </Paper>
+
+          <Grid container spacing={3}>
+            <Grid item xs={12} lg={7}>
+              <Stack spacing={3}>
+                <Card variant="outlined" sx={builderCardSx}>
+                  <CardContent>
+                    <Stack spacing={2.5}>
+                      <SectionTitle
+                        title="Datos del reporte"
+                        subtitle="Llena los campos principales. Los vacíos se muestran como una guía visual, no como un requisito para arrancar."
+                      />
                       <Grid container spacing={2}>
-                        <Grid item xs={12} md={3}>
-                          <TextField label="Fecha" type="date" value={block.date} onChange={(e) => updateBlock(block.id, { date: e.target.value as BuilderBlock['date'] })} InputLabelProps={{ shrink: true }} fullWidth />
+                        <Grid item xs={12} md={6}>
+                          <TextField label="Nombre" value={personName} onChange={(e) => setPersonName(e.target.value)} fullWidth />
+                        </Grid>
+                        <Grid item xs={12} md={6}>
+                          <TextField label="Título del reporte" value={reportTitle} onChange={(e) => setReportTitle(e.target.value)} fullWidth />
+                        </Grid>
+                        <Grid item xs={12} md={6}>
+                          <TextField label="Periodo" value={periodLabel} onChange={(e) => setPeriodLabel(e.target.value)} fullWidth helperText="Ej: 9 y 10 de julio de 2026" />
                         </Grid>
                         <Grid item xs={12} md={3}>
-                          <TextField label="Inicio" value={block.startTime} onChange={(e) => updateBlock(block.id, { startTime: e.target.value })} fullWidth />
+                          <TextField label="Tarifa USD/h" value={hourlyRate} onChange={(e) => setHourlyRate(e.target.value)} fullWidth />
                         </Grid>
                         <Grid item xs={12} md={3}>
-                          <TextField label="Fin" value={block.endTime} onChange={(e) => updateBlock(block.id, { endTime: e.target.value })} fullWidth />
-                        </Grid>
-                        <Grid item xs={12} md={3}>
-                          <TextField label="Descuento horas" type="number" value={String(block.discountHours)} onChange={(e) => updateBlock(block.id, { discountHours: Number.parseInt(e.target.value || '0', 10) || 0 })} fullWidth />
-                        </Grid>
-                        <Grid item xs={12} md={4}>
-                          <TextField label="Foto inicio" value={block.startPhotoLabel} onChange={(e) => updateBlock(block.id, { startPhotoLabel: e.target.value })} fullWidth />
-                        </Grid>
-                        <Grid item xs={12} md={4}>
-                          <TextField label="Foto fin" value={block.endPhotoLabel} onChange={(e) => updateBlock(block.id, { endPhotoLabel: e.target.value })} fullWidth />
-                        </Grid>
-                        <Grid item xs={12} md={4}>
-                          <TextField label="Razón del descuento" value={block.discountReason} onChange={(e) => updateBlock(block.id, { discountReason: e.target.value })} fullWidth />
+                          <TextField
+                            label="Corte"
+                            type="date"
+                            value={asOfDate}
+                            onChange={(e) => setAsOfDate(e.target.value as typeof asOfDate)}
+                            InputLabelProps={{ shrink: true }}
+                            fullWidth
+                          />
                         </Grid>
                         <Grid item xs={12}>
-                          <TextField label="Descripción" value={block.description} onChange={(e) => updateBlock(block.id, { description: e.target.value })} fullWidth multiline minRows={2} />
+                          <TextField label="Notas internas" value={notes} onChange={(e) => setNotes(e.target.value)} fullWidth multiline minRows={3} />
                         </Grid>
                       </Grid>
                     </Stack>
-                  </Paper>
-                ))}
+                  </CardContent>
+                </Card>
+
+                <Card variant="outlined" sx={builderCardSx}>
+                  <CardContent>
+                    <Stack spacing={2}>
+                      <SectionTitle
+                        title="Campos personalizados"
+                        subtitle="Añade secciones o etiquetas que no estén en el formulario base."
+                        action={
+                          <Button startIcon={<AddCircleOutlineIcon />} onClick={addField} variant="outlined">
+                            Agregar campo
+                          </Button>
+                        }
+                      />
+
+                      {customFields.length === 0 ? (
+                        <Paper
+                          variant="outlined"
+                          sx={{
+                            p: 3,
+                            borderRadius: 3,
+                            borderStyle: 'dashed',
+                            bgcolor: 'rgba(248,250,252,0.9)',
+                          }}
+                        >
+                          <Stack spacing={1}>
+                            <Typography fontWeight={800}>No hay campos personalizados todavía.</Typography>
+                            <Typography color="text.secondary">
+                              Usa este espacio para crear etiquetas como propósito, ubicación, cliente secundario o cualquier dato que quieras ver en el PDF.
+                            </Typography>
+                            <Box>
+                              <Button startIcon={<AddCircleOutlineIcon />} variant="contained" onClick={addField}>
+                                Crear primer campo
+                              </Button>
+                            </Box>
+                          </Stack>
+                        </Paper>
+                      ) : (
+                        <Stack spacing={1.5}>
+                          {customFields.map((field, index) => (
+                            <Paper key={field.id} variant="outlined" sx={{ p: 2, borderRadius: 3 }}>
+                              <Stack spacing={2}>
+                                <Stack direction="row" alignItems="center" justifyContent="space-between">
+                                  <Stack direction="row" spacing={1} alignItems="center">
+                                    <DragIndicatorIcon fontSize="small" color="disabled" />
+                                    <Typography fontWeight={800}>Campo {index + 1}</Typography>
+                                  </Stack>
+                                  <Stack direction="row" spacing={0.5}>
+                                    <IconButton
+                                      onClick={() => moveField(field.id, -1)}
+                                      aria-label="Mover campo arriba"
+                                      disabled={index === 0}
+                                    >
+                                      <KeyboardArrowUpIcon />
+                                    </IconButton>
+                                    <IconButton
+                                      onClick={() => moveField(field.id, 1)}
+                                      aria-label="Mover campo abajo"
+                                      disabled={index === customFields.length - 1}
+                                    >
+                                      <KeyboardArrowDownIcon />
+                                    </IconButton>
+                                    <IconButton onClick={() => removeField(field.id)} aria-label="Eliminar campo">
+                                      <DeleteOutlineIcon />
+                                    </IconButton>
+                                  </Stack>
+                                </Stack>
+                                <Grid container spacing={2}>
+                                  <Grid item xs={12} md={5}>
+                                    <TextField
+                                      label="Etiqueta"
+                                      value={field.label}
+                                      onChange={(e) => updateField(field.id, { label: e.target.value })}
+                                      fullWidth
+                                    />
+                                  </Grid>
+                                  <Grid item xs={12} md={7}>
+                                    <TextField
+                                      label="Valor"
+                                      value={field.value}
+                                      onChange={(e) => updateField(field.id, { value: e.target.value })}
+                                      fullWidth
+                                    />
+                                  </Grid>
+                                  <Grid item xs={12} md={4}>
+                                    <TextField
+                                      select
+                                      label="Tipo"
+                                      value={field.type}
+                                      onChange={(e) =>
+                                        updateField(field.id, { type: e.target.value as BuilderCustomField['type'] })
+                                      }
+                                      fullWidth
+                                      helperText={fieldTypeOptions.find((option) => option.value === field.type)?.helper}
+                                    >
+                                      {fieldTypeOptions.map((option) => (
+                                        <MenuItem key={option.value} value={option.value}>
+                                          {option.label}
+                                        </MenuItem>
+                                      ))}
+                                    </TextField>
+                                  </Grid>
+                                </Grid>
+                              </Stack>
+                            </Paper>
+                          ))}
+                        </Stack>
+                      )}
+                    </Stack>
+                  </CardContent>
+                </Card>
+
+                <Card variant="outlined" sx={builderCardSx}>
+                  <CardContent>
+                    <Stack spacing={2}>
+                      <SectionTitle
+                        title="Bloques de trabajo"
+                        subtitle="Cada bloque puede tener su propia foto de inicio y fin, además de un descuento explícito."
+                        action={
+                          <Button startIcon={<AddCircleOutlineIcon />} onClick={addBlock} variant="outlined">
+                            Agregar bloque
+                          </Button>
+                        }
+                      />
+
+                      {blocks.length === 0 ? (
+                        <Paper
+                          variant="outlined"
+                          sx={{
+                            p: 3,
+                            borderRadius: 3,
+                            borderStyle: 'dashed',
+                            bgcolor: 'rgba(248,250,252,0.9)',
+                          }}
+                        >
+                          <Stack spacing={1}>
+                            <Typography fontWeight={800}>Todavía no has agregado bloques.</Typography>
+                            <Typography color="text.secondary">
+                              Empieza con un bloque de trabajo y el sistema calculará la duración, las horas facturables y el descuento.
+                            </Typography>
+                            <Box>
+                              <Button startIcon={<AddCircleOutlineIcon />} variant="contained" onClick={addBlock}>
+                                Crear primer bloque
+                              </Button>
+                            </Box>
+                          </Stack>
+                        </Paper>
+                      ) : (
+                        <Stack spacing={2}>
+                          {blocks.map((block, index) => (
+                            <Paper key={block.id} variant="outlined" sx={{ p: 2.25, borderRadius: 3 }}>
+                              <Stack spacing={2}>
+                                <Stack direction="row" justifyContent="space-between" alignItems="center">
+                                  <Stack direction="row" spacing={1} alignItems="center">
+                                    <Chip label={`Bloque ${index + 1}`} color="primary" size="small" />
+                                    <Typography variant="body2" color="text.secondary">
+                                      {formatDateLabel(block.date)}
+                                    </Typography>
+                                  </Stack>
+                                  <Stack direction="row" spacing={0.5}>
+                                    <IconButton
+                                      onClick={() => moveBlock(block.id, -1)}
+                                      aria-label="Mover bloque arriba"
+                                      disabled={index === 0}
+                                    >
+                                      <KeyboardArrowUpIcon />
+                                    </IconButton>
+                                    <IconButton
+                                      onClick={() => moveBlock(block.id, 1)}
+                                      aria-label="Mover bloque abajo"
+                                      disabled={index === blocks.length - 1}
+                                    >
+                                      <KeyboardArrowDownIcon />
+                                    </IconButton>
+                                    <IconButton onClick={() => removeBlock(block.id)} aria-label="Eliminar bloque">
+                                      <DeleteOutlineIcon />
+                                    </IconButton>
+                                  </Stack>
+                                </Stack>
+
+                                <Grid container spacing={2}>
+                                  <Grid item xs={12} sm={6} md={3}>
+                                    <TextField
+                                      label="Fecha"
+                                      type="date"
+                                      value={block.date}
+                                      onChange={(e) =>
+                                        updateBlock(block.id, {
+                                          date: e.target.value as BuilderBlock['date'],
+                                        })
+                                      }
+                                      InputLabelProps={{ shrink: true }}
+                                      fullWidth
+                                    />
+                                  </Grid>
+                                  <Grid item xs={12} sm={6} md={3}>
+                                    <TextField
+                                      label="Inicio"
+                                      value={block.startTime}
+                                      onChange={(e) => updateBlock(block.id, { startTime: e.target.value })}
+                                      fullWidth
+                                      helperText="HH:MM:SS"
+                                    />
+                                  </Grid>
+                                  <Grid item xs={12} sm={6} md={3}>
+                                    <TextField
+                                      label="Fin"
+                                      value={block.endTime}
+                                      onChange={(e) => updateBlock(block.id, { endTime: e.target.value })}
+                                      fullWidth
+                                      helperText="HH:MM:SS"
+                                    />
+                                  </Grid>
+                                  <Grid item xs={12} sm={6} md={3}>
+                                    <TextField
+                                      label="Descuento horas"
+                                      type="number"
+                                      value={String(block.discountHours)}
+                                      onChange={(e) =>
+                                        updateBlock(block.id, {
+                                          discountHours: Number.parseInt(e.target.value || '0', 10) || 0,
+                                        })
+                                      }
+                                      fullWidth
+                                    />
+                                  </Grid>
+                                  <Grid item xs={12} md={4}>
+                                    <TextField
+                                      label="Foto de inicio"
+                                      value={block.startPhotoLabel}
+                                      onChange={(e) => updateBlock(block.id, { startPhotoLabel: e.target.value })}
+                                      fullWidth
+                                    />
+                                  </Grid>
+                                  <Grid item xs={12} md={4}>
+                                    <TextField
+                                      label="Foto de fin"
+                                      value={block.endPhotoLabel}
+                                      onChange={(e) => updateBlock(block.id, { endPhotoLabel: e.target.value })}
+                                      fullWidth
+                                    />
+                                  </Grid>
+                                  <Grid item xs={12} md={4}>
+                                    <TextField
+                                      label="Razón del descuento"
+                                      value={block.discountReason}
+                                      onChange={(e) => updateBlock(block.id, { discountReason: e.target.value })}
+                                      fullWidth
+                                    />
+                                  </Grid>
+                                  <Grid item xs={12}>
+                                    <TextField
+                                      label="Descripción"
+                                      value={block.description}
+                                      onChange={(e) => updateBlock(block.id, { description: e.target.value })}
+                                      fullWidth
+                                      multiline
+                                      minRows={2}
+                                    />
+                                  </Grid>
+                                </Grid>
+                              </Stack>
+                            </Paper>
+                          ))}
+                        </Stack>
+                      )}
+                    </Stack>
+                  </CardContent>
+                </Card>
               </Stack>
-            </Stack>
-          </CardContent>
-        </Card>
+            </Grid>
 
-        <Card variant="outlined">
-          <CardContent>
-            <Stack spacing={2}>
-              <Typography variant="h6" fontWeight={850}>Vista previa</Typography>
-              <Grid container spacing={2}>
-                <Grid item xs={12} md={3}>
-                  <PreviewMetric label="Horas netas" value={`${report.totalBillableHours}h`} />
-                </Grid>
-                <Grid item xs={12} md={3}>
-                  <PreviewMetric label="Descuento total" value={`${report.totalDiscountHours}h`} />
-                </Grid>
-                <Grid item xs={12} md={3}>
-                  <PreviewMetric label="Importe neto" value={formatCurrency(report.totalBillableCents)} />
-                </Grid>
-                <Grid item xs={12} md={3}>
-                  <PreviewMetric label="Duración total" value={formatDuration(report.totalDurationSeconds)} />
-                </Grid>
-              </Grid>
+            <Grid item xs={12} lg={5}>
+              <Box
+                sx={{
+                  position: { lg: 'sticky' },
+                  top: { lg: 24 },
+                }}
+              >
+                <Card variant="outlined" sx={{ ...builderCardSx, bgcolor: 'rgba(15,23,42,0.96)', color: 'white' }}>
+                  <CardContent>
+                    <Stack spacing={2.5}>
+                      <Box>
+                        <Chip label="Vista previa en vivo" color="primary" sx={{ mb: 1, fontWeight: 800 }} />
+                        <Typography variant="h5" fontWeight={900}>
+                          {report.source.personName}
+                        </Typography>
+                        <Typography color="rgba(255,255,255,0.72)">
+                          {report.source.reportTitle} · {report.source.periodLabel}
+                        </Typography>
+                      </Box>
 
-              <Divider />
+                      <Grid container spacing={1.5}>
+                        <Grid item xs={6}>
+                          <StatCard
+                            icon={<AccessTimeIcon />}
+                            label="Horas netas"
+                            value={`${report.totalBillableHours}h`}
+                            caption="Facturables después del descuento."
+                          />
+                        </Grid>
+                        <Grid item xs={6}>
+                          <StatCard
+                            icon={<PhotoLibraryIcon />}
+                            label="Descuento"
+                            value={`${report.totalDiscountHours}h`}
+                            caption={formatCurrency(report.totalDiscountCents)}
+                          />
+                        </Grid>
+                        <Grid item xs={12}>
+                          <StatCard
+                            icon={<ReceiptLongIcon />}
+                            label="Importe neto"
+                            value={formatCurrency(report.totalBillableCents)}
+                            caption={`Tarifa base ${formatCurrency(report.source.hourlyRateCents)}/h`}
+                          />
+                        </Grid>
+                      </Grid>
 
-              <TableContainer>
-                <Table>
-                  <TableHead>
-                    <TableRow>
-                      <TableCell>Fecha</TableCell>
-                      <TableCell>Inicio</TableCell>
-                      <TableCell>Fin</TableCell>
-                      <TableCell align="right">Base</TableCell>
-                      <TableCell align="right">Desc.</TableCell>
-                      <TableCell align="right">Neto</TableCell>
-                      <TableCell align="right">Importe</TableCell>
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {report.workBlocks.map((block) => (
-                      <TableRow key={block.id}>
-                        <TableCell>{formatDateLabel(block.date)}</TableCell>
-                        <TableCell>{block.startTime}</TableCell>
-                        <TableCell>{block.endTime}</TableCell>
-                        <TableCell align="right">{`${block.billableHours}h`}</TableCell>
-                        <TableCell align="right">{`${block.discountHours}h`}</TableCell>
-                        <TableCell align="right">{`${block.netBillableHours}h`}</TableCell>
-                        <TableCell align="right">{block.billableLabel}</TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </TableContainer>
-            </Stack>
-          </CardContent>
-        </Card>
-      </Stack>
+                      <Divider sx={{ borderColor: 'rgba(255,255,255,0.12)' }} />
+
+                      <Alert severity="info" sx={{ bgcolor: 'rgba(56,189,248,0.12)', color: 'white' }}>
+                        El documento saldrá con los bloques, los campos personalizados y el resumen de descuentos.
+                      </Alert>
+
+                      <Stack spacing={1}>
+                        <Typography variant="subtitle2" sx={{ textTransform: 'uppercase', letterSpacing: 0.8, color: 'rgba(255,255,255,0.62)' }}>
+                          Campos visibles
+                        </Typography>
+                        {report.customFields?.length ? (
+                          <Stack spacing={1}>
+                            {report.customFields.map((field) => (
+                              <Paper
+                                key={field.id}
+                                variant="outlined"
+                                sx={{ p: 1.5, borderRadius: 2, bgcolor: 'rgba(255,255,255,0.06)', borderColor: 'rgba(255,255,255,0.10)' }}
+                              >
+                                <Typography variant="caption" color="rgba(255,255,255,0.66)">
+                                  {field.label} · {fieldTypeLabels[field.type]}
+                                </Typography>
+                                <Typography fontWeight={700}>{field.value}</Typography>
+                              </Paper>
+                            ))}
+                          </Stack>
+                        ) : (
+                          <Typography color="rgba(255,255,255,0.72)">
+                            No has añadido campos personalizados.
+                          </Typography>
+                        )}
+                      </Stack>
+
+                      <Stack spacing={1}>
+                        <Typography variant="subtitle2" sx={{ textTransform: 'uppercase', letterSpacing: 0.8, color: 'rgba(255,255,255,0.62)' }}>
+                          Bloques
+                        </Typography>
+                        {report.workBlocks.length ? (
+                          <Stack spacing={1}>
+                            {report.workBlocks.map((block, index) => (
+                              <Paper
+                                key={block.id}
+                                variant="outlined"
+                                sx={{ p: 1.5, borderRadius: 2, bgcolor: 'rgba(255,255,255,0.06)', borderColor: 'rgba(255,255,255,0.10)' }}
+                              >
+                                <Stack spacing={0.5}>
+                                  <Typography fontWeight={800}>
+                                    Bloque {index + 1} · {formatDateLabel(block.date)}
+                                  </Typography>
+                                  <Typography variant="body2" color="rgba(255,255,255,0.72)">
+                                    {block.startTime} - {block.endTime} · {block.billableHours}h base · -{block.discountHours}h · {block.netBillableHours}h netas
+                                  </Typography>
+                                  <Typography variant="body2" color="rgba(255,255,255,0.72)">
+                                    {block.billableLabel}
+                                  </Typography>
+                                </Stack>
+                              </Paper>
+                            ))}
+                          </Stack>
+                        ) : (
+                          <Typography color="rgba(255,255,255,0.72)">
+                            Aún no agregaste bloques.
+                          </Typography>
+                        )}
+                      </Stack>
+                    </Stack>
+                  </CardContent>
+                </Card>
+              </Box>
+            </Grid>
+          </Grid>
+        </Stack>
+      </Box>
     </PageShell>
-  );
-}
-
-function PreviewMetric({ label, value }: { label: string; value: string }) {
-  return (
-    <Paper variant="outlined" sx={{ p: 2, borderRadius: 2 }}>
-      <Stack spacing={0.5}>
-        <Typography variant="body2" color="text.secondary">{label}</Typography>
-        <Typography variant="h6" fontWeight={850}>{value}</Typography>
-      </Stack>
-    </Paper>
   );
 }

--- a/tdf-hq-ui/src/routes/protectedRoutes.tsx
+++ b/tdf-hq-ui/src/routes/protectedRoutes.tsx
@@ -21,6 +21,7 @@ const CourseRegistrationsAdminPage = lazy(() => import('../pages/CourseRegistrat
 const DocsPage = lazy(() => import('../pages/DocsPage'));
 const EstebanMunozReportPage = lazy(() => import('../pages/EstebanMunozReportPage'));
 const DavidCelayaReportPage = lazy(() => import('../pages/DavidCelayaReportPage'));
+const WorkAccountReportBuilderPage = lazy(() => import('../pages/WorkAccountReportBuilderPage'));
 const FanHubPage = lazy(() => import('../pages/FanHubPage'));
 const FanClubPage = lazy(() => import('../pages/FanClubPage'));
 const FanClubMemberProfilePage = lazy(() => import('../pages/FanClubMemberProfilePage'));
@@ -135,6 +136,7 @@ export function renderProtectedRoutes() {
 
         <Route path="/finanzas" element={<Outlet />}>
           <Route path="pagos" element={<PaymentsPage />} />
+          <Route path="creador-reporte-cuenta" element={<WorkAccountReportBuilderPage />} />
           <Route path="reporte-esteban-munoz" element={<EstebanMunozReportPage />} />
           <Route path="reporte-david-celaya" element={<DavidCelayaReportPage />} />
           <Route index element={<Navigate to="pagos" replace />} />

--- a/tdf-hq-ui/src/routes/protectedRoutes.tsx
+++ b/tdf-hq-ui/src/routes/protectedRoutes.tsx
@@ -20,6 +20,7 @@ const CourseBuilderPage = lazy(() => import('../pages/CourseBuilderPage'));
 const CourseRegistrationsAdminPage = lazy(() => import('../pages/CourseRegistrationsAdminPage'));
 const DocsPage = lazy(() => import('../pages/DocsPage'));
 const EstebanMunozReportPage = lazy(() => import('../pages/EstebanMunozReportPage'));
+const DavidCelayaReportPage = lazy(() => import('../pages/DavidCelayaReportPage'));
 const FanHubPage = lazy(() => import('../pages/FanHubPage'));
 const FanClubPage = lazy(() => import('../pages/FanClubPage'));
 const FanClubMemberProfilePage = lazy(() => import('../pages/FanClubMemberProfilePage'));
@@ -135,6 +136,7 @@ export function renderProtectedRoutes() {
         <Route path="/finanzas" element={<Outlet />}>
           <Route path="pagos" element={<PaymentsPage />} />
           <Route path="reporte-esteban-munoz" element={<EstebanMunozReportPage />} />
+          <Route path="reporte-david-celaya" element={<DavidCelayaReportPage />} />
           <Route index element={<Navigate to="pagos" replace />} />
         </Route>
 

--- a/tdf-hq-ui/src/utils/navigationLabels.ts
+++ b/tdf-hq-ui/src/utils/navigationLabels.ts
@@ -58,6 +58,8 @@ const FRIENDLY_SEGMENTS: Record<string, string> = {
   facturas: 'Facturas',
   cobros: 'Cobros',
   pagos: 'Pagos',
+  'reporte-esteban-munoz': 'Reporte Esteban Muñoz',
+  'reporte-david-celaya': 'Reporte David Celaya',
   recibos: 'Recibos',
   regalias: 'Regalías',
   docs: 'Documentación',

--- a/tdf-hq-ui/src/utils/navigationLabels.ts
+++ b/tdf-hq-ui/src/utils/navigationLabels.ts
@@ -58,6 +58,7 @@ const FRIENDLY_SEGMENTS: Record<string, string> = {
   facturas: 'Facturas',
   cobros: 'Cobros',
   pagos: 'Pagos',
+  'creador-reporte-cuenta': 'Creador de reportes',
   'reporte-esteban-munoz': 'Reporte Esteban Muñoz',
   'reporte-david-celaya': 'Reporte David Celaya',
   recibos: 'Recibos',


### PR DESCRIPTION
## What changed
- Added a new finance report for David Celaya at `/finanzas/reporte-david-celaya`.
- Built a matching PDF export and web view modeled after the existing Esteban Muñoz report.
- Added explicit block-level discounts and a summary of total discounted hours and amount.
- Wired the route into navigation and manual links.

## Billing model
- Hourly rate: USD 25/hour.
- Block 1: 1 hour discount.
- Block 2: 2 hour discount.
- Net billable total: 9 hours / USD 225.00.

## Validation
- `npm run typecheck --workspace=tdf-hq-ui`
- `npm test --workspace=tdf-hq-ui -- --runTestsByPath src/features/finance/davidCelayaReport.test.ts`

## Notes
- The report uses the timestamps visible in the supplied screenshots as block boundaries.
- The totals are shown in both the web UI and the generated PDF.