### PR TITLE
Fix social discovery production migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,13 +119,16 @@ jobs:
         run: |
           node scripts/render-production-migration-batch.mjs | psql "$PGURL" -v ON_ERROR_STOP=1
           node scripts/render-production-migration-batch.mjs | psql "$PGURL" -v ON_ERROR_STOP=1
-          test "$(psql "$PGURL" -Atqc 'SELECT COUNT(*) FROM public.tdf_schema_migration')" = "3"
+          expected_migrations="$(node -p "require('./scripts/production-migrations.json').migrations.length")"
+          test "$(psql "$PGURL" -Atqc 'SELECT COUNT(*) FROM public.tdf_schema_migration')" = "$expected_migrations"
 
       - name: Verify raw migration idempotency and the release schema contract
         run: |
           psql "$PGURL" -v ON_ERROR_STOP=1 -f tdf-hq/sql/2026-07-12_ticketing_runtime_schema.sql
           psql "$PGURL" -v ON_ERROR_STOP=1 -f tdf-hq/sql/2026-07-12_ticket_checkout_idempotency.sql
           psql "$PGURL" -v ON_ERROR_STOP=1 -f tdf-hq/sql/2026-07-12_event_discovery_imports.sql
+          psql "$PGURL" -v ON_ERROR_STOP=1 -f tdf-hq/sql/2026-07-15_social_sync_runtime_schema.sql
+          psql "$PGURL" -v ON_ERROR_STOP=1 -f tdf-hq/sql/2026-07-15_social_discovery_reviews.sql
           node scripts/render-production-schema-verification.mjs | psql "$PGURL" -v ON_ERROR_STOP=1
           node scripts/render-production-schema-preflight.mjs | psql "$PGURL" -v ON_ERROR_STOP=1
 

--- a/scripts/__tests__/fixtures/production-ticketing-base.sql
+++ b/scripts/__tests__/fixtures/production-ticketing-base.sql
@@ -33,6 +33,10 @@ CREATE TABLE social_artist_profile (
     id BIGSERIAL PRIMARY KEY
 );
 
+CREATE TABLE artist_profile (
+    id BIGSERIAL PRIMARY KEY
+);
+
 CREATE TABLE event_ticket_tier (
     id BIGSERIAL PRIMARY KEY,
     event_id BIGINT NOT NULL REFERENCES social_event(id),

--- a/scripts/__tests__/production-release.test.mjs
+++ b/scripts/__tests__/production-release.test.mjs
@@ -202,7 +202,7 @@ test('buildMigrationBatchSql validates every path before rendering psql input', 
   );
 });
 
-test('buildSchemaVerificationSql fails closed over the ticketing and discovery schema contract', () => {
+test('buildSchemaVerificationSql fails closed over the ticketing, discovery, and social schema contract', () => {
   const sql = buildSchemaVerificationSql();
 
   assert.match(sql, /\\set\s+ON_ERROR_STOP\s+(?:on|1)/i);
@@ -216,18 +216,26 @@ test('buildSchemaVerificationSql fails closed over the ticketing and discovery s
     'external_event_ref',
     'external_event_discovery_run',
     'idx_external_event_ref_city',
+    'social_sync_account',
+    'social_sync_post',
+    'social_sync_run',
+    'social_discovery_review',
+    'unique_social_sync_account',
+    'unique_social_sync_post',
+    'unique_social_discovery_review',
   ]) {
     assert.match(sql, new RegExp(requiredObject), `verification must inspect ${requiredObject}`);
   }
   assert.match(sql, /RAISE\s+EXCEPTION|\\quit/i, 'schema drift must terminate verification');
 });
 
-test('buildSchemaPreflightSql is read-only and accepts an unapplied ticket idempotency column', () => {
+test('buildSchemaPreflightSql is read-only and accepts unapplied release tables', () => {
   const sql = buildSchemaPreflightSql();
 
   assert.match(sql, /BEGIN READ ONLY/i);
   assert.match(sql, /default_transaction_read_only/i);
   assert.match(sql, /information_schema\.columns[\s\S]*checkout_idempotency_key/i);
+  assert.match(sql, /social_sync_account[\s\S]*social_sync_post[\s\S]*social_sync_run/i);
   assert.match(sql, /ROLLBACK/i);
   assert.doesNotMatch(sql, /ALTER\s+TABLE|CREATE\s+TABLE|INSERT\s+INTO|UPDATE\s+|DELETE\s+FROM/i);
 });

--- a/scripts/lib/production-release.mjs
+++ b/scripts/lib/production-release.mjs
@@ -249,8 +249,9 @@ BEGIN
   IF to_regclass('public.event_ticket_order') IS NULL
      OR to_regclass('public.venue') IS NULL
      OR to_regclass('public.social_artist_profile') IS NULL
+     OR to_regclass('public.artist_profile') IS NULL
      OR to_regclass('public.social_event') IS NULL THEN
-    RAISE EXCEPTION 'Required ticketing/event base tables are missing';
+    RAISE EXCEPTION 'Required ticketing/event/social base tables are missing';
   END IF;
   IF to_regclass('public.notification') IS NULL OR (
     SELECT COUNT(*) FROM information_schema.columns
@@ -306,6 +307,15 @@ BEGIN
   ) NOT IN (0, 4) THEN
     RAISE EXCEPTION 'Event discovery tables are partially present';
   END IF;
+  IF (
+    SELECT COUNT(*) FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name IN (
+        'social_sync_account', 'social_sync_post', 'social_sync_run'
+      )
+  ) NOT IN (0, 3) THEN
+    RAISE EXCEPTION 'Social-sync runtime tables are partially present';
+  END IF;
 END
 $preflight$;
 ROLLBACK;
@@ -317,6 +327,7 @@ export function buildSchemaVerificationSql(options = {}) {
   return `${header}DO $verify$
 DECLARE
   discovery_table TEXT;
+  social_table TEXT;
   ticketing_table TEXT;
 BEGIN
   IF NOT EXISTS (
@@ -686,6 +697,103 @@ BEGIN
       AND indexdef ILIKE '%lower(city)%'
   ) THEN
     RAISE EXCEPTION 'idx_external_event_ref_city is missing or invalid';
+  END IF;
+
+  FOREACH social_table IN ARRAY ARRAY[
+    'social_sync_account',
+    'social_sync_post',
+    'social_sync_run',
+    'social_discovery_review'
+  ] LOOP
+    IF to_regclass('public.' || social_table) IS NULL THEN
+      RAISE EXCEPTION 'Social-sync relation public.% is missing', social_table;
+    END IF;
+  END LOOP;
+
+  IF (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'social_sync_account'
+  ) <> 12 OR (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'social_sync_post'
+  ) <> 20 OR (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'social_sync_run'
+  ) <> 9 OR (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'social_discovery_review'
+  ) <> 8 THEN
+    RAISE EXCEPTION 'A social-sync relation has an unexpected column count';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM (
+      VALUES
+        ('social_sync_account', 'party_id', 'bigint', 'YES'),
+        ('social_sync_account', 'artist_profile_id', 'bigint', 'YES'),
+        ('social_sync_account', 'platform', 'character varying', 'NO'),
+        ('social_sync_account', 'external_user_id', 'character varying', 'NO'),
+        ('social_sync_account', 'created_at', 'timestamp with time zone', 'NO'),
+        ('social_sync_post', 'account_id', 'bigint', 'YES'),
+        ('social_sync_post', 'platform', 'character varying', 'NO'),
+        ('social_sync_post', 'external_post_id', 'character varying', 'NO'),
+        ('social_sync_post', 'artist_party_id', 'bigint', 'YES'),
+        ('social_sync_post', 'artist_profile_id', 'bigint', 'YES'),
+        ('social_sync_post', 'fetched_at', 'timestamp with time zone', 'NO'),
+        ('social_sync_post', 'ingest_source', 'character varying', 'NO'),
+        ('social_sync_post', 'like_count', 'bigint', 'YES'),
+        ('social_sync_post', 'created_at', 'timestamp with time zone', 'NO'),
+        ('social_sync_post', 'updated_at', 'timestamp with time zone', 'NO'),
+        ('social_sync_run', 'platform', 'character varying', 'NO'),
+        ('social_sync_run', 'new_posts', 'bigint', 'NO'),
+        ('social_discovery_review', 'social_sync_post_id', 'bigint', 'NO'),
+        ('social_discovery_review', 'status', 'text', 'NO'),
+        ('social_discovery_review', 'reviewed_by_party_id', 'bigint', 'YES'),
+        ('social_discovery_review', 'created_at', 'timestamp with time zone', 'NO')
+    ) AS expected(table_name, column_name, data_type, is_nullable)
+    LEFT JOIN information_schema.columns AS actual
+      ON actual.table_schema = 'public'
+     AND actual.table_name = expected.table_name
+     AND actual.column_name = expected.column_name
+    WHERE actual.column_name IS NULL
+       OR actual.data_type <> expected.data_type
+       OR actual.is_nullable <> expected.is_nullable
+  ) THEN
+    RAISE EXCEPTION 'Social-sync columns do not match the runtime schema';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.social_sync_account'::regclass
+      AND conname = 'unique_social_sync_account'
+      AND contype = 'u'
+      AND convalidated
+  ) OR NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.social_sync_post'::regclass
+      AND conname = 'unique_social_sync_post'
+      AND contype = 'u'
+      AND convalidated
+  ) OR NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.social_discovery_review'::regclass
+      AND conname = 'unique_social_discovery_review'
+      AND contype = 'u'
+      AND convalidated
+  ) THEN
+    RAISE EXCEPTION 'A social-sync uniqueness constraint is missing or invalid';
+  END IF;
+
+  IF (
+    SELECT COUNT(*) FROM pg_constraint
+    WHERE conrelid IN (
+      'public.social_sync_account'::regclass,
+      'public.social_sync_post'::regclass,
+      'public.social_discovery_review'::regclass
+    ) AND contype = 'f' AND convalidated
+  ) <> 7 THEN
+    RAISE EXCEPTION 'A social-sync foreign key is missing or invalid';
   END IF;
 END
 $verify$;`;

--- a/scripts/production-migrations.json
+++ b/scripts/production-migrations.json
@@ -17,6 +17,11 @@
       "introducedBy": "4d1f1fe1a7736b967001fc02b2c21d59ced343ce"
     },
     {
+      "id": "2026-07-15_social_sync_runtime_schema",
+      "path": "tdf-hq/sql/2026-07-15_social_sync_runtime_schema.sql",
+      "introducedBy": "f4805f72b4749029741373798da659566b5c4ea5"
+    },
+    {
       "id": "2026-07-15_social_discovery_reviews",
       "path": "tdf-hq/sql/2026-07-15_social_discovery_reviews.sql",
       "introducedBy": "f4805f72b4749029741373798da659566b5c4ea5"

--- a/tdf-hq/sql/2026-07-15_social_sync_runtime_schema.sql
+++ b/tdf-hq/sql/2026-07-15_social_sync_runtime_schema.sql
@@ -1,0 +1,135 @@
+-- Install the social-sync tables used by the ingestion, discovery, and Meta
+-- account flows. These were previously created only by Persistent's optional
+-- startup migration, while production deliberately runs with migrations off.
+-- Apply before 2026-07-15_social_discovery_reviews.sql.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '10s';
+SET LOCAL statement_timeout = '5min';
+
+DO $preflight$
+BEGIN
+    IF to_regclass('public.party') IS NULL
+       OR to_regclass('public.artist_profile') IS NULL THEN
+        RAISE EXCEPTION 'Cannot install social-sync schema: party or artist_profile is missing';
+    END IF;
+
+    IF (
+        SELECT COUNT(*)
+        FROM pg_catalog.pg_class AS c
+        JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relkind IN ('r', 'p')
+          AND c.relname IN (
+              'social_sync_account',
+              'social_sync_post',
+              'social_sync_run'
+          )
+    ) NOT IN (0, 3) THEN
+        RAISE EXCEPTION 'Refusing social-sync migration: runtime tables are partially present';
+    END IF;
+END
+$preflight$;
+
+CREATE TABLE IF NOT EXISTS public.social_sync_account (
+    id BIGSERIAL PRIMARY KEY,
+    party_id BIGINT REFERENCES public.party(id),
+    artist_profile_id BIGINT REFERENCES public.artist_profile(id),
+    platform VARCHAR NOT NULL,
+    external_user_id VARCHAR NOT NULL,
+    handle VARCHAR,
+    access_token VARCHAR,
+    token_expires_at TIMESTAMPTZ,
+    status VARCHAR NOT NULL,
+    last_synced_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ,
+    CONSTRAINT unique_social_sync_account UNIQUE (platform, external_user_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.social_sync_post (
+    id BIGSERIAL PRIMARY KEY,
+    account_id BIGINT REFERENCES public.social_sync_account(id),
+    platform VARCHAR NOT NULL,
+    external_post_id VARCHAR NOT NULL,
+    artist_party_id BIGINT REFERENCES public.party(id),
+    artist_profile_id BIGINT REFERENCES public.artist_profile(id),
+    caption VARCHAR,
+    permalink VARCHAR,
+    media_urls VARCHAR,
+    posted_at TIMESTAMPTZ,
+    fetched_at TIMESTAMPTZ NOT NULL,
+    tags VARCHAR,
+    summary VARCHAR,
+    ingest_source VARCHAR NOT NULL,
+    like_count BIGINT,
+    comment_count BIGINT,
+    share_count BIGINT,
+    view_count BIGINT,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    CONSTRAINT unique_social_sync_post UNIQUE (platform, external_post_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.social_sync_run (
+    id BIGSERIAL PRIMARY KEY,
+    platform VARCHAR NOT NULL,
+    ingest_source VARCHAR NOT NULL,
+    started_at TIMESTAMPTZ NOT NULL,
+    ended_at TIMESTAMPTZ,
+    status VARCHAR NOT NULL,
+    new_posts BIGINT NOT NULL,
+    updated_posts BIGINT NOT NULL,
+    error_message VARCHAR
+);
+
+CREATE INDEX IF NOT EXISTS idx_social_sync_account_party
+    ON public.social_sync_account (party_id) WHERE party_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_social_sync_account_artist_profile
+    ON public.social_sync_account (artist_profile_id) WHERE artist_profile_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_social_sync_post_account
+    ON public.social_sync_post (account_id) WHERE account_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_social_sync_post_artist_party
+    ON public.social_sync_post (artist_party_id) WHERE artist_party_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_social_sync_post_artist_profile
+    ON public.social_sync_post (artist_profile_id) WHERE artist_profile_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_social_sync_post_platform_posted
+    ON public.social_sync_post (platform, posted_at DESC, fetched_at DESC);
+CREATE INDEX IF NOT EXISTS idx_social_sync_run_platform_started
+    ON public.social_sync_run (platform, started_at DESC);
+
+DO $verification$
+BEGIN
+    IF (
+        SELECT COUNT(*)
+        FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_name IN (
+              'social_sync_account',
+              'social_sync_post',
+              'social_sync_run'
+          )
+    ) <> 3 THEN
+        RAISE EXCEPTION 'Social-sync runtime tables are incomplete';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_constraint
+        WHERE conrelid = 'public.social_sync_account'::regclass
+          AND conname = 'unique_social_sync_account'
+          AND contype = 'u'
+          AND convalidated
+    ) OR NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_constraint
+        WHERE conrelid = 'public.social_sync_post'::regclass
+          AND conname = 'unique_social_sync_post'
+          AND contype = 'u'
+          AND convalidated
+    ) THEN
+        RAISE EXCEPTION 'A social-sync uniqueness constraint is missing or invalid';
+    END IF;
+END
+$verification$;
+
+COMMIT;


### PR DESCRIPTION
## What changed

- add the missing production migration for `social_sync_account`, `social_sync_post`, and `social_sync_run`
- register it ahead of `2026-07-15_social_discovery_reviews` without changing the existing migration checksum
- extend production schema preflight and verification to cover the social-sync runtime and review tables
- derive the CI migration ledger count from the manifest and exercise both social migrations for raw idempotency

## Root cause

The review migration referenced `public.social_sync_post`, but the authoritative production migration manifest never created the `social_sync_*` runtime tables. Runtime Persistent migrations had masked the missing production prerequisite in some environments. The CI ledger assertion was also hard-coded to three migrations even though the manifest had grown.

## Impact

Fresh production migration batches can now install the social discovery schema with `RUN_MIGRATIONS=false`, and CI will catch future dependency, drift, idempotency, and manifest-count regressions.

## Validation

- `npm run test:production-release` — 21 tests passed
- PostgreSQL 17 baseline preflight passed
- authoritative migration batch applied successfully twice
- all raw production migrations reapplied successfully
- expanded schema verification and post-migration preflight passed
- deliberate checksum corruption was rejected with exit code 3