### PR TITLE
Fix public feedback submissions

### DIFF
--- a/tdf-hq-ui/src/api/feedback.test.ts
+++ b/tdf-hq-ui/src/api/feedback.test.ts
@@ -1,0 +1,74 @@
+import { jest } from '@jest/globals';
+
+const buildAuthorizationHeaderMock = jest.fn<() => string | undefined>(() => undefined);
+
+jest.unstable_mockModule('./authHeader', () => ({
+  buildAuthorizationHeader: buildAuthorizationHeaderMock,
+}));
+
+jest.unstable_mockModule('../config/apiBase', () => ({
+  resolveApiBase: () => '',
+}));
+
+const { submitFeedback } = await import('./feedback');
+
+const successfulResponse = {
+  ok: true,
+  status: 200,
+} as Response;
+
+describe('feedback api', () => {
+  const fetchMock = jest.fn<typeof fetch>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    buildAuthorizationHeaderMock.mockReset();
+    buildAuthorizationHeaderMock.mockReturnValue(undefined);
+    (globalThis as unknown as { fetch: typeof fetch }).fetch = fetchMock;
+  });
+
+  it('allows anonymous submissions while including the session cookie when available', async () => {
+    fetchMock.mockResolvedValueOnce(successfulResponse);
+
+    await submitFeedback({
+      title: 'No puedo enviar feedback',
+      description: 'El formulario devuelve un error de autenticación.',
+      category: 'bug',
+      severity: 'P2',
+      consent: true,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, request] = fetchMock.mock.calls[0] ?? [];
+    expect(url).toBe('/feedback');
+    expect(request).toMatchObject({
+      method: 'POST',
+      credentials: 'include',
+      headers: undefined,
+    });
+
+    const form = request?.body as FormData;
+    expect(form.get('title')).toBe('No puedo enviar feedback');
+    expect(form.get('description')).toBe('El formulario devuelve un error de autenticación.');
+    expect(form.get('consent')).toBe('true');
+  });
+
+  it('forwards bearer credentials so authenticated feedback can retain its author', async () => {
+    buildAuthorizationHeaderMock.mockReturnValue('Bearer session-token');
+    fetchMock.mockResolvedValueOnce(successfulResponse);
+
+    await submitFeedback({
+      title: 'Idea',
+      description: 'Agregar filtros.',
+      consent: true,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/feedback',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer session-token' },
+        credentials: 'include',
+      }),
+    );
+  });
+});

--- a/tdf-hq-ui/src/api/feedback.ts
+++ b/tdf-hq-ui/src/api/feedback.ts
@@ -1,4 +1,5 @@
 import { buildAuthorizationHeader } from './authHeader';
+import { resolveApiBase } from '../config/apiBase';
 
 export interface FeedbackPayload {
   title: string;
@@ -11,7 +12,7 @@ export interface FeedbackPayload {
 }
 
 export async function submitFeedback(payload: FeedbackPayload): Promise<void> {
-  const base = import.meta.env.VITE_API_BASE ?? '';
+  const base = resolveApiBase();
   const authHeader = buildAuthorizationHeader();
 
   const form = new FormData();
@@ -29,6 +30,7 @@ export async function submitFeedback(payload: FeedbackPayload): Promise<void> {
     method: 'POST',
     body: form,
     headers: authHeader ? { Authorization: authHeader } : undefined,
+    credentials: 'include',
   });
 
   if (!res.ok) {

--- a/tdf-hq-ui/src/pages/FeedbackPage.test.ts
+++ b/tdf-hq-ui/src/pages/FeedbackPage.test.ts
@@ -1,0 +1,12 @@
+import { contactEmailFromSessionUsername } from './FeedbackPage';
+
+describe('FeedbackPage contact email', () => {
+  it('prefills email-shaped account usernames', () => {
+    expect(contactEmailFromSessionUsername('diego@example.com')).toBe('diego@example.com');
+  });
+
+  it('does not submit account handles as contact email addresses', () => {
+    expect(contactEmailFromSessionUsername('admin')).toBe('');
+    expect(contactEmailFromSessionUsername()).toBe('');
+  });
+});

--- a/tdf-hq-ui/src/pages/FeedbackPage.tsx
+++ b/tdf-hq-ui/src/pages/FeedbackPage.tsx
@@ -32,13 +32,16 @@ const severities = [
   { value: 'P4', label: 'P4 - Bajo' },
 ];
 
+export const contactEmailFromSessionUsername = (username?: string): string =>
+  username?.includes('@') ? username : '';
+
 export default function FeedbackPage() {
   const { session } = useSession();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [category, setCategory] = useState('bug');
   const [severity, setSeverity] = useState('P2');
-  const [contactEmail, setContactEmail] = useState(session?.username ?? '');
+  const [contactEmail, setContactEmail] = useState(contactEmailFromSessionUsername(session?.username));
   const [consent, setConsent] = useState(false);
   const [attachment, setAttachment] = useState<File | null>(null);
 

--- a/tdf-hq/src/TDF/API.hs
+++ b/tdf-hq/src/TDF/API.hs
@@ -491,7 +491,6 @@ type ProtectedAPI =
   :<|> PipelinesAPI
   :<|> RoomsAPI
   :<|> LiveSessionsAPI
-  :<|> FeedbackAPI
   :<|> "marketplace" :> MarketplaceAdminAPI
   :<|> "payments" :> PaymentsAPI
   :<|> InstagramAPI
@@ -545,6 +544,7 @@ type API =
   :<|> CmsPublicAPI
   :<|> WhatsAppConsentPublicAPI
   :<|> InventoryPublicAPI
+  :<|> FeedbackAPI
   -- Keep the authenticated marketplace branch ahead of the public one so
   -- /marketplace/orders is not consumed by the public /marketplace/:id capture.
   :<|> AuthProtect "bearer-token" :> ProtectedAPI

--- a/tdf-hq/src/TDF/API/Feedback.hs
+++ b/tdf-hq/src/TDF/API/Feedback.hs
@@ -24,8 +24,10 @@ import           Servant.Multipart        ( FileData
                                           )
 
 type FeedbackAPI =
-  "feedback" :>
-    ( MultipartForm Tmp FeedbackPayload :> Post '[JSON] NoContent )
+  Header "Authorization" Text :>
+    Header "Cookie" Text :>
+      "feedback" :>
+        ( MultipartForm Tmp FeedbackPayload :> Post '[JSON] NoContent )
 
 data FeedbackPayload = FeedbackPayload
   { fpTitle        :: Text

--- a/tdf-hq/src/TDF/Server.hs
+++ b/tdf-hq/src/TDF/Server.hs
@@ -691,6 +691,7 @@ server env =
   :<|> cmsPublicServer
   :<|> whatsappConsentPublicServer
   :<|> inventoryPublicServer
+  :<|> feedbackServer
   :<|> protectedServer
   :<|> marketplacePublicServer
   :<|> radioPresencePublicServer
@@ -3692,7 +3693,6 @@ protectedServer user =
   :<|> pipelinesServer user
   :<|> roomsServer user
   :<|> liveSessionsServer user
-  :<|> feedbackServer user
   :<|> marketplaceAdminServer user
   :<|> paymentsServer user
   :<|> instagramServer user

--- a/tdf-hq/src/TDF/ServerFeedback.hs
+++ b/tdf-hq/src/TDF/ServerFeedback.hs
@@ -49,7 +49,10 @@ import           Data.UUID.V4               (nextRandom)
 import           Data.UUID                  (toText)
 
 import           TDF.API.Feedback
-import           TDF.Auth                   (AuthedUser(..))
+import           TDF.Auth                   ( AuthedUser(..)
+                                            , extractTokenFromHeaders
+                                            , loadAuthedUser
+                                            )
 import           TDF.DB                     (Env(..))
 import           TDF.ModelsExtra            (Feedback(..))
 import qualified TDF.Email.Service          as EmailSvc
@@ -60,9 +63,8 @@ feedbackServer
      , MonadIO m
      , MonadError ServerError m
      )
-  => AuthedUser
-  -> ServerT FeedbackAPI m
-feedbackServer user = submitFeedback
+  => ServerT FeedbackAPI m
+feedbackServer authorizationHeader cookieHeader = submitFeedback
   where
     submitFeedback :: FeedbackPayload -> m NoContent
     submitFeedback FeedbackPayload{..} = do
@@ -78,6 +80,11 @@ feedbackServer user = submitFeedback
 
       Env{..} <- ask
       let emailSvc = EmailSvc.mkEmailService envConfig
+      creator <- case extractTokenFromHeaders envConfig authorizationHeader cookieHeader of
+        Left _ ->
+          pure Nothing
+        Right token ->
+          liftIO $ runSqlPool (loadAuthedUser token) envPool
 
       _ <- liftIO $ runSqlPool
         (insert Feedback
@@ -88,7 +95,7 @@ feedbackServer user = submitFeedback
           , feedbackContactEmail = contactEmail
           , feedbackAttachment   = fmap T.pack attachmentPath
           , feedbackConsent      = fpConsent
-          , feedbackCreatedBy    = Just (auPartyId user)
+          , feedbackCreatedBy    = auPartyId <$> creator
           , feedbackCreatedAt    = now
           })
         envPool


### PR DESCRIPTION
## What changed

- Move `POST /feedback` out of the authenticated API branch so public visitors can submit feedback.
- Treat bearer/cookie credentials as optional and retain creator attribution only when they resolve to a valid session.
- Include browser session cookies and use the deployed API-base resolver.
- Avoid prefilling non-email account handles such as `admin` into the contact-email field.
- Add focused frontend regression tests for anonymous submission, authenticated attribution, and contact-email prefilling.

## Why

The public feedback page returned `Missing or invalid auth token` because its backend route was composed under `AuthProtect`. A previous fix was committed on an automation branch and then automatically reverted before it reached `main`.

## Impact

Anonymous visitors can submit suggestions and bug reports again. Signed-in users remain optionally attributable, while stale or missing credentials no longer block submission.

## Validation

- `npm test -- --runTestsByPath src/api/feedback.test.ts src/pages/FeedbackPage.test.ts` — 4 tests passed
- `stack test --test-arguments='--match feedback'` — 23 examples passed; executable and test-suite composition compiled
- `npm run build` — TypeScript check and production Vite build passed
- `git diff --check`