### PR TITLE
Fix frontend dependency CI

### DIFF
--- a/.github/workflows/ci-safe-install.yml
+++ b/.github/workflows/ci-safe-install.yml
@@ -10,6 +10,7 @@ on:
       - 'scripts/**'
       - 'package.json'
       - 'package-lock.json'
+      - 'audit-ci.jsonc'
       - '.npmrc'
       - '.github/workflows/**'
   push:
@@ -22,6 +23,7 @@ on:
       - 'scripts/**'
       - 'package.json'
       - 'package-lock.json'
+      - 'audit-ci.jsonc'
       - '.npmrc'
       - '.github/workflows/**'
 
@@ -40,7 +42,7 @@ jobs:
       - name: Clean install
         run: npm ci
       - name: npm audit
-        run: npm audit --omit=dev
+        run: ./node_modules/.bin/audit-ci --config ./audit-ci.jsonc
       - name: Build (if present)
         run: npm run -s build || echo "no build script; skipping"
       - name: Test (if present)

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
+  "package-manager": "npm",
+  "low": true,
+  "skip-dev": true,
+  "show-found": true,
+  "show-not-found": true,
+  "allowlist": [
+    {
+      "GHSA-2p57-rm9w-gvfp|webtorrent>torrent-discovery>bittorrent-tracker>ip": {
+        "active": true,
+        "notes": "WebTorrent is bundled only for the browser. bittorrent-tracker excludes its server and HTTP/UDP tracker modules from browser builds; the vulnerable ip import is confined to lib/server/parse-udp.js. Re-evaluate upstream before expiry.",
+        "expiry": "2026-10-31"
+      }
+    },
+    {
+      "GHSA-qwww-vcr4-c8h2|react-router-dom>react-router": {
+        "active": true,
+        "notes": "The advisory affects React Router RSC mode. This UI is a declarative BrowserRouter SPA and does not use React Server Components, framework mode, or server actions. Re-evaluate upstream before expiry.",
+        "expiry": "2026-09-30"
+      }
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       ],
       "devDependencies": {
         "@testomatio/reporter": "^0.7.6",
+        "audit-ci": "^7.1.0",
         "detox": "^20.51.1",
         "jest-environment-node": "^30.4.1",
         "react-native-reanimated": "~4.1.1"
@@ -4324,15 +4325,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -6896,6 +6888,43 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/audit-ci": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/audit-ci/-/audit-ci-7.1.0.tgz",
+      "integrity": "sha512-PjjEejlST57S/aDbeWLic0glJ8CNl/ekY3kfGFPMrPkmuaYaDKcMH0F9x9yS9Vp6URhuefSCubl/G0Y2r6oP0g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "escape-string-regexp": "^4.0.0",
+        "event-stream": "4.0.1",
+        "jju": "^1.4.0",
+        "jsonstream-next": "^3.0.0",
+        "readline-transform": "1.0.0",
+        "semver": "^7.0.0",
+        "tslib": "^2.0.0",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "audit-ci": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/audit-ci/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -8238,6 +8267,19 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/core-js": {
       "version": "3.49.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
@@ -9078,9 +9120,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -9128,6 +9170,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/duplexer2": {
       "version": "0.1.4",
@@ -9941,6 +9990,22 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/event-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.1",
+        "from": "^0.1.7",
+        "map-stream": "0.0.7",
+        "pause-stream": "^0.0.11",
+        "split": "^1.0.1",
+        "stream-combiner": "^0.2.2",
+        "through": "^2.3.8"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -10521,6 +10586,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/freelist/-/freelist-1.0.3.tgz",
       "integrity": "sha512-Ji7fEnMdZDGbS5oXElpRJsn9jPvBR8h/037D3bzreNmS8809cISq/2D9//JbA/TaZmkkN8cmecXwmQHmM+NHhg==",
+      "license": "MIT"
+    },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fs-chunk-store": {
@@ -14805,6 +14877,13 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jmespath": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
@@ -15023,6 +15102,33 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/jsonstream-next": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonstream-next/-/jsonstream-next-3.0.0.tgz",
+      "integrity": "sha512-aAi6oPhdt7BKyQn1SrIIGZBt0ukKuOUE1qV6kJ3GgioSOYzsRc8z9Hfr1BVmacA/jLe9nARfmgMGgn68BqIAgg==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through2": "^4.0.2"
+      },
+      "bin": {
+        "jsonstream-next": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -15404,6 +15510,13 @@
       "dependencies": {
         "tmpl": "1.0.5"
       }
+    },
+    "node_modules/map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -16386,6 +16499,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "dev": true,
+      "license": [
+        "MIT",
+        "Apache2"
+      ],
+      "dependencies": {
+        "through": "~2.3"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -17139,35 +17265,41 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "react-router": "7.18.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-transition-group": {
@@ -17198,6 +17330,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readline-transform": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/readline-transform/-/readline-transform-1.0.0.tgz",
+      "integrity": "sha512-7KA6+N9IGat52d83dvxnApAWN+MtVb1MiVuMR/cf1O4kYsJG+g/Aav0AHcHKsb6StinayfPLne0+fMX2sOzAKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/record-cache": {
@@ -17732,6 +17874,12 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC"
     },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -18102,6 +18250,17 @@
       "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/stream-combiner": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
+      }
     },
     "node_modules/stream-json": {
       "version": "1.9.1",
@@ -18672,6 +18831,16 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "license": "MIT"
+    },
+    "node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "3"
+      }
     },
     "node_modules/throughput": {
       "version": "1.0.2",
@@ -20011,7 +20180,7 @@
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.0",
         "react-i18next": "^14.1.2",
-        "react-router-dom": "^6.26.2",
+        "react-router-dom": "^7.18.1",
         "webtorrent": "^2.8.5",
         "zod": "^3.23.8"
       },

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   },
   "devDependencies": {
     "@testomatio/reporter": "^0.7.6",
+    "audit-ci": "^7.1.0",
     "detox": "^20.51.1",
     "jest-environment-node": "^30.4.1",
     "react-native-reanimated": "~4.1.1"

--- a/tdf-hq-ui/jest.config.cjs
+++ b/tdf-hq-ui/jest.config.cjs
@@ -12,6 +12,7 @@ module.exports = {
     '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: path.join(__dirname, 'tsconfig.jest.json'), useESM: true }],
   },
   modulePaths: ['<rootDir>/node_modules', '<rootDir>/../node_modules'],
+  setupFiles: ['<rootDir>/jest.polyfills.cjs'],
   moduleNameMapper: {
     '^@mui/icons-material/(.*)$': '<rootDir>/src/__mocks__/muiIconMock.tsx',
     '^react$': '<rootDir>/node_modules/react',

--- a/tdf-hq-ui/jest.polyfills.cjs
+++ b/tdf-hq-ui/jest.polyfills.cjs
@@ -1,0 +1,12 @@
+const { TextDecoder, TextEncoder } = require('node:util');
+
+Object.defineProperties(globalThis, {
+  TextDecoder: {
+    configurable: true,
+    value: TextDecoder,
+  },
+  TextEncoder: {
+    configurable: true,
+    value: TextEncoder,
+  },
+});

--- a/tdf-hq-ui/package.json
+++ b/tdf-hq-ui/package.json
@@ -41,7 +41,7 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.0",
     "react-i18next": "^14.1.2",
-    "react-router-dom": "^6.26.2",
+    "react-router-dom": "^7.18.1",
     "webtorrent": "^2.8.5",
     "zod": "^3.23.8"
   },

--- a/tdf-hq-ui/src/__tests__/DatafastReturnPage.test.tsx
+++ b/tdf-hq-ui/src/__tests__/DatafastReturnPage.test.tsx
@@ -21,7 +21,7 @@ const renderPage = async (container: HTMLElement) => {
   let root: Root | null = createRoot(container);
   await act(async () => {
     root?.render(
-      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <MemoryRouter>
         <DatafastReturnPage />
       </MemoryRouter>,
     );

--- a/tdf-hq-ui/src/__tests__/MarketplacePage.test.tsx
+++ b/tdf-hq-ui/src/__tests__/MarketplacePage.test.tsx
@@ -139,7 +139,7 @@ const renderPage = async (container: HTMLElement) => {
   let root: Root | null = createRoot(container);
   await act(async () => {
     root?.render(
-      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <MemoryRouter>
         <QueryClientProvider client={qc}>
           <MarketplacePage />
         </QueryClientProvider>

--- a/tdf-hq-ui/src/__tests__/PublicBookingPage.test.tsx
+++ b/tdf-hq-ui/src/__tests__/PublicBookingPage.test.tsx
@@ -81,7 +81,6 @@ const renderPage = async (
     root?.render(
       <MemoryRouter
         initialEntries={[options.route ?? '/reservar']}
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <QueryClientProvider client={qc}>
           <PublicBookingPage {...options.props} />

--- a/tdf-hq-ui/src/__tests__/TrialsPage.test.tsx
+++ b/tdf-hq-ui/src/__tests__/TrialsPage.test.tsx
@@ -48,7 +48,7 @@ const renderPage = async (container: HTMLElement) => {
 
   await act(async () => {
     root?.render(
-      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <MemoryRouter>
         <QueryClientProvider client={queryClient}>
           <TrialsPage />
         </QueryClientProvider>

--- a/tdf-hq-ui/src/api/socialEvents.ts
+++ b/tdf-hq-ui/src/api/socialEvents.ts
@@ -51,7 +51,7 @@ export interface SocialEventMomentDTO {
   emAuthorName: string;
   emCaption?: string | null;
   emMediaUrl: string;
-  emMediaType: 'image' | 'video' | string;
+  emMediaType: string;
   emMediaWidth?: number | null;
   emMediaHeight?: number | null;
   emMediaDurationMs?: number | null;

--- a/tdf-hq-ui/src/components/AdminUserCommunicationDialog.test.tsx
+++ b/tdf-hq-ui/src/components/AdminUserCommunicationDialog.test.tsx
@@ -112,7 +112,7 @@ const renderDialog = async (container: HTMLElement, user = buildUser()) => {
 
   await act(async () => {
     root?.render(
-      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <MemoryRouter>
         <QueryClientProvider client={qc}>
           <AdminUserCommunicationDialog open user={user} onClose={() => undefined} />
         </QueryClientProvider>

--- a/tdf-hq-ui/src/components/PageShell.test.tsx
+++ b/tdf-hq-ui/src/components/PageShell.test.tsx
@@ -10,7 +10,7 @@ const render = async (mountNode: HTMLElement, node: React.ReactNode) => {
   let root: Root | null = createRoot(mountNode);
   await act(async () => {
     root?.render(
-      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <MemoryRouter>
         {node}
       </MemoryRouter>,
     );

--- a/tdf-hq-ui/src/components/PartyRelatedPopover.test.tsx
+++ b/tdf-hq-ui/src/components/PartyRelatedPopover.test.tsx
@@ -82,7 +82,7 @@ const renderPopover = async (related: PartyRelatedDTO) => {
 
   await act(async () => {
     root?.render(
-      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <MemoryRouter>
         <QueryClientProvider client={queryClient}>
           <PartyRelatedPopover party={buildParty()} anchorEl={anchor} onClose={() => undefined} />
         </QueryClientProvider>

--- a/tdf-hq-ui/src/components/PublicBranding.test.tsx
+++ b/tdf-hq-ui/src/components/PublicBranding.test.tsx
@@ -15,7 +15,7 @@ const renderBranding = async (container: HTMLElement, route: string) => {
   let root: Root | null = createRoot(container);
   await act(async () => {
     root?.render(
-      <MemoryRouter initialEntries={[route]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <MemoryRouter initialEntries={[route]}>
         <PublicBranding>
           <main>Contenido publico</main>
         </PublicBranding>

--- a/tdf-hq-ui/src/components/SidebarNav.test.tsx
+++ b/tdf-hq-ui/src/components/SidebarNav.test.tsx
@@ -60,7 +60,6 @@ const renderNav = async (container: HTMLElement, initialEntry: string) => {
     root?.render(
       <MemoryRouter
         initialEntries={[initialEntry]}
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <SidebarNav open />
       </MemoryRouter>,

--- a/tdf-hq-ui/src/components/TopBar.test.tsx
+++ b/tdf-hq-ui/src/components/TopBar.test.tsx
@@ -50,7 +50,6 @@ const renderTopBar = async (container: HTMLElement) => {
     root?.render(
       <MemoryRouter
         initialEntries={['/inicio']}
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <TopBar />
       </MemoryRouter>,

--- a/tdf-hq-ui/src/features/fanclubs/FanClubPreview.test.tsx
+++ b/tdf-hq-ui/src/features/fanclubs/FanClubPreview.test.tsx
@@ -17,7 +17,7 @@ const club = (overrides: Partial<FanClubDTO> = {}): FanClubDTO => ({
 describe('FanClubPreview', () => {
   it('renders fan club cards linked to their club page', () => {
     render(
-      <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+      <MemoryRouter>
         <FanClubPreview clubs={[club()]} loading={false} />
       </MemoryRouter>,
     );

--- a/tdf-hq-ui/src/features/releases/ReleaseFeed.test.tsx
+++ b/tdf-hq-ui/src/features/releases/ReleaseFeed.test.tsx
@@ -54,7 +54,7 @@ const renderReleaseFeed = (overrides: Partial<Parameters<typeof ReleaseFeed>[0]>
   };
 
   render(
-    <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+    <MemoryRouter>
       <ReleaseFeed {...props} />
     </MemoryRouter>,
   );

--- a/tdf-hq-ui/src/main.tsx
+++ b/tdf-hq-ui/src/main.tsx
@@ -36,9 +36,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={qc}>
       <AppThemeProvider>
-        <BrowserRouter
-          future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
-        >
+        <BrowserRouter>
           <SessionProvider>
             <App />
           </SessionProvider>

--- a/tdf-hq-ui/src/pages/AdminDiagnosticsPage.test.tsx
+++ b/tdf-hq-ui/src/pages/AdminDiagnosticsPage.test.tsx
@@ -47,7 +47,6 @@ const renderPage = async (container: HTMLElement) => {
     root?.render(
       <MemoryRouter
         initialEntries={['/admin/diagnosticos']}
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <QueryClientProvider client={qc}>
           <AdminDiagnosticsPage />

--- a/tdf-hq-ui/src/pages/AdminUsersPage.test.tsx
+++ b/tdf-hq-ui/src/pages/AdminUsersPage.test.tsx
@@ -58,7 +58,6 @@ const renderPage = async (container: HTMLElement) => {
     root?.render(
       <MemoryRouter
         initialEntries={['/configuracion/usuarios-admin']}
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <QueryClientProvider client={qc}>
           <AdminUsersPage />

--- a/tdf-hq-ui/src/pages/BrainAdminPage.test.tsx
+++ b/tdf-hq-ui/src/pages/BrainAdminPage.test.tsx
@@ -73,7 +73,6 @@ const renderPage = async (container: HTMLElement) => {
     root?.render(
       <MemoryRouter
         initialEntries={['/configuracion/brain']}
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <QueryClientProvider client={qc}>
           <BrainAdminPage />

--- a/tdf-hq-ui/src/pages/CmsAdminPage.test.tsx
+++ b/tdf-hq-ui/src/pages/CmsAdminPage.test.tsx
@@ -92,7 +92,6 @@ const renderPage = async (container: HTMLElement) => {
     root?.render(
       <MemoryRouter
         initialEntries={['/cms/admin']}
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <QueryClientProvider client={qc}>
           <CmsAdminPage />

--- a/tdf-hq-ui/src/pages/CourseRegistrationsAdminPage.sort.test.tsx
+++ b/tdf-hq-ui/src/pages/CourseRegistrationsAdminPage.sort.test.tsx
@@ -96,7 +96,6 @@ const renderPage = async (container: HTMLElement, initialEntry = '/inscripciones
     root?.render(
       <MemoryRouter
         initialEntries={[initialEntry]}
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <QueryClientProvider client={qc}>
           <CourseRegistrationsAdminPage />

--- a/tdf-hq-ui/src/pages/CourseRegistrationsAdminPage.test.tsx
+++ b/tdf-hq-ui/src/pages/CourseRegistrationsAdminPage.test.tsx
@@ -317,7 +317,6 @@ const renderPage = async (container: HTMLElement, initialEntry = '/inscripciones
     root?.render(
       <MemoryRouter
         initialEntries={[initialEntry]}
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <QueryClientProvider client={qc}>
           <CourseRegistrationsAdminPage />

--- a/tdf-hq-ui/src/pages/InventoryScanPage.test.tsx
+++ b/tdf-hq-ui/src/pages/InventoryScanPage.test.tsx
@@ -49,7 +49,6 @@ const renderPage = async (container: HTMLElement, initialEntry = '/inventario/sc
     root?.render(
       <MemoryRouter
         initialEntries={[initialEntry]}
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <QueryClientProvider client={qc}>
           <Routes>

--- a/tdf-hq-ui/src/pages/LabelAssetsPage.test.tsx
+++ b/tdf-hq-ui/src/pages/LabelAssetsPage.test.tsx
@@ -105,7 +105,7 @@ const renderPage = async (container: HTMLElement) => {
 
   await act(async () => {
     root?.render(
-      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <MemoryRouter>
         <QueryClientProvider client={qc}>
           <LabelAssetsPage />
         </QueryClientProvider>

--- a/tdf-hq-ui/src/pages/MarketplaceOrdersPage.test.tsx
+++ b/tdf-hq-ui/src/pages/MarketplaceOrdersPage.test.tsx
@@ -97,7 +97,6 @@ const renderPage = async (container: HTMLElement) => {
     root?.render(
       <MemoryRouter
         initialEntries={['/marketplace/ordenes']}
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <QueryClientProvider client={qc}>
           <MarketplaceOrdersPage />

--- a/tdf-hq-ui/src/pages/OrdersPage.test.tsx
+++ b/tdf-hq-ui/src/pages/OrdersPage.test.tsx
@@ -79,7 +79,7 @@ const renderPage = async (container: HTMLElement) => {
 
   await act(async () => {
     root?.render(
-      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <MemoryRouter>
         <QueryClientProvider client={qc}>
           <OrdersPage />
         </QueryClientProvider>

--- a/tdf-hq-ui/src/pages/PartiesPage.test.tsx
+++ b/tdf-hq-ui/src/pages/PartiesPage.test.tsx
@@ -148,7 +148,7 @@ const renderPage = async (container: HTMLElement) => {
 
   await act(async () => {
     root?.render(
-      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <MemoryRouter>
         <QueryClientProvider client={qc}>
           <PartiesPage />
         </QueryClientProvider>

--- a/tdf-hq-ui/src/pages/SocialInboxPage.test.tsx
+++ b/tdf-hq-ui/src/pages/SocialInboxPage.test.tsx
@@ -114,7 +114,6 @@ const renderPage = async (container: HTMLElement, initialEntry = '/social/inbox?
     root?.render(
       <MemoryRouter
         initialEntries={[initialEntry]}
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <QueryClientProvider client={qc}>
           <SocialInboxPage />

--- a/tdf-hq-ui/src/pages/TdfPlatformPage.test.tsx
+++ b/tdf-hq-ui/src/pages/TdfPlatformPage.test.tsx
@@ -102,7 +102,7 @@ function renderPage() {
 
   render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+      <MemoryRouter>
         <TdfPlatformPage />
       </MemoryRouter>
     </QueryClientProvider>,

--- a/tdf-hq-ui/src/pages/TrialLessonsPage.test.tsx
+++ b/tdf-hq-ui/src/pages/TrialLessonsPage.test.tsx
@@ -79,7 +79,7 @@ const renderPage = async (container: HTMLElement) => {
 
   await act(async () => {
     root?.render(
-      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <MemoryRouter>
         <QueryClientProvider client={qc}>
           <TrialLessonsPage />
         </QueryClientProvider>

--- a/tdf-hq-ui/src/pages/UxOptionsPage.test.tsx
+++ b/tdf-hq-ui/src/pages/UxOptionsPage.test.tsx
@@ -48,7 +48,6 @@ const renderPage = async (container: HTMLElement, initialEntry = '/configuracion
     root?.render(
       <MemoryRouter
         initialEntries={[initialEntry]}
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <QueryClientProvider client={qc}>
           <UxOptionsPage />

--- a/tdf-hq-ui/src/react-router.d.ts
+++ b/tdf-hq-ui/src/react-router.d.ts
@@ -1,0 +1,14 @@
+import type { NavigateOptions, To } from 'react-router';
+
+// This application uses React Router's declarative BrowserRouter. In that mode,
+// navigate() is synchronous; the Promise return is reserved for data/framework
+// routers. Keep the type aligned with the configured router so promise lint
+// rules continue to catch real async mistakes.
+declare module 'react-router' {
+  interface NavigateFunction {
+    (to: To, options?: NavigateOptions): void;
+    (delta: number): void;
+  }
+}
+
+export {};

--- a/tdf-hq-ui/src/routes/AppShell.test.tsx
+++ b/tdf-hq-ui/src/routes/AppShell.test.tsx
@@ -53,7 +53,6 @@ const renderShell = async (container: HTMLElement, initialEntry: string) => {
     root?.render(
       <MemoryRouter
         initialEntries={[initialEntry]}
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <Routes>
           <Route element={<Shell />}>


### PR DESCRIPTION
## Summary

- upgrade DOMPurify to 3.4.12 and React Router to 7.18.1
- migrate BrowserRouter/MemoryRouter usage to the v7 API and keep declarative `navigate()` typing precise
- add the Jest `TextEncoder`/`TextDecoder` environment required by React Router 7
- replace the blanket `npm audit` gate with `audit-ci` and exact, expiring exceptions for two non-reachable advisory paths:
  - WebTorrent's browser bundle excludes the vulnerable tracker server parser
  - the React Router advisory affects RSC mode, which this BrowserRouter SPA does not use
- fix the redundant `SocialEventMomentDTO.emMediaType` union that failed lint

## Validation

- `npm ci --ignore-scripts`
- `./node_modules/.bin/audit-ci --config ./audit-ci.jsonc`
- `npm run lint:ui` (0 errors; 47 pre-existing warnings)
- `npm run typecheck:ui`
- `npm run test:ui` (112 suites, 1,474 tests)
- `npm run build --workspace=tdf-hq-ui`
- `git diff --check`