### PR TITLE
feat(growth): add community attribution foundations

### DIFF
--- a/docs/TDF_COMMUNITY_GROWTH_STRATEGY_2026.md
+++ b/docs/TDF_COMMUNITY_GROWTH_STRATEGY_2026.md
@@ -1,0 +1,428 @@
+# Estrategia tecnológica y de crecimiento de la comunidad TDF
+
+**Fecha:** 7 de agosto de 2026
+
+**Horizonte operativo:** 90 días
+
+**Mercado inicial:** Quito como núcleo de densidad; Ecuador como alcance digital
+
+**Marca principal:** TDF Records
+
+**Concepto de campaña:** **Tu escena, conectada.**
+
+**Llamado principal:** **Crea tu perfil. Sigue a tu artista. Activa tu escena.**
+
+## 1. Decisión estratégica
+
+TDF no debe salir a comprar “la mayor cantidad posible” de registros todavía. Debe salir cuando pueda medir y producir una relación real entre dos lados de la red: artista y fan.
+
+La unidad de valor no será el usuario registrado, sino la **relación activada**. Un usuario queda activado cuando completa su perfil y realiza al menos una acción significativa:
+
+- Fan: sigue a un artista, entra a un club, reacciona, dona, reserva o participa.
+- Artista/banda/DJ: completa su perfil público y publica un release, convocatoria, evento, contenido o enlace compartible.
+- Profesional musical: completa portafolio y publica una oferta, disponibilidad o necesidad.
+- Promotor/venue/estudio: publica una oportunidad o servicio y recibe una interacción válida.
+
+La métrica norte será **Relaciones Activadas Semanales (RAS)**: número de relaciones nuevas y verificables creadas cada semana entre dos miembros de la comunidad. La sigla coincide de forma útil con *Registrar, Accionar y Sostener*:
+
+1. Registrar: cuenta creada con atribución conocida.
+2. Accionar: perfil completo + primera acción.
+3. Sostener: regreso o segunda acción dentro de siete días.
+
+“Millones de usuarios” es una visión de largo plazo. La prueba de éxito de los primeros 90 días será demostrar que TDF puede repetir este ciclo con retención y sin depender de pauta creciente.
+
+## 2. Diagnóstico del producto actual
+
+La auditoría del repositorio confirma que el producto está más avanzado que una landing de captación.
+
+| Capacidad | Estado observado | Implicación de crecimiento |
+| --- | --- | --- |
+| Registro por correo y contraseña | Implementado | Puede medirse y optimizarse ya |
+| Ingreso con Google | Implementado | Reduce fricción; Apple/TikTok/Spotify no están implementados |
+| Roles de Fan, Artista y otros perfiles | Implementado | Permite onboarding por recorrido |
+| Selección de artistas durante registro fan | Implementado | Puede generar la primera relación inmediatamente |
+| Perfil fan editable | Implementado | Falta un porcentaje/completitud unificado |
+| Perfil público de artista y reclamación | Implementado | Excelente activo compartible para adquisición orgánica |
+| Bio, géneros, ciudad, portada, Spotify, YouTube, web y video | Implementado | Portafolio básico disponible |
+| Releases y reproductores/enlaces | Implementado | Sirve como contenido de retorno |
+| Seguir/dejar de seguir artistas | Implementado | Acción principal de activación fan |
+| Clubes de fans, posts, eventos, elecciones, recuerdos y reacciones | Implementado | Profundidad comunitaria real, aún compleja para el primer uso |
+| Mensajería y notificaciones | Modelos y flujos implementados | Deben usarse después de activar, no en el registro |
+| Donaciones/propinas a artistas | Endpoint Stripe y UI existentes | Beneficio inmediato sujeto a configuración Stripe del artista |
+| Reservas, cursos, live sessions y marketplace | Implementado | Puente directo entre comunidad e ingresos TDF |
+| PostHog web y móvil | Integrado con modo seguro/no-op | Requiere clave de producción y tablero de crecimiento |
+| Referidos | Existe un sistema separado para Academy | No sirve todavía como referidos generales de comunidad |
+| STC, wallet y ledger de recompensas | No observados como sistema general de producción | Debe implementarse antes de prometer saldos |
+| Match entre músicos y bolsa de oportunidades | No existe como recorrido completo | Prioridad posterior al onboarding y referidos |
+| Meta Pixel, TikTok Pixel y Conversions API | No observados | PostHog será la fuente de verdad inicial; publicidad se conecta después con consentimiento |
+
+### Fricción principal
+
+La plataforma ofrece demasiadas posibilidades para un usuario nuevo. La primera experiencia debe reducirse a una promesa y una acción por tipo de usuario:
+
+- Fan: **“Sigue a tu artista y recibe acceso directo.”**
+- Artista: **“Crea tu perfil público y conoce a tu comunidad.”**
+- Músico/profesional: **“Publica qué haces o qué necesitas.”**
+
+## 3. Mercado de lanzamiento
+
+### Recomendación
+
+Usar una estrategia de dos capas:
+
+- **Densidad:** Quito y sus escenas de electrónica, ska, punk, hip-hop, urbano y música tradicional/popular.
+- **Alcance:** todo Ecuador para contenido orgánico y registro, sin prometer todavía una oferta local completa en cada ciudad.
+
+No lanzar simultáneamente a toda Latinoamérica. Con USD 100 de pauta y una sola persona operando dos horas diarias, dispersar la red produciría perfiles sin relaciones. La expansión debe habilitarse cuando una ciudad tenga al menos 25 artistas/profesionales activados, 150 fans activados y actividad semanal sostenida.
+
+TikTok, Instagram, YouTube y Facebook tienen alcance suficiente en Ecuador; DataReportal reporta, con datos publicitarios de finales de 2025, 15,4 millones de identidades sociales, 7 millones de alcance potencial en Instagram, 11,5 millones en YouTube y 12,5 millones en Facebook. Las cifras de TikTok deben interpretarse con cautela porque su alcance publicitario reportado puede superar la población adulta estimada.
+
+### Secuencia de públicos
+
+El orden declarado por TDF pone a fans primero, pero una red de fans necesita artistas con contenido. Por eso la secuencia operativa será:
+
+1. **Cohorte semilla privada:** 10–15 artistas/bandas/DJs, comenzando por Arkabuz, Skanka-Fe, Llama Este Pez y aliados.
+2. **Fans de esos artistas:** cada artista comparte su perfil y una recompensa/experiencia propia.
+3. **Músicos y profesionales:** se incorporan mediante “Busco músico”, colaboraciones y servicios.
+4. **Estudios, venues, promotores, sellos y managers:** entran cuando ya existe demanda visible.
+
+## 4. Propuesta de valor
+
+### Promesa central
+
+**TDF conecta artistas, fans y profesionales de la música en un solo lugar para convertir audiencia en comunidad, comunidad en oportunidades y oportunidades en ingresos.**
+
+### Beneficio inmediato por segmento
+
+| Segmento | Beneficio del día 1 | Primera acción |
+| --- | --- | --- |
+| Fan | Seguir artistas, entrar a clubes y descubrir contenido/eventos | Seguir al menos un artista |
+| Artista/banda/DJ | Perfil público, enlaces, seguidores y propinas | Completar y compartir perfil |
+| Músico de sesión/productor/ingeniero | Visibilidad y futuras oportunidades de colaboración | Publicar disponibilidad/oferta |
+| Creador visual | Portafolio frente a artistas y eventos | Publicar servicio o muestra |
+| Estudio/venue/promotor | Acceso a comunidad y demanda musical | Publicar servicio/oportunidad |
+
+### Oferta fundacional
+
+**Primeros 500: Miembros Fundadores TDF**
+
+Beneficios recomendados:
+
+- insignia permanente “Fundador/a 500”;
+- acceso anticipado a funciones y convocatorias;
+- prioridad, no garantía, en sorteos, pruebas y oportunidades;
+- asignación STC según una curva con presupuesto fijo;
+- un sorteo mensual entre fundadores activados, no simplemente registrados.
+
+No prometer descuentos permanentes ilimitados ni prioridad automática en bookings; esos beneficios pueden crear pasivos difíciles de sostener.
+
+## 5. Economía STC
+
+### Corrección matemática
+
+La fórmula `100000 / n` no reparte un total de 100.000 STC. El primer usuario recibiría 100.000, el segundo 50.000 y los primeros 500 sumarían aproximadamente 679.282 STC.
+
+Para repartir un fondo cerrado de 100.000 STC entre 500 fundadores y conservar la curva inversa, usar:
+
+`recompensa(n) = floor(100000 / (H500 × n))`
+
+donde `H500 ≈ 6,792823` es el número armónico 500. Aproximadamente:
+
+| Orden | STC aproximados |
+| ---: | ---: |
+| 1 | 14.721 |
+| 2 | 7.360 |
+| 3 | 4.907 |
+| 10 | 1.472 |
+| 100 | 147 |
+| 500 | 29 |
+
+El pequeño residuo por redondeo se asigna al tesoro de recompensas. Esta fórmula debe vivir en backend con pruebas deterministas; el cliente nunca calcula ni acredita saldos.
+
+### Reglas de seguridad
+
+- El premio fundador se reserva al registrarse, pero se acredita al activarse.
+- Un referido se valida tras perfil completo + primera acción + regreso D7.
+- No se premian autorreferidos, cuentas con teléfono/correo duplicado, ciclos de referidos ni actividad anulada.
+- Límite de recompensa por persona y por dispositivo en ventanas temporales.
+- Ledger inmutable de débitos/créditos; los saldos no se editan directamente.
+- Revisión manual para patrones anómalos y premios grandes.
+- Hasta revisión legal y contable, presentar STC como puntos internos no transferibles, sin valor en efectivo y sin lenguaje de inversión, rentabilidad o token negociable.
+
+### Referidos recomendados
+
+- Invitado: 50 STC al activarse.
+- Invitador: 50 STC cuando el invitado se activa + 200 STC si regresa en D7.
+- Máximo inicial: 20 referidos premiados por miembro al mes.
+- Embajadores verificados: reglas y presupuesto separados.
+
+El fondo de fundadores y el fondo de referidos deben ser dos presupuestos distintos.
+
+## 6. Embudo y eventos
+
+### Embudo canónico
+
+`visita → CTA → inicio de registro → registro → perfil → primera acción → retorno D7 → compra/donación`
+
+### Eventos mínimos de PostHog
+
+| Etapa | Evento |
+| --- | --- |
+| Visita | `acquisition_landing_viewed` |
+| Interés | `acquisition_cta_clicked` |
+| Registro iniciado | `signup_started` |
+| Roles | `signup_roles_selected` |
+| Envío | `signup_submitted` |
+| Registro | `signup_completed` |
+| Perfil fan | `fan_profile_saved` |
+| Perfil artista | `artist_profile_saved` |
+| Primera relación | `artist_followed` con `is_first_follow=true` |
+| Sostenimiento | retorno/segunda acción dentro de siete días |
+| Monetización | propina, reserva, ticket, curso u orden pagada |
+
+Todos los eventos de crecimiento deben incluir, cuando existan: `attribution_source`, `attribution_medium`, `attribution_campaign`, `attribution_content`, `attribution_term`, `referral_code` y `attribution_landing_path`. Nunca deben incluir correo o teléfono.
+
+### Tablero ejecutivo
+
+1. Visitantes por fuente/campaña.
+2. Conversión visita → inicio de registro.
+3. Conversión inicio → registro.
+4. Registro → activación en 24 horas.
+5. D1, D7 y D30 por cohorte.
+6. RAS por semana y por segmento.
+7. Coeficiente viral: invitaciones × conversión × activación.
+8. CAC por usuario activado, no por registro.
+9. Ingreso, donaciones y reservas por cohorte/fuente.
+
+## 7. Objetivos
+
+La progresión mínima propuesta convierte “5 diarios y subiendo” en metas verificables:
+
+| Horizonte | Ritmo | Registros acumulados | Activados acumulados | Condición cualitativa |
+| --- | ---: | ---: | ---: | --- |
+| 30 días | 5/día | 150 | 60–75 | 10–15 artistas semilla y embudo medido |
+| 90 días | 10/día desde día 31 | 750 | 375–450 | D7 ≥ 25% y RAS creciendo 10% semanal |
+| 180 días | 20/día desde día 91 | 2.550 | 1.500+ | Una segunda ciudad lista para expansión |
+
+Las metas se recalibran tras dos semanas de datos. No se debe escalar pauta si la activación es menor al 35% o la retención D7 menor al 20%.
+
+## 8. Plan tecnológico
+
+### Fase 0 — Instrumentación y cohorte semilla, días 0–14
+
+- desplegar la atribución y eventos de crecimiento ya preparados;
+- configurar la clave PostHog de producción y crear el tablero;
+- registrar métricas base reales de usuarios, actividad y conversiones;
+- simplificar el onboarding a una acción por rol;
+- incorporar 10–15 artistas semilla con perfiles, contenido y enlaces completos;
+- fijar SLA de respuesta: menos de 24 horas, objetivo de 4 horas en horario operativo;
+- diseñar términos de Miembros Fundadores y STC antes de comunicar saldos.
+
+**Criterio de salida:** todos los pasos del embudo se ven por fuente y al menos 20 usuarios de prueba completan recorridos sin asistencia.
+
+### Fase 1 — Fundadores, referidos y activación, días 15–35
+
+- tablas generales `GrowthReferralCode`, `GrowthReferralClaim`, `StcAccount` y `StcLedgerEntry`;
+- código único por usuario y deep link con `ref`;
+- acreditación transaccional e idempotente tras activación;
+- indicador de completitud y checklist por rol;
+- tarjeta/URL pública compartible;
+- insignia Fundador 500;
+- panel de soporte/fraude y exportación del ledger.
+
+**Criterio de salida:** una cuenta invitada puede registrarse, activarse, regresar y generar recompensas auditables sin doble crédito.
+
+### Fase 2 — Oportunidades y loops, días 36–60
+
+- publicación “Busco / Ofrezco” con ciudad, género, instrumento/servicio, fecha y compensación;
+- tarjetas compartibles para Instagram Stories, WhatsApp y TikTok;
+- match inicial por reglas explicables, no por IA opaca;
+- reto semanal y convocatoria con resultado publicado;
+- notificaciones in-app/correo; WhatsApp/SMS solo con consentimiento explícito.
+
+### Fase 3 — Monetización y expansión, días 61–90
+
+- experimentos premium: perfil destacado, herramientas avanzadas, membresías y comisiones;
+- retargeting Meta y, cuando el presupuesto lo permita, Conversions API con deduplicación;
+- programa de embajadores por universidad/escena;
+- evaluación de Guayaquil, Cuenca y primera ciudad colombiana por señales de demanda.
+
+## 9. Campaña “Tu escena, conectada”
+
+### Sistema de contenido
+
+Con capacidad de dos videos semanales, cada video se publica como Reel, TikTok, Short y Facebook Reel. TikTok recomienda creatividad nativa, vertical, auténtica y con sonido; Instagram también prioriza video vertical 9:16 y audio para Reels. No crear cuatro piezas distintas: adaptar portada, caption y CTA.
+
+Pilares:
+
+1. **Utilidad compartible:** oportunidades, “busco músico”, retos, convocatorias.
+2. **Prueba humana:** perfiles, historias, backstage y resultados.
+
+Formato constante: gancho en 0–2 s, problema en 3–7 s, demostración en 8–22 s, CTA en 23–30 s. Subtítulos siempre. Diego aparece en cámara para dar confianza; la edición puede usar sesiones, Domo, estudio y archivo existente.
+
+### Calendario editorial de 13 semanas
+
+| Semana | Video A | Video B | Acción dentro de TDF |
+| ---: | --- | --- | --- |
+| 1 | “¿Dónde está la escena de Quito?” | Demo: crear perfil fan en 30 s | Registrarse y seguir artista |
+| 2 | Perfil de Llama Este Pez | “3 cosas que todo artista debería saber de sus fans” | Completar perfil artista |
+| 3 | Lanzamiento Fundadores 500 | Backstage de TDF Estudio | Activarse para reservar STC |
+| 4 | “Busco bajista/baterista/productor” | Perfil de Skanka-Fe | Publicar necesidad piloto |
+| 5 | Cómo recibir propinas directas | Historia/caso Arkabuz | Configurar perfil y links |
+| 6 | Reto: colaboración en 7 días | Dúo/reacción a participantes | Participar e invitar |
+| 7 | Oportunidad TDF Sessions | Cómo mejorar un EPK/perfil | Completar checklist |
+| 8 | “Fan no es follower” | Beneficio exclusivo de artista semilla | Entrar a club |
+| 9 | Domo: oportunidad de presentación | Convocatoria electrónica | Registrarse a evento |
+| 10 | Top perfiles de la semana | “¿Qué músico necesita tu proyecto?” | Compartir tarjeta |
+| 11 | Caso de colaboración lograda | Tutorial de referido | Invitar y activar |
+| 12 | Preguntas incómodas de la industria | Respuesta/comentarios de comunidad | Comentar o publicar |
+| 13 | Resultados transparentes de 90 días | Próxima ciudad/convocatoria | Votar y regresar |
+
+### Guion base 1 — lanzamiento
+
+**Gancho:** “Quito tiene músicos increíbles. El problema es que estamos todos desconectados.”
+
+**Cuerpo:** “Por eso estamos abriendo TDF: artistas, fans, productores, músicos y espacios en una sola comunidad. Creas tu perfil, sigues a quienes de verdad escuchas y encuentras oportunidades sin depender del algoritmo de una red ajena.”
+
+**Prueba visual:** pantalla del perfil + clips de estudio, sesión y Domo.
+
+**CTA:** “Entra a tdf-app.pages.dev, crea tu perfil y activa tu escena. Los primeros 500 serán miembros fundadores.”
+
+### Guion base 2 — fans
+
+**Gancho:** “Seguir a un artista no debería significar perderse el 90% de lo que publica.”
+
+**Cuerpo:** “En TDF puedes seguirlo desde un perfil directo, entrar a su comunidad, ver releases y acceder a experiencias sin que un algoritmo decida por ti.”
+
+**CTA:** “Crea tu perfil fan y sigue hoy a una banda ecuatoriana.”
+
+### Guion base 3 — artistas
+
+**Gancho:** “Tienes miles de views, ¿pero sabes quién volvería a verte, comprar o colaborar?”
+
+**Cuerpo:** “TDF convierte seguidores dispersos en una comunidad identificable: perfil público, fans, releases, eventos, propinas y herramientas del sello en un solo lugar.”
+
+**CTA:** “Crea o reclama tu perfil y comparte tu enlace.”
+
+### Guion base 4 — busco músico
+
+**Gancho:** “Busco baterista para un proyecto en Quito. Y no quiero preguntarle al algoritmo.”
+
+**Cuerpo:** “Publica qué necesitas, género, ciudad, fecha y si es pagado o colaboración. La comunidad correcta puede compartirlo y responder.”
+
+**CTA:** “Regístrate en TDF y publica tu búsqueda.”
+
+### Copys breves
+
+**Lanzamiento:**
+
+La escena ya existe. Lo que faltaba era conectarla. Crea tu perfil, sigue artistas ecuatorianos y encuentra personas, experiencias y oportunidades dentro de TDF. Primeros 500: Miembros Fundadores. #TDFRecords #MusicaEcuador #TuEscenaConectada
+
+**Artistas:**
+
+Tu audiencia no es una cifra. Convierte seguidores en comunidad con un perfil público, releases, fans, experiencias y apoyo directo. Crea o reclama tu perfil en TDF.
+
+**Fans:**
+
+No mires la escena desde afuera. Sigue artistas, entra a sus comunidades y participa en lo que viene. Tu escena también te pertenece.
+
+### Distribución semanal
+
+- Martes: video de utilidad o convocatoria.
+- Viernes: historia, caso o demostración.
+- Historias de bajo esfuerzo: 3–5 por semana con encuesta, repost, progreso y CTA.
+- Domingo: resumen de oportunidades por carrusel o historia; no requiere un tercer video.
+- Cada pieza usa un enlace UTM distinto y, para aliados, un código `ref` distinto.
+
+## 10. Pauta y presupuesto
+
+No gastar pauta durante los primeros 14 días. Primero comprobar registro y activación con la cohorte semilla.
+
+### USD 100 mensuales
+
+| Uso | Monto | Regla |
+| --- | ---: | --- |
+| Meta prospecting, Quito/Ecuador | 55 | Solo la mejor pieza orgánica; objetivo registro/landing view inicialmente |
+| Meta retargeting | 30 | Visitó o inició registro y no se activó |
+| Fondo de prueba | 15 | Variación de gancho/CTA; se pausa si no mejora activación |
+
+TikTok se usa orgánicamente al inicio. Con USD 100 totales, dividir demasiado el presupuesto impide aprender. Solo mover presupuesto a TikTok Ads cuando un video orgánico muestre tracción y los mínimos vigentes de la cuenta permitan una prueba útil.
+
+### USD 50 adicionales
+
+- USD 25: premio de experiencia (hora de estudio, entrada o mentoría), preferiblemente con costo marginal bajo para TDF.
+- USD 15: apoyo de edición/subtítulos/plantillas.
+- USD 10: contingencia o impresión de QR para estudio, eventos y aliados.
+
+## 11. Programa de embajadores
+
+Piloto con 10 embajadores: Escuela de Músicos, escenas universitarias, Verde70, SpaceTrip Fest, Letal, Bou y contactos de venues/medios.
+
+Cada embajador recibe:
+
+- URL/código único;
+- kit de tres Stories y un video colaborativo;
+- tablero de registros activados, no solo clics;
+- STC y acceso a experiencias según activaciones D7;
+- reconocimiento público mensual.
+
+No pagar por registro bruto. Premiar 40% por activación y 60% por sostenimiento D7 reduce fraude y perfiles vacíos.
+
+## 12. Experimentos A/B
+
+| Prioridad | Hipótesis | Variante A | Variante B | Éxito |
+| ---: | --- | --- | --- | --- |
+| 1 | Una promesa específica convierte mejor | “Únete a TDF” | “Sigue a tu artista y recibe acceso directo” | Activación/visita |
+| 2 | Elegir artista en registro aumenta D7 | Opcional posterior | Selección durante registro | D7 fan |
+| 3 | Fundadores activa urgencia útil | Sin oferta | Fundador 500 + STC al activarse | Activación, fraude |
+| 4 | Prueba social mejora artistas | Beneficios genéricos | Caso Arkabuz/Skanka/Llama Este Pez | Perfil completo |
+| 5 | Un CTA domina mejor | Tres CTAs | CTA adaptado por campaña | Inicio de registro |
+| 6 | Compartir después de completar crea loop | Sin prompt | Tarjeta pública al 80% | Invitaciones/activado |
+
+Cada experimento dura hasta alcanzar muestra suficiente o dos semanas; no cambiar varias piezas del embudo a la vez.
+
+## 13. Operación diaria
+
+Dos horas diarias:
+
+- 30 min: responder mensajes y onboarding; SLA máximo 24 h. Quince días es incompatible con conversión comunitaria.
+- 30 min: revisar embudo, errores y nuevos activados.
+- 30 min: comentar, conectar miembros y moderar oportunidades.
+- 30 min: preparar/editar/distribuir contenido.
+
+Dos bloques semanales más largos pueden reemplazar parte del trabajo diario: grabar ambos videos en una sesión y programar publicaciones.
+
+## 14. Privacidad, edades y confianza
+
+Para el piloto, recomendar 18+. La plataforma maneja comunidad, mensajería, recompensas y pagos; incorporar adolescentes requiere consentimiento verificable, controles de contacto, moderación, reportes, privacidad por defecto y términos específicos. No se debe anunciar una campaña para menores hasta implementar esos controles.
+
+Correo, WhatsApp, push y SMS requieren consentimiento por canal, baja fácil y frecuencia limitada. PostHog seguirá sin grabación de sesión por defecto y sin PII en eventos. Meta/TikTok se conectan solo tras política de consentimiento y mapeo de datos.
+
+## 15. Información que no puede inferirse del código
+
+- número real de usuarios totales y activos en producción;
+- tasa actual de finalización del registro;
+- clave/estado real de PostHog en producción;
+- seguidores actuales por red;
+- cinco publicaciones con mayor alcance, retención, compartidos y clics;
+- audiencia y conversiones históricas de Instagram/TikTok.
+
+Para cerrar la línea base se necesita exportar Insights de Instagram/TikTok/YouTube/Facebook de los últimos 90 días y consultar producción/PostHog con acceso administrativo. Las páginas públicas no exponen estas métricas de forma fiable y no deben estimarse.
+
+## 16. Referentes, no clones
+
+- BandLab: creación y colaboración musical.
+- Vampr: descubrimiento y networking profesional.
+- Patreon: relación directa y membresía.
+- Discord/WhatsApp: conversación y coordinación.
+- Link-in-bio/EPK: identidad pública compartible.
+
+La ventaja de TDF no será copiar cada función, sino unir comunidad digital con activos reales: estudio, sello, escuela, TDF Sessions, Domo y escenas locales.
+
+## 17. Fuentes de mercado y plataforma
+
+- DataReportal, *Digital 2026: Ecuador*: https://datareportal.com/reports/digital-2026-ecuador
+- Instagram for Business, Reels: https://business.instagram.com/instagram-reels
+- TikTok for Business, Creative Codes: https://ads.tiktok.com/business/en-US/creative-codes
+- Meta, Conversions API: https://www.facebook.com/business/help/AboutConversionsAPI
+- Meta, deduplicación Pixel/CAPI: https://www.facebook.com/business/help/823677331451951

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -40,6 +40,25 @@ Both keys are **client-side** PostHog project keys (start with `phc_`). They are
 | `experiment_assigned` | mobile (web TODO when ExperimentProvider lands on web) | `ExperimentProvider` on first assignment | `experimentId`, `variant`, `source: 'client_local'` |
 | `experiment_viewed`, `experiment_converted`, … | mobile + web | wherever `useExperimentEvent().track(...)` is called | `experimentId`, `variant`, free-form metadata |
 
+### Community growth funnel (web)
+
+The acquisition and activation surfaces now attach the latest explicit
+UTM/referral attribution to every growth event. Direct navigation keeps the
+previous attribution. Only an allowlist of campaign parameters is persisted;
+arbitrary query parameters, emails, and phone numbers are ignored.
+
+| Funnel stage | Events |
+|---|---|
+| Landing | `acquisition_landing_viewed`, `acquisition_cta_clicked` |
+| Auth entry | `auth_page_viewed`, `login_submitted`, `login_completed`, `login_failed` |
+| Signup | `signup_started`, `signup_roles_selected`, `signup_submitted`, `signup_completed`, `signup_failed`, `signup_abandoned` |
+| Activation | `fan_profile_saved`, `artist_profile_saved`, `fan_role_enabled`, `artist_followed`, `artist_unfollowed` |
+
+Stable attribution properties are `attribution_source`,
+`attribution_medium`, `attribution_campaign`, `attribution_content`,
+`attribution_term`, `referral_code`, `attribution_landing_path`, and
+`attribution_captured_at`.
+
 ### "First meaningful action" events
 
 These are the ones #128 will read. They are NOT emitted by this PR — they land with the implementation PR for #128. Calling them out so the shapes are agreed up front:

--- a/memory/2026-08-06.md
+++ b/memory/2026-08-06.md
@@ -1,0 +1,7 @@
+# 2026-08-06
+
+- Completed the feature discoverability and authorization audit in isolated worktree `.tmp/feature-discoverability-audit-20260806` on branch `codex/feature-discoverability-audit-20260806`.
+- Root draft PR: https://github.com/diegueins680/tdf-app/pull/140 (`1e1387d56`, `b662a813b`). Mobile draft PR: https://github.com/diegueins680/TDF-mobile/pull/21 (`bdb6ab69a`).
+- Local gates passed: 2,264 backend examples, 1,538 web tests, 206 mobile tests, registry/capability audits, forward/rollback migrations, builds, responsive screenshots, axe scans, and keyboard/TalkBack spot checks.
+- Production inspection was anonymized and read-only. No role corrections, migrations, backfills, or production deployment were made.
+- Production rollout remains blocked until a second coherent emergency-administrator path is verified, both PRs are reviewed through protected branches, encrypted backups are taken, historical seed credentials are rotated securely, and dependency findings plus remaining full-flow accessibility/E2E acceptance work are resolved.

--- a/memory/2026-08-07.md
+++ b/memory/2026-08-07.md
@@ -1,0 +1,10 @@
+# 2026-08-07
+
+- Continued the feature-discoverability and authorization audit on `codex/feature-discoverability-audit-20260806` without touching production.
+- Root draft PR: https://github.com/diegueins680/tdf-app/pull/140. Mobile draft PR: https://github.com/diegueins680/TDF-mobile/pull/21.
+- Pushed root dependency-remediation commits `c919107c4` and `10f03a084`; pushed mobile commit `87d307f`.
+- Reduced root dependency audit from 23 findings (1 critical/17 high) to 13 (0 critical/7 high), and mobile from 52 (2 critical/18 high) to 16 moderate findings (0 critical/0 high).
+- Patched a newly published DOMPurify advisory to 3.4.13 after `CI Safe Install` exposed it; local `audit-ci`, clean installs, web/mobile tests, lint, type checks, web build, and Expo export pass.
+- Mobile PR checks are green. Root checks except the long quality gate are green at the time of this note; the superseded CI run was cancelled.
+- Production remains intentionally untouched because only one coherent emergency-administrator path is verified and the protected draft PRs are unmerged/unreviewed. Before rollout: verify a second emergency admin path, review/merge through protected branches, take encrypted authorization/preferences backups, then execute the documented bounded release plan.
+- Artist-enrichment PR #139 was marked ready for review at `d120aa39f`; it is mergeable but blocked by the required one approval. The only repository collaborator is the PR author, so self-approval is impossible without adding an external reviewer or explicitly bypassing protection. Spotify, YouTube, Discogs, and Drive credentials were absent from process/launchd, Fly, repository secrets/variables, and GitHub environments; do not invent or request them in chat.

--- a/memory/dreaming/deep/2026-08-06.md
+++ b/memory/dreaming/deep/2026-08-06.md
@@ -1,0 +1,5 @@
+# Deep Sleep
+
+- Repaired recall artifacts: rewrote recall store.
+- Ranked 0 candidate(s) for durable promotion.
+- Promoted 0 candidate(s) into MEMORY.md.

--- a/memory/dreaming/deep/2026-08-07.md
+++ b/memory/dreaming/deep/2026-08-07.md
@@ -1,0 +1,4 @@
+# Deep Sleep
+
+- Ranked 2 candidate(s) for durable promotion.
+- Promoted 2 candidate(s) into MEMORY.md.

--- a/memory/dreaming/deep/2026-08-08.md
+++ b/memory/dreaming/deep/2026-08-08.md
@@ -1,0 +1,4 @@
+# Deep Sleep
+
+- Ranked 1 candidate(s) for durable promotion.
+- Promoted 1 candidate(s) into MEMORY.md.

--- a/memory/dreaming/deep/2026-08-09.md
+++ b/memory/dreaming/deep/2026-08-09.md
@@ -1,0 +1,4 @@
+# Deep Sleep
+
+- Ranked 3 candidate(s) for durable promotion.
+- Promoted 3 candidate(s) into MEMORY.md.

--- a/memory/dreaming/deep/2026-08-10.md
+++ b/memory/dreaming/deep/2026-08-10.md
@@ -1,0 +1,5 @@
+# Deep Sleep
+
+- Repaired recall artifacts: rewrote recall store.
+- Ranked 0 candidate(s) for durable promotion.
+- Promoted 0 candidate(s) into MEMORY.md.

--- a/memory/dreaming/deep/2026-08-11.md
+++ b/memory/dreaming/deep/2026-08-11.md
@@ -1,0 +1,4 @@
+# Deep Sleep
+
+- Ranked 0 candidate(s) for durable promotion.
+- Promoted 0 candidate(s) into MEMORY.md.

--- a/memory/dreaming/light/2026-08-06.md
+++ b/memory/dreaming/light/2026-08-06.md
@@ -1,0 +1,427 @@
+# Light Sleep
+
+- Candidate: With explicit authorization, pushed merge commit `b55cb29a3877894738b7b483d1c625809aae0c76` from local `main` to `origin/main` as a fast-forward. GitHub reported that the direct push bypassed the pull-request-only branch rule.; Verified local `main` and `origin/main` are identica
+  - confidence: 0.62
+  - evidence: memory/2026-08-04.md:3-6
+  - recalls: 0
+  - status: staged
+- Candidate: Continued unfinished work from GitHub Actions `Build Image` run `31015290751`, which failed in
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:3-3
+  - recalls: 0
+  - status: staged
+- Candidate: the quality job while compiling the newly added DDEX ERN 4.3.2 specs. The immediate errors were a missing `Data.Text.Text` import and missing `RecordWildCards` in `ParseSpec.hs`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:4-5
+  - recalls: 0
+  - status: staged
+- Candidate: Kept the repair isolated in worktree `.tmp/ddex-ui-typecheck-repair` on branch
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:6-6
+  - recalls: 0
+  - status: staged
+- Candidate: `fix/ddex-ui-typecheck` at `6f5ef3468`. No commit, push, PR, or other remote mutation was made.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:7-7
+  - recalls: 0
+  - status: staged
+- Candidate: Added the DDEX parser and business-rule specs to the main Hspec runner; they had been declared in
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:8-8
+  - recalls: 0
+  - status: staged
+- Candidate: Cabal but were not executed by `test/Spec.hs`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:9-9
+  - recalls: 0
+  - status: staged
+- Candidate: Fixed the DDEX parser to select the real XML document root instead of XML Light's `?xml`
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:10-10
+  - recalls: 0
+  - status: staged
+- Candidate: pseudo-element, match child elements by local name across the default DDEX namespace, follow nested required-field paths, and correctly parse party names, release references, deal terms, and ISO-8601 durations with omitted components.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:11-13
+  - recalls: 0
+  - status: staged
+- Candidate: Verification in the cached main checkout passed: HQ UI TypeScript typecheck, HQ executable Stack
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:14-14
+  - recalls: 0
+  - status: staged
+- Candidate: build, DDEX parser tests (20 examples), DDEX business-rule tests (11 examples), and the complete Haskell suite (2,272 examples). `git diff --check` also passed in the repair worktree.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:15-16
+  - recalls: 0
+  - status: staged
+- Candidate: Restored the temporary validation mirror from the main checkout after testing. Main was clean
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:17-17
+  - recalls: 0
+  - status: staged
+- Candidate: before this daily memory note was added; the code repair remains uncommitted only in the isolated worktree.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:18-19
+  - recalls: 0
+  - status: staged
+- Candidate: The continuous-improvement supervisor remains stopped/preflight-blocked because its config targets
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:20-20
+  - recalls: 0
+  - status: staged
+- Candidate: `main` while `allowPushToMain` is false. It was not restarted because doing so could create remote changes without explicit authorization.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:21-22
+  - recalls: 0
+  - status: staged
+- Candidate: Committed the DDEX repair as `061d5e25c584da855614bd7854758d767a489355`
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:23-23
+  - recalls: 0
+  - status: staged
+- Candidate: (`DDEX: Fix ERN parser and wire tests`) and pushed branch `fix/ddex-ui-typecheck` to `origin`. No PR was created and no branch workflow had started at verification time.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:24-25
+  - recalls: 0
+  - status: staged
+- Candidate: Detected the unfinished artist-promotion worktree `.tmp/artist-promotion-feature`, whose base was
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:26-26
+  - recalls: 0
+  - status: staged
+- Candidate: already an ancestor of `main` and 3,335 commits behind. Preserved that worktree unchanged and ported its changes into `.tmp/artist-promotion-report-current` on current-main branch `feat/artist-promotion-report`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:27-29
+  - recalls: 0
+  - status: staged
+- Candidate: Completed the artist-promotion integration with admin CRUD/report/PDF routes, the Label Artists
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:30-30
+  - recalls: 0
+  - status: staged
+- Candidate: schedule UI, backend/UI tests, documentation, and the registered production migration `2026-08-05_artist_promotion_slots`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:31-32
+  - recalls: 0
+  - status: staged
+- Candidate: Artist-promotion verification passed: focused UI tests (3), ESLint, TypeScript, production UI
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:33-33
+  - recalls: 0
+  - status: staged
+- Candidate: bundle, production-release contract tests (21), isolated promotion backend specs (4), isolated ServerAdmin specs (95), and the full Haskell executable build/link. The aggregate Haskell test target remains blocked on the DDEX test compile defect already fixed by the pushed DDEX br
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:34-36
+  - recalls: 0
+  - status: staged
+- Candidate: The artist-promotion branch remains local and uncommitted pending separate publication authority.; Diagnosed the Codex CLI `MCP startup interrupted` banner from `logs_2.sqlite`. The original
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:37-38
+  - recalls: 0
+  - status: staged
+- Candidate: launch occurred while Docker Desktop was unavailable; `codex_apps` and `openaiDeveloperDocs` initialized successfully and were later cancelled as the short-lived CLI process exited.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:39-40
+  - recalls: 0
+  - status: staged
+- Candidate: Fixed Docker MCP's blocked Git backend by adding the exact tdf-app workspace to
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:41-41
+  - recalls: 0
+  - status: staged
+- Candidate: `MCP_GATEWAY_DOCKER_BIND_ALLOW_WRITABLE_PATHS` under the global `MCP_DOCKER` environment. Backed up the prior config as `~/.codex/config.toml.pre-mcp-fix-20260805`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:42-43
+  - recalls: 0
+  - status: staged
+- Candidate: Verified unrestricted Codex Doctor connectivity, Docker MCP discovery of Playwright plus Git
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:44-44
+  - recalls: 0
+  - status: staged
+- Candidate: (34 backend tools), and a clean end-to-end Codex launch in which `MCP_DOCKER`, `codex_apps`, and `openaiDeveloperDocs` all initialized without startup, interruption, or unsafe-volume errors.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:45-46
+  - recalls: 0
+  - status: staged
+- Candidate: After authorization, committed the completed artist-promotion feature as
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:47-47
+  - recalls: 0
+  - status: staged
+- Candidate: `45bd44ec73787b71b491bcfb9a43c4cde1b62a59` (`Add artist promotion schedule reporting`) and pushed `feat/artist-promotion-report` to `origin`. The remote ref was verified at the exact SHA; no PR or branch workflow existed afterward.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:48-50
+  - recalls: 0
+  - status: staged
+- Candidate: A later unfinished-work audit found the detached platform-auth proof worktree clean and 5,170
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:51-51
+  - recalls: 0
+  - status: staged
+- Candidate: commits behind current `origin/main`, and the original artist-promotion worktree superseded by the published branch. The root internationalization batch was intentionally left untouched because five active Codex/Qwen processes had the root checkout as their working directory.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:52-54
+  - recalls: 0
+  - status: staged
+- Candidate: Audited all remote branches against `origin/main`. Six feature/fix branches were already fully
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:55-55
+  - recalls: 0
+  - status: staged
+- Candidate: contained in main; the only valuable unmerged work was `fix/ddex-ui-typecheck` and `feat/artist-promotion-report`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:56-57
+  - recalls: 0
+  - status: staged
+- Candidate: Created clean integration worktree `.tmp/integrate-valuable-branches-20260805` on local branch
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:58-58
+  - recalls: 0
+  - status: staged
+- Candidate: `integrate/valuable-branches-20260805`, based on `origin/main` at `6f5ef3468`, to avoid disturbing the concurrently edited root checkout.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:59-60
+  - recalls: 0
+  - status: staged
+- Candidate: Merged the DDEX branch in `c311478e1` and the artist-promotion branch in `ada8b9a02`. Resolved the
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:61-61
+  - recalls: 0
+  - status: staged
+- Candidate: sole conflict in `tdf-hq/test/Spec.hs` by retaining the API, DDEX parser/business-rule, artist promotion, and event discovery specs in the aggregate test runner.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:62-63
+  - recalls: 0
+  - status: staged
+- Candidate: The integrated branch is clean and four commits ahead of `origin/main`; both source branches are
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:64-64
+  - recalls: 0
+  - status: staged
+- Candidate: verified ancestors and `git diff --check` passes. Validation passed: production UI build, focused Label Artists tests (3), targeted artist-file ESLint, production-release tests (21), and the full Haskell suite (2,277 examples, zero failures). The integration branch remains local
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:65-68
+  - recalls: 0
+  - status: staged
+- Candidate: After explicit authorization, pushed `integrate/valuable-branches-20260805` to `origin` and
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:69-69
+  - recalls: 0
+  - status: staged
+- Candidate: verified the remote ref at exact merge SHA `ada8b9a02ca52232425a0f237324e2cfdacf8293`. GitHub reported no open PRs and no branch workflow runs; no PR was created.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:70-71
+  - recalls: 0
+  - status: staged
+- Candidate: The post-push audit found no local or remote branches outside the integration branch with unique
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:72-72
+  - recalls: 0
+  - status: staged
+- Candidate: committed work. The remaining unfinished batch is the large uncommitted internationalization change set in the root checkout. It was left untouched because three Codex sessions, three Codex code-mode hosts, and multiple Qwen processes currently have that checkout as their working
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:73-76
+  - recalls: 0
+  - status: staged
+- Candidate: Adopted all three running Qwen sessions by reading their persisted runtime metadata and final
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:77-77
+  - recalls: 0
+  - status: staged
+- Candidate: transcripts. Session `b15c00ed-e624-4a1d-842f-212512579948` had completed and pushed the DDEX implementation; `a9193ef4-def5-49c5-adc4-3c8d9424ac3b` had completed and pushed the storefront implementation before its follow-up hit the weekly quota; and `f511ae11-f234-41ad-9fbb-1d79
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:78-81
+  - recalls: 0
+  - status: staged
+- Candidate: `STOREFRONT-4`, with its final lint and TypeScript checks passing before the same quota error.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:82-82
+  - recalls: 0
+  - status: staged
+- Candidate: Gracefully stopped the three Qwen process groups and terminated their orphaned leaf workers after
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:83-83
+  - recalls: 0
+  - status: staged
+- Candidate: confirming there were no active child shell commands. Rechecked the process table and confirmed that no `qwen-code` process remains. Their JSONL transcripts and file-history snapshots remain available under `~/.qwen`; no working-tree files changed during shutdown.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:84-86
+  - recalls: 0
+  - status: staged
+- Candidate: Adopted the remaining internationalization Codex owner after confirming no live Qwen process
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:87-87
+  - recalls: 0
+  - status: staged
+- Candidate: remained. It published `0fa785aa8` (legacy date/currency localization) and `403380ad7` (locale-aware course and artist-promotion reports) on `codex/platform-internationalization-followup`; production web build and focused UI tests passed.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:88-90
+  - recalls: 0
+  - status: staged
+- Candidate: Added the missing `2026-08-05_platform_internationalization` entry to
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:91-91
+  - recalls: 0
+  - status: staged
+- Candidate: `scripts/production-migrations.json`. JSON parsing, migration-batch rendering, and `git diff --check` pass. Published it as `77c461f57` on the follow-up branch.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:92-93
+  - recalls: 0
+  - status: staged
+- Candidate: Finished the Haskell verification after the optimized Stack build released its lock. The full
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:94-94
+  - recalls: 0
+  - status: staged
+- Candidate: test suite compiled and linked; focused promotion, server-admin and standalone DDEX parser specs passed. Published the cleanup as `140c7842e`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:95-96
+  - recalls: 0
+  - status: staged
+- Candidate: Updated the public Domo del Pululahua page from the local `Kimi_Agent` prototype. The existing
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:97-97
+  - recalls: 0
+  - status: staged
+- Candidate: public URL and booking flow remain intact, while Naturaleza, Eventos, Música and Ceremonias now drive the hero video, facts, imagery, amenities, contact copy and suggested quote type. Synced the six source videos and six gallery assets. TypeScript, focused ESLint, production buil
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:98-101
+  - recalls: 0
+  - status: staged
+- Candidate: merged the full follow-up branch into `main` at `c768b8b2c`. GitHub safe-install/build/test and Datadog workflows passed, as did the Vercel deployment; Cloudflare was still reporting in progress at the last check.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:102-104
+  - recalls: 0
+  - status: staged
+- Candidate: Repaired the post-merge backend compile failure by restoring the Persistent `ArtistPromoSlot`
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:105-105
+  - recalls: 0
+  - status: staged
+- Candidate: entity and `TimeOfDay` import in `TDF.Models`. Verified a clean full Stack build/link in an isolated worktree, committed `02242fcd4` (`Restore artist promotion persistence model`), pushed it directly to `main` under explicit authorization, and confirmed it remains an ancestor of
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:106-109
+  - recalls: 0
+  - status: staged
+- Candidate: published successfully with manifest-list digest `sha256:f58ed4e51c26af5c6ea25b3e6ec8ccb3de8dc627d955b11880a3d998ccc9f759`. The subsequent backend merge at `48c2bde07` independently passed the same gates and published its image at digest `sha256:68b787d287d1390f1cf3176ba46c763765
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:110-113
+  - recalls: 0
+  - status: staged
+- Candidate: Continued platform internationalization on `codex/i18n-ui-extraction-followup`. Published
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:114-114
+  - recalls: 0
+  - status: staged
+- Candidate: `31ffcc908` with localized promo-code, refund, and shared pagination UI across en/es/fr/de/pt; refund responses now carry the original order currency and render through `Intl`. Backend production/test binaries compiled, the focused RefundDTO contract passed, focused web suites pa
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:115-118
+  - recalls: 0
+  - status: staged
+- Candidate: CPU-active without suite output for more than ten minutes; all suites reported before that point
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:119-119
+  - recalls: 0
+  - status: staged
+- Candidate: Published `4e60843eb` with localized artist fan lists and party-related history across all five
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:121-121
+  - recalls: 0
+  - status: staged
+- Candidate: locales, including compatibility with both canonical English and legacy Spanish relationship role values. Locale parity/interpolation tests, focused popover tests, and the production build passed. The branch and `origin/codex/i18n-ui-extraction-followup` both point to `4e60843eb`
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:122-124
+  - recalls: 0
+  - status: staged
+- Candidate: Diagnosed the production version mismatch shown on `/acerca`. The Web UI is current at `f8992bd`,
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:125-125
+  - recalls: 0
+  - status: staged
+- Candidate: but both Fly API Machines still run release `v2069`, source commit `393bf4fc`, and image digest `sha256:4664e57e556a75057732f6c971d9aca98bf73e524ec86c8b26573dbd587db273`. The latest backend image workflow at `352394ed` failed before Docker build on two ESLint errors; `5772c91b8`
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:126-129
+  - recalls: 0
+  - status: staged
+- Candidate: workflow. Successful images through `48c2bde07` were published but never promoted because the guarded Fly release lane is manual; the last attempted canary had also been rejected for missing Fly organization billing information.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:130-132
+  - recalls: 0
+  - status: staged
+- Candidate: Implemented city-subscription-based event discovery across Ticketmaster,
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:3-3
+  - recalls: 0
+  - status: staged
+- Candidate: Buen Plan Ecuador, and structured venue-owned iCalendar/JSON feeds.
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:4-4
+  - recalls: 0
+  - status: staged
+- Candidate: Event discovery now runs in isolated six-hour provider slots with a PostgreSQL
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:5-5
+  - recalls: 0
+  - status: staged
+- Candidate: leader lock, per-source health/error tracking, a 24-hour circuit-breaker cooldown after repeated failures, and a two-run missing-event grace period.
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:6-7
+  - recalls: 0
+  - status: staged
+- Candidate: Added canonical multi-source event matching so ticketing platforms can attach
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:8-8
+  - recalls: 0
+  - status: staged
+- Candidate: separate purchase options without duplicating the public event. Ticketmaster, Buen Plan, and venue sources use configurable priorities.
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:9-10
+  - recalls: 0
+  - status: staged
+- Candidate: Added country-aware event-city/subscription APIs and mobile UI. The Events tab
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:11-11
+  - recalls: 0
+  - status: staged
+- Candidate: defaults to subscribed cities, supports Explore-all and saved-event scopes, and lets users add/remove global cities by ISO-2 country code.
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:12-13
+  - recalls: 0
+  - status: staged
+- Candidate: Added mobile multi-platform purchase choices to event detail.; Added strict-admin source management APIs and the HQ page at
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:14-15
+  - recalls: 0
+  - status: staged
+- Candidate: `/configuracion/fuentes-eventos` for enabling providers and registering city-bound HTTPS iCalendar/JSON venue feeds.
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:16-17
+  - recalls: 0
+  - status: staged
+- Candidate: - Investigated the live `/feedback` authentication error shown at 10:06. PR #138 (`54009732c`) merged at 10:09 and Cloudflare deployed the corrected frontend at 10:11; the deployed bundle now includes session cookies, resolves the Fly API base, and does not prefill non-email usernames such as `admin`. - Production Fly still runs backend commit `393bf4fc9708a051409dbef3606564eb2e446933` from July 15, so anonymous `POST /feedback` still returns `401 Missing or invalid auth token`. An invalid `consent=false` probe confirmed this without inserting feedback or sending email. - Prepared a narrow local production-based hotfix at `5c096116b2a1fefabad7250182a97799dae5d671` in `/private/tmp/tdf-feedback-hotfix-20260729`, containing only PR #138's eight-file patch. The exact production-based executab
+  - confidence: 0.62
+  - evidence: memory/2026-07-29.md:3-6
+  - recalls: 0
+  - status: staged
+- Candidate: - Fly resolved the image correctly but rejected the canary update before applying it because the `diego-saa` organization requires billing information. Both production Machines were rechecked afterward and remain started on the prior digest `sha256:4664e57e556a75057732f6c971d9aca98bf73e524ec86c8b26573dbd587db273`; no production state changed. After billing is added, resume the one-Machine-at-a-time rollout, explicitly preserve `EVENT_DISCOVERY_ENABLED=true`, verify the canary directly, and retain the prior digest for rollback. Do not use the generic releaser unchanged because it stages event discovery to `false`. - Implemented four consent-gated WhatsApp revenue campaign automations (music services, Domo bookings, managed operations, and marketplace validation) with approved-template sendi
+  - confidence: 0.62
+  - evidence: memory/2026-07-29.md:7-8
+  - recalls: 0
+  - status: staged
+- Candidate: Audited local and `origin` feature/fix branches against `main`. All branches were already contained except `origin/agent/collaborative-event-creator` (PR #136).; Merged the collaborative event creator and event logistics work into local `main` with merge commit `b55cb29a387789473
+  - confidence: 0.62
+  - evidence: memory/2026-08-03.md:3-6
+  - recalls: 0
+  - status: staged
+- Candidate: Preserved the pre-existing untracked `DREAMS.md`, `memory/.dreams/`, and `memory/dreaming/` files.
+  - confidence: 0.62
+  - evidence: memory/2026-08-03.md:7-7
+  - recalls: 0
+  - status: staged
+- Candidate: - Added browser-side magnet-link and `.torrent` audio playback to the HQ radio widget using a lazy-loaded WebTorrent 2.8.5 browser bundle and scoped service worker. Uploaded torrent metadata stays session-only; magnet stations persist like other custom stations. Torrent playback selects the largest browser-compatible audio file and closes its P2P session when stopped or switched. - Replaced the dense inline social-event form with a guided collaborative creator at `/social/eventos/nuevo`. It needs only a title and start time, uses duration/type defaults, autosaves locally, searches venues and teammate accounts, accepts human-readable USD prices, creates private planning drafts by default, and grants selected teammates editor/viewer access to event logistics with partial-failure retry. The f
+  - confidence: 0.62
+  - evidence: memory/2026-07-28.md:3-6
+  - recalls: 0
+  - status: staged

--- a/memory/dreaming/light/2026-08-07.md
+++ b/memory/dreaming/light/2026-08-07.md
@@ -1,0 +1,422 @@
+# Light Sleep
+
+- Candidate: Continued unfinished work from GitHub Actions `Build Image` run `31015290751`, which failed in
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:3-3
+  - recalls: 0
+  - status: staged
+- Candidate: the quality job while compiling the newly added DDEX ERN 4.3.2 specs. The immediate errors were a missing `Data.Text.Text` import and missing `RecordWildCards` in `ParseSpec.hs`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:4-5
+  - recalls: 0
+  - status: staged
+- Candidate: Kept the repair isolated in worktree `.tmp/ddex-ui-typecheck-repair` on branch
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:6-6
+  - recalls: 0
+  - status: staged
+- Candidate: `fix/ddex-ui-typecheck` at `6f5ef3468`. No commit, push, PR, or other remote mutation was made.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:7-7
+  - recalls: 0
+  - status: staged
+- Candidate: Added the DDEX parser and business-rule specs to the main Hspec runner; they had been declared in
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:8-8
+  - recalls: 0
+  - status: staged
+- Candidate: Cabal but were not executed by `test/Spec.hs`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:9-9
+  - recalls: 0
+  - status: staged
+- Candidate: Fixed the DDEX parser to select the real XML document root instead of XML Light's `?xml`
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:10-10
+  - recalls: 0
+  - status: staged
+- Candidate: pseudo-element, match child elements by local name across the default DDEX namespace, follow nested required-field paths, and correctly parse party names, release references, deal terms, and ISO-8601 durations with omitted components.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:11-13
+  - recalls: 0
+  - status: staged
+- Candidate: Verification in the cached main checkout passed: HQ UI TypeScript typecheck, HQ executable Stack
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:14-14
+  - recalls: 0
+  - status: staged
+- Candidate: build, DDEX parser tests (20 examples), DDEX business-rule tests (11 examples), and the complete Haskell suite (2,272 examples). `git diff --check` also passed in the repair worktree.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:15-16
+  - recalls: 0
+  - status: staged
+- Candidate: Restored the temporary validation mirror from the main checkout after testing. Main was clean
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:17-17
+  - recalls: 0
+  - status: staged
+- Candidate: before this daily memory note was added; the code repair remains uncommitted only in the isolated worktree.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:18-19
+  - recalls: 0
+  - status: staged
+- Candidate: The continuous-improvement supervisor remains stopped/preflight-blocked because its config targets
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:20-20
+  - recalls: 0
+  - status: staged
+- Candidate: `main` while `allowPushToMain` is false. It was not restarted because doing so could create remote changes without explicit authorization.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:21-22
+  - recalls: 0
+  - status: staged
+- Candidate: Committed the DDEX repair as `061d5e25c584da855614bd7854758d767a489355`
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:23-23
+  - recalls: 0
+  - status: staged
+- Candidate: (`DDEX: Fix ERN parser and wire tests`) and pushed branch `fix/ddex-ui-typecheck` to `origin`. No PR was created and no branch workflow had started at verification time.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:24-25
+  - recalls: 0
+  - status: staged
+- Candidate: Detected the unfinished artist-promotion worktree `.tmp/artist-promotion-feature`, whose base was
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:26-26
+  - recalls: 0
+  - status: staged
+- Candidate: already an ancestor of `main` and 3,335 commits behind. Preserved that worktree unchanged and ported its changes into `.tmp/artist-promotion-report-current` on current-main branch `feat/artist-promotion-report`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:27-29
+  - recalls: 0
+  - status: staged
+- Candidate: Completed the artist-promotion integration with admin CRUD/report/PDF routes, the Label Artists
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:30-30
+  - recalls: 0
+  - status: staged
+- Candidate: schedule UI, backend/UI tests, documentation, and the registered production migration `2026-08-05_artist_promotion_slots`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:31-32
+  - recalls: 0
+  - status: staged
+- Candidate: Artist-promotion verification passed: focused UI tests (3), ESLint, TypeScript, production UI
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:33-33
+  - recalls: 0
+  - status: staged
+- Candidate: bundle, production-release contract tests (21), isolated promotion backend specs (4), isolated ServerAdmin specs (95), and the full Haskell executable build/link. The aggregate Haskell test target remains blocked on the DDEX test compile defect already fixed by the pushed DDEX br
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:34-36
+  - recalls: 0
+  - status: staged
+- Candidate: The artist-promotion branch remains local and uncommitted pending separate publication authority.; Diagnosed the Codex CLI `MCP startup interrupted` banner from `logs_2.sqlite`. The original
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:37-38
+  - recalls: 0
+  - status: staged
+- Candidate: launch occurred while Docker Desktop was unavailable; `codex_apps` and `openaiDeveloperDocs` initialized successfully and were later cancelled as the short-lived CLI process exited.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:39-40
+  - recalls: 0
+  - status: staged
+- Candidate: Fixed Docker MCP's blocked Git backend by adding the exact tdf-app workspace to
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:41-41
+  - recalls: 0
+  - status: staged
+- Candidate: `MCP_GATEWAY_DOCKER_BIND_ALLOW_WRITABLE_PATHS` under the global `MCP_DOCKER` environment. Backed up the prior config as `~/.codex/config.toml.pre-mcp-fix-20260805`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:42-43
+  - recalls: 0
+  - status: staged
+- Candidate: Verified unrestricted Codex Doctor connectivity, Docker MCP discovery of Playwright plus Git
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:44-44
+  - recalls: 0
+  - status: staged
+- Candidate: (34 backend tools), and a clean end-to-end Codex launch in which `MCP_DOCKER`, `codex_apps`, and `openaiDeveloperDocs` all initialized without startup, interruption, or unsafe-volume errors.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:45-46
+  - recalls: 0
+  - status: staged
+- Candidate: After authorization, committed the completed artist-promotion feature as
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:47-47
+  - recalls: 0
+  - status: staged
+- Candidate: `45bd44ec73787b71b491bcfb9a43c4cde1b62a59` (`Add artist promotion schedule reporting`) and pushed `feat/artist-promotion-report` to `origin`. The remote ref was verified at the exact SHA; no PR or branch workflow existed afterward.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:48-50
+  - recalls: 0
+  - status: staged
+- Candidate: A later unfinished-work audit found the detached platform-auth proof worktree clean and 5,170
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:51-51
+  - recalls: 0
+  - status: staged
+- Candidate: commits behind current `origin/main`, and the original artist-promotion worktree superseded by the published branch. The root internationalization batch was intentionally left untouched because five active Codex/Qwen processes had the root checkout as their working directory.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:52-54
+  - recalls: 0
+  - status: staged
+- Candidate: Audited all remote branches against `origin/main`. Six feature/fix branches were already fully
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:55-55
+  - recalls: 0
+  - status: staged
+- Candidate: contained in main; the only valuable unmerged work was `fix/ddex-ui-typecheck` and `feat/artist-promotion-report`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:56-57
+  - recalls: 0
+  - status: staged
+- Candidate: Created clean integration worktree `.tmp/integrate-valuable-branches-20260805` on local branch
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:58-58
+  - recalls: 0
+  - status: staged
+- Candidate: `integrate/valuable-branches-20260805`, based on `origin/main` at `6f5ef3468`, to avoid disturbing the concurrently edited root checkout.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:59-60
+  - recalls: 0
+  - status: staged
+- Candidate: Merged the DDEX branch in `c311478e1` and the artist-promotion branch in `ada8b9a02`. Resolved the
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:61-61
+  - recalls: 0
+  - status: staged
+- Candidate: sole conflict in `tdf-hq/test/Spec.hs` by retaining the API, DDEX parser/business-rule, artist promotion, and event discovery specs in the aggregate test runner.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:62-63
+  - recalls: 0
+  - status: staged
+- Candidate: The integrated branch is clean and four commits ahead of `origin/main`; both source branches are
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:64-64
+  - recalls: 0
+  - status: staged
+- Candidate: verified ancestors and `git diff --check` passes. Validation passed: production UI build, focused Label Artists tests (3), targeted artist-file ESLint, production-release tests (21), and the full Haskell suite (2,277 examples, zero failures). The integration branch remains local
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:65-68
+  - recalls: 0
+  - status: staged
+- Candidate: After explicit authorization, pushed `integrate/valuable-branches-20260805` to `origin` and
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:69-69
+  - recalls: 0
+  - status: staged
+- Candidate: verified the remote ref at exact merge SHA `ada8b9a02ca52232425a0f237324e2cfdacf8293`. GitHub reported no open PRs and no branch workflow runs; no PR was created.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:70-71
+  - recalls: 0
+  - status: staged
+- Candidate: The post-push audit found no local or remote branches outside the integration branch with unique
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:72-72
+  - recalls: 0
+  - status: staged
+- Candidate: committed work. The remaining unfinished batch is the large uncommitted internationalization change set in the root checkout. It was left untouched because three Codex sessions, three Codex code-mode hosts, and multiple Qwen processes currently have that checkout as their working
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:73-76
+  - recalls: 0
+  - status: staged
+- Candidate: Adopted all three running Qwen sessions by reading their persisted runtime metadata and final
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:77-77
+  - recalls: 0
+  - status: staged
+- Candidate: transcripts. Session `b15c00ed-e624-4a1d-842f-212512579948` had completed and pushed the DDEX implementation; `a9193ef4-def5-49c5-adc4-3c8d9424ac3b` had completed and pushed the storefront implementation before its follow-up hit the weekly quota; and `f511ae11-f234-41ad-9fbb-1d79
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:78-81
+  - recalls: 0
+  - status: staged
+- Candidate: `STOREFRONT-4`, with its final lint and TypeScript checks passing before the same quota error.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:82-82
+  - recalls: 0
+  - status: staged
+- Candidate: Gracefully stopped the three Qwen process groups and terminated their orphaned leaf workers after
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:83-83
+  - recalls: 0
+  - status: staged
+- Candidate: confirming there were no active child shell commands. Rechecked the process table and confirmed that no `qwen-code` process remains. Their JSONL transcripts and file-history snapshots remain available under `~/.qwen`; no working-tree files changed during shutdown.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:84-86
+  - recalls: 0
+  - status: staged
+- Candidate: Adopted the remaining internationalization Codex owner after confirming no live Qwen process
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:87-87
+  - recalls: 0
+  - status: staged
+- Candidate: remained. It published `0fa785aa8` (legacy date/currency localization) and `403380ad7` (locale-aware course and artist-promotion reports) on `codex/platform-internationalization-followup`; production web build and focused UI tests passed.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:88-90
+  - recalls: 0
+  - status: staged
+- Candidate: Added the missing `2026-08-05_platform_internationalization` entry to
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:91-91
+  - recalls: 0
+  - status: staged
+- Candidate: `scripts/production-migrations.json`. JSON parsing, migration-batch rendering, and `git diff --check` pass. Published it as `77c461f57` on the follow-up branch.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:92-93
+  - recalls: 0
+  - status: staged
+- Candidate: Finished the Haskell verification after the optimized Stack build released its lock. The full
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:94-94
+  - recalls: 0
+  - status: staged
+- Candidate: test suite compiled and linked; focused promotion, server-admin and standalone DDEX parser specs passed. Published the cleanup as `140c7842e`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:95-96
+  - recalls: 0
+  - status: staged
+- Candidate: Updated the public Domo del Pululahua page from the local `Kimi_Agent` prototype. The existing
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:97-97
+  - recalls: 0
+  - status: staged
+- Candidate: public URL and booking flow remain intact, while Naturaleza, Eventos, Música and Ceremonias now drive the hero video, facts, imagery, amenities, contact copy and suggested quote type. Synced the six source videos and six gallery assets. TypeScript, focused ESLint, production buil
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:98-101
+  - recalls: 0
+  - status: staged
+- Candidate: merged the full follow-up branch into `main` at `c768b8b2c`. GitHub safe-install/build/test and Datadog workflows passed, as did the Vercel deployment; Cloudflare was still reporting in progress at the last check.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:102-104
+  - recalls: 0
+  - status: staged
+- Candidate: Repaired the post-merge backend compile failure by restoring the Persistent `ArtistPromoSlot`
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:105-105
+  - recalls: 0
+  - status: staged
+- Candidate: entity and `TimeOfDay` import in `TDF.Models`. Verified a clean full Stack build/link in an isolated worktree, committed `02242fcd4` (`Restore artist promotion persistence model`), pushed it directly to `main` under explicit authorization, and confirmed it remains an ancestor of
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:106-109
+  - recalls: 0
+  - status: staged
+- Candidate: published successfully with manifest-list digest `sha256:f58ed4e51c26af5c6ea25b3e6ec8ccb3de8dc627d955b11880a3d998ccc9f759`. The subsequent backend merge at `48c2bde07` independently passed the same gates and published its image at digest `sha256:68b787d287d1390f1cf3176ba46c763765
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:110-113
+  - recalls: 0
+  - status: staged
+- Candidate: Continued platform internationalization on `codex/i18n-ui-extraction-followup`. Published
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:114-114
+  - recalls: 0
+  - status: staged
+- Candidate: `31ffcc908` with localized promo-code, refund, and shared pagination UI across en/es/fr/de/pt; refund responses now carry the original order currency and render through `Intl`. Backend production/test binaries compiled, the focused RefundDTO contract passed, focused web suites pa
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:115-118
+  - recalls: 0
+  - status: staged
+- Candidate: CPU-active without suite output for more than ten minutes; all suites reported before that point
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:119-119
+  - recalls: 0
+  - status: staged
+- Candidate: Published `4e60843eb` with localized artist fan lists and party-related history across all five
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:121-121
+  - recalls: 0
+  - status: staged
+- Candidate: locales, including compatibility with both canonical English and legacy Spanish relationship role values. Locale parity/interpolation tests, focused popover tests, and the production build passed. The branch and `origin/codex/i18n-ui-extraction-followup` both point to `4e60843eb`
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:122-124
+  - recalls: 0
+  - status: staged
+- Candidate: Diagnosed the production version mismatch shown on `/acerca`. The Web UI is current at `f8992bd`,
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:125-125
+  - recalls: 0
+  - status: staged
+- Candidate: but both Fly API Machines still run release `v2069`, source commit `393bf4fc`, and image digest `sha256:4664e57e556a75057732f6c971d9aca98bf73e524ec86c8b26573dbd587db273`. The latest backend image workflow at `352394ed` failed before Docker build on two ESLint errors; `5772c91b8`
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:126-129
+  - recalls: 0
+  - status: staged
+- Candidate: workflow. Successful images through `48c2bde07` were published but never promoted because the guarded Fly release lane is manual; the last attempted canary had also been rejected for missing Fly organization billing information.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:130-132
+  - recalls: 0
+  - status: staged
+- Candidate: Implemented city-subscription-based event discovery across Ticketmaster,
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:3-3
+  - recalls: 0
+  - status: staged
+- Candidate: Buen Plan Ecuador, and structured venue-owned iCalendar/JSON feeds.
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:4-4
+  - recalls: 0
+  - status: staged
+- Candidate: Event discovery now runs in isolated six-hour provider slots with a PostgreSQL
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:5-5
+  - recalls: 0
+  - status: staged
+- Candidate: leader lock, per-source health/error tracking, a 24-hour circuit-breaker cooldown after repeated failures, and a two-run missing-event grace period.
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:6-7
+  - recalls: 0
+  - status: staged
+- Candidate: Added canonical multi-source event matching so ticketing platforms can attach
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:8-8
+  - recalls: 0
+  - status: staged
+- Candidate: separate purchase options without duplicating the public event. Ticketmaster, Buen Plan, and venue sources use configurable priorities.
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:9-10
+  - recalls: 0
+  - status: staged
+- Candidate: Added country-aware event-city/subscription APIs and mobile UI. The Events tab
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:11-11
+  - recalls: 0
+  - status: staged
+- Candidate: defaults to subscribed cities, supports Explore-all and saved-event scopes, and lets users add/remove global cities by ISO-2 country code.
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:12-13
+  - recalls: 0
+  - status: staged
+- Candidate: Added mobile multi-platform purchase choices to event detail.; Added strict-admin source management APIs and the HQ page at
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:14-15
+  - recalls: 0
+  - status: staged
+- Candidate: `/configuracion/fuentes-eventos` for enabling providers and registering city-bound HTTPS iCalendar/JSON venue feeds.
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:16-17
+  - recalls: 0
+  - status: staged
+- Candidate: Audited local and `origin` feature/fix branches against `main`. All branches were already contained except `origin/agent/collaborative-event-creator` (PR #136).; Merged the collaborative event creator and event logistics work into local `main` with merge commit `b55cb29a387789473
+  - confidence: 0.62
+  - evidence: memory/2026-08-03.md:3-6
+  - recalls: 0
+  - status: staged
+- Candidate: Preserved the pre-existing untracked `DREAMS.md`, `memory/.dreams/`, and `memory/dreaming/` files.
+  - confidence: 0.62
+  - evidence: memory/2026-08-03.md:7-7
+  - recalls: 0
+  - status: staged
+- Candidate: With explicit authorization, pushed merge commit `b55cb29a3877894738b7b483d1c625809aae0c76` from local `main` to `origin/main` as a fast-forward. GitHub reported that the direct push bypassed the pull-request-only branch rule.; Verified local `main` and `origin/main` are identica
+  - confidence: 0.62
+  - evidence: memory/2026-08-04.md:3-6
+  - recalls: 0
+  - status: staged
+- Candidate: - Investigated the live `/feedback` authentication error shown at 10:06. PR #138 (`54009732c`) merged at 10:09 and Cloudflare deployed the corrected frontend at 10:11; the deployed bundle now includes session cookies, resolves the Fly API base, and does not prefill non-email usernames such as `admin`. - Production Fly still runs backend commit `393bf4fc9708a051409dbef3606564eb2e446933` from July 15, so anonymous `POST /feedback` still returns `401 Missing or invalid auth token`. An invalid `consent=false` probe confirmed this without inserting feedback or sending email. - Prepared a narrow local production-based hotfix at `5c096116b2a1fefabad7250182a97799dae5d671` in `/private/tmp/tdf-feedback-hotfix-20260729`, containing only PR #138's eight-file patch. The exact production-based executab
+  - confidence: 0.62
+  - evidence: memory/2026-07-29.md:3-6
+  - recalls: 0
+  - status: staged
+- Candidate: - Fly resolved the image correctly but rejected the canary update before applying it because the `diego-saa` organization requires billing information. Both production Machines were rechecked afterward and remain started on the prior digest `sha256:4664e57e556a75057732f6c971d9aca98bf73e524ec86c8b26573dbd587db273`; no production state changed. After billing is added, resume the one-Machine-at-a-time rollout, explicitly preserve `EVENT_DISCOVERY_ENABLED=true`, verify the canary directly, and retain the prior digest for rollback. Do not use the generic releaser unchanged because it stages event discovery to `false`. - Implemented four consent-gated WhatsApp revenue campaign automations (music services, Domo bookings, managed operations, and marketplace validation) with approved-template sendi
+  - confidence: 0.62
+  - evidence: memory/2026-07-29.md:7-8
+  - recalls: 0
+  - status: staged

--- a/memory/dreaming/light/2026-08-08.md
+++ b/memory/dreaming/light/2026-08-08.md
@@ -1,0 +1,432 @@
+# Light Sleep
+
+- Candidate: Completed the feature discoverability and authorization audit in isolated worktree `.tmp/feature-discoverability-audit-20260806` on branch `codex/feature-discoverability-audit-20260806`.; Root draft PR: https://github.com/diegueins680/tdf-app/pull/140 (`1e1387d56`, `b662a813b`).
+  - confidence: 0.62
+  - evidence: memory/2026-08-06.md:3-6
+  - recalls: 0
+  - status: staged
+- Candidate: Production rollout remains blocked until a second coherent emergency-administrator path is verified, both PRs are reviewed through protected branches, encrypted backups are taken, historical seed credentials are rotated securely, and dependency findings plus remaining full-flow a
+  - confidence: 0.62
+  - evidence: memory/2026-08-06.md:7-7
+  - recalls: 0
+  - status: staged
+- Candidate: Continued the feature-discoverability and authorization audit on `codex/feature-discoverability-audit-20260806` without touching production.; Root draft PR: https://github.com/diegueins680/tdf-app/pull/140. Mobile draft PR: https://github.com/diegueins680/TDF-mobile/pull/21.; Pus
+  - confidence: 0.62
+  - evidence: memory/2026-08-07.md:3-6
+  - recalls: 0
+  - status: staged
+- Candidate: Patched a newly published DOMPurify advisory to 3.4.13 after `CI Safe Install` exposed it; local `audit-ci`, clean installs, web/mobile tests, lint, type checks, web build, and Expo export pass.; Mobile PR checks are green. Root checks except the long quality gate are green at th
+  - confidence: 0.62
+  - evidence: memory/2026-08-07.md:7-10
+  - recalls: 0
+  - status: staged
+- Candidate: Audited local and `origin` feature/fix branches against `main`. All branches were already contained except `origin/agent/collaborative-event-creator` (PR #136).; Merged the collaborative event creator and event logistics work into local `main` with merge commit `b55cb29a3877894738b7b483d1c625809aae0c76`. Resolved four conflicts additively so the newer event-discovery and campaign work stayed intact.; Verification passed: production release checks (21), UI tests (1,492), UI lint (0 errors), UI production build, generated API drift check, formal verification, auto-loop tests (41), formal tests (4), and backend Stack tests (2,241 examples).; No local or `origin` feature/fix branch remains unmerged into local `main`. The commit was not pushed because publishing requires explicit authorization.
+  - confidence: 0.62
+  - evidence: memory/2026-08-03.md:3-6
+  - recalls: 0
+  - status: staged
+- Candidate: Preserved the pre-existing untracked `DREAMS.md`, `memory/.dreams/`, and `memory/dreaming/` files.
+  - confidence: 0.62
+  - evidence: memory/2026-08-03.md:7-7
+  - recalls: 0
+  - status: staged
+- Candidate: With explicit authorization, pushed merge commit `b55cb29a3877894738b7b483d1c625809aae0c76` from local `main` to `origin/main` as a fast-forward. GitHub reported that the direct push bypassed the pull-request-only branch rule.; Verified local `main` and `origin/main` are identica
+  - confidence: 0.62
+  - evidence: memory/2026-08-04.md:3-6
+  - recalls: 0
+  - status: staged
+- Candidate: Continued unfinished work from GitHub Actions `Build Image` run `31015290751`, which failed in
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:3-3
+  - recalls: 0
+  - status: staged
+- Candidate: the quality job while compiling the newly added DDEX ERN 4.3.2 specs. The immediate errors were a missing `Data.Text.Text` import and missing `RecordWildCards` in `ParseSpec.hs`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:4-5
+  - recalls: 0
+  - status: staged
+- Candidate: Kept the repair isolated in worktree `.tmp/ddex-ui-typecheck-repair` on branch
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:6-6
+  - recalls: 0
+  - status: staged
+- Candidate: `fix/ddex-ui-typecheck` at `6f5ef3468`. No commit, push, PR, or other remote mutation was made.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:7-7
+  - recalls: 0
+  - status: staged
+- Candidate: Added the DDEX parser and business-rule specs to the main Hspec runner; they had been declared in
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:8-8
+  - recalls: 0
+  - status: staged
+- Candidate: Cabal but were not executed by `test/Spec.hs`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:9-9
+  - recalls: 0
+  - status: staged
+- Candidate: Fixed the DDEX parser to select the real XML document root instead of XML Light's `?xml`
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:10-10
+  - recalls: 0
+  - status: staged
+- Candidate: pseudo-element, match child elements by local name across the default DDEX namespace, follow nested required-field paths, and correctly parse party names, release references, deal terms, and ISO-8601 durations with omitted components.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:11-13
+  - recalls: 0
+  - status: staged
+- Candidate: Verification in the cached main checkout passed: HQ UI TypeScript typecheck, HQ executable Stack
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:14-14
+  - recalls: 0
+  - status: staged
+- Candidate: build, DDEX parser tests (20 examples), DDEX business-rule tests (11 examples), and the complete Haskell suite (2,272 examples). `git diff --check` also passed in the repair worktree.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:15-16
+  - recalls: 0
+  - status: staged
+- Candidate: Restored the temporary validation mirror from the main checkout after testing. Main was clean
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:17-17
+  - recalls: 0
+  - status: staged
+- Candidate: before this daily memory note was added; the code repair remains uncommitted only in the isolated worktree.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:18-19
+  - recalls: 0
+  - status: staged
+- Candidate: The continuous-improvement supervisor remains stopped/preflight-blocked because its config targets
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:20-20
+  - recalls: 0
+  - status: staged
+- Candidate: `main` while `allowPushToMain` is false. It was not restarted because doing so could create remote changes without explicit authorization.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:21-22
+  - recalls: 0
+  - status: staged
+- Candidate: Committed the DDEX repair as `061d5e25c584da855614bd7854758d767a489355`
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:23-23
+  - recalls: 0
+  - status: staged
+- Candidate: (`DDEX: Fix ERN parser and wire tests`) and pushed branch `fix/ddex-ui-typecheck` to `origin`. No PR was created and no branch workflow had started at verification time.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:24-25
+  - recalls: 0
+  - status: staged
+- Candidate: Detected the unfinished artist-promotion worktree `.tmp/artist-promotion-feature`, whose base was
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:26-26
+  - recalls: 0
+  - status: staged
+- Candidate: already an ancestor of `main` and 3,335 commits behind. Preserved that worktree unchanged and ported its changes into `.tmp/artist-promotion-report-current` on current-main branch `feat/artist-promotion-report`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:27-29
+  - recalls: 0
+  - status: staged
+- Candidate: Completed the artist-promotion integration with admin CRUD/report/PDF routes, the Label Artists
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:30-30
+  - recalls: 0
+  - status: staged
+- Candidate: schedule UI, backend/UI tests, documentation, and the registered production migration `2026-08-05_artist_promotion_slots`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:31-32
+  - recalls: 0
+  - status: staged
+- Candidate: Artist-promotion verification passed: focused UI tests (3), ESLint, TypeScript, production UI
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:33-33
+  - recalls: 0
+  - status: staged
+- Candidate: bundle, production-release contract tests (21), isolated promotion backend specs (4), isolated ServerAdmin specs (95), and the full Haskell executable build/link. The aggregate Haskell test target remains blocked on the DDEX test compile defect already fixed by the pushed DDEX br
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:34-36
+  - recalls: 0
+  - status: staged
+- Candidate: The artist-promotion branch remains local and uncommitted pending separate publication authority.; Diagnosed the Codex CLI `MCP startup interrupted` banner from `logs_2.sqlite`. The original
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:37-38
+  - recalls: 0
+  - status: staged
+- Candidate: launch occurred while Docker Desktop was unavailable; `codex_apps` and `openaiDeveloperDocs` initialized successfully and were later cancelled as the short-lived CLI process exited.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:39-40
+  - recalls: 0
+  - status: staged
+- Candidate: Fixed Docker MCP's blocked Git backend by adding the exact tdf-app workspace to
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:41-41
+  - recalls: 0
+  - status: staged
+- Candidate: `MCP_GATEWAY_DOCKER_BIND_ALLOW_WRITABLE_PATHS` under the global `MCP_DOCKER` environment. Backed up the prior config as `~/.codex/config.toml.pre-mcp-fix-20260805`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:42-43
+  - recalls: 0
+  - status: staged
+- Candidate: Verified unrestricted Codex Doctor connectivity, Docker MCP discovery of Playwright plus Git
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:44-44
+  - recalls: 0
+  - status: staged
+- Candidate: (34 backend tools), and a clean end-to-end Codex launch in which `MCP_DOCKER`, `codex_apps`, and `openaiDeveloperDocs` all initialized without startup, interruption, or unsafe-volume errors.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:45-46
+  - recalls: 0
+  - status: staged
+- Candidate: After authorization, committed the completed artist-promotion feature as
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:47-47
+  - recalls: 0
+  - status: staged
+- Candidate: `45bd44ec73787b71b491bcfb9a43c4cde1b62a59` (`Add artist promotion schedule reporting`) and pushed `feat/artist-promotion-report` to `origin`. The remote ref was verified at the exact SHA; no PR or branch workflow existed afterward.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:48-50
+  - recalls: 0
+  - status: staged
+- Candidate: A later unfinished-work audit found the detached platform-auth proof worktree clean and 5,170
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:51-51
+  - recalls: 0
+  - status: staged
+- Candidate: commits behind current `origin/main`, and the original artist-promotion worktree superseded by the published branch. The root internationalization batch was intentionally left untouched because five active Codex/Qwen processes had the root checkout as their working directory.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:52-54
+  - recalls: 0
+  - status: staged
+- Candidate: Audited all remote branches against `origin/main`. Six feature/fix branches were already fully
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:55-55
+  - recalls: 0
+  - status: staged
+- Candidate: contained in main; the only valuable unmerged work was `fix/ddex-ui-typecheck` and `feat/artist-promotion-report`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:56-57
+  - recalls: 0
+  - status: staged
+- Candidate: Created clean integration worktree `.tmp/integrate-valuable-branches-20260805` on local branch
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:58-58
+  - recalls: 0
+  - status: staged
+- Candidate: `integrate/valuable-branches-20260805`, based on `origin/main` at `6f5ef3468`, to avoid disturbing the concurrently edited root checkout.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:59-60
+  - recalls: 0
+  - status: staged
+- Candidate: Merged the DDEX branch in `c311478e1` and the artist-promotion branch in `ada8b9a02`. Resolved the
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:61-61
+  - recalls: 0
+  - status: staged
+- Candidate: sole conflict in `tdf-hq/test/Spec.hs` by retaining the API, DDEX parser/business-rule, artist promotion, and event discovery specs in the aggregate test runner.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:62-63
+  - recalls: 0
+  - status: staged
+- Candidate: The integrated branch is clean and four commits ahead of `origin/main`; both source branches are
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:64-64
+  - recalls: 0
+  - status: staged
+- Candidate: verified ancestors and `git diff --check` passes. Validation passed: production UI build, focused Label Artists tests (3), targeted artist-file ESLint, production-release tests (21), and the full Haskell suite (2,277 examples, zero failures). The integration branch remains local
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:65-68
+  - recalls: 0
+  - status: staged
+- Candidate: After explicit authorization, pushed `integrate/valuable-branches-20260805` to `origin` and
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:69-69
+  - recalls: 0
+  - status: staged
+- Candidate: verified the remote ref at exact merge SHA `ada8b9a02ca52232425a0f237324e2cfdacf8293`. GitHub reported no open PRs and no branch workflow runs; no PR was created.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:70-71
+  - recalls: 0
+  - status: staged
+- Candidate: The post-push audit found no local or remote branches outside the integration branch with unique
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:72-72
+  - recalls: 0
+  - status: staged
+- Candidate: committed work. The remaining unfinished batch is the large uncommitted internationalization change set in the root checkout. It was left untouched because three Codex sessions, three Codex code-mode hosts, and multiple Qwen processes currently have that checkout as their working
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:73-76
+  - recalls: 0
+  - status: staged
+- Candidate: Adopted all three running Qwen sessions by reading their persisted runtime metadata and final
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:77-77
+  - recalls: 0
+  - status: staged
+- Candidate: transcripts. Session `b15c00ed-e624-4a1d-842f-212512579948` had completed and pushed the DDEX implementation; `a9193ef4-def5-49c5-adc4-3c8d9424ac3b` had completed and pushed the storefront implementation before its follow-up hit the weekly quota; and `f511ae11-f234-41ad-9fbb-1d79
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:78-81
+  - recalls: 0
+  - status: staged
+- Candidate: `STOREFRONT-4`, with its final lint and TypeScript checks passing before the same quota error.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:82-82
+  - recalls: 0
+  - status: staged
+- Candidate: Gracefully stopped the three Qwen process groups and terminated their orphaned leaf workers after
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:83-83
+  - recalls: 0
+  - status: staged
+- Candidate: confirming there were no active child shell commands. Rechecked the process table and confirmed that no `qwen-code` process remains. Their JSONL transcripts and file-history snapshots remain available under `~/.qwen`; no working-tree files changed during shutdown.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:84-86
+  - recalls: 0
+  - status: staged
+- Candidate: Adopted the remaining internationalization Codex owner after confirming no live Qwen process
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:87-87
+  - recalls: 0
+  - status: staged
+- Candidate: remained. It published `0fa785aa8` (legacy date/currency localization) and `403380ad7` (locale-aware course and artist-promotion reports) on `codex/platform-internationalization-followup`; production web build and focused UI tests passed.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:88-90
+  - recalls: 0
+  - status: staged
+- Candidate: Added the missing `2026-08-05_platform_internationalization` entry to
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:91-91
+  - recalls: 0
+  - status: staged
+- Candidate: `scripts/production-migrations.json`. JSON parsing, migration-batch rendering, and `git diff --check` pass. Published it as `77c461f57` on the follow-up branch.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:92-93
+  - recalls: 0
+  - status: staged
+- Candidate: Finished the Haskell verification after the optimized Stack build released its lock. The full
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:94-94
+  - recalls: 0
+  - status: staged
+- Candidate: test suite compiled and linked; focused promotion, server-admin and standalone DDEX parser specs passed. Published the cleanup as `140c7842e`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:95-96
+  - recalls: 0
+  - status: staged
+- Candidate: Updated the public Domo del Pululahua page from the local `Kimi_Agent` prototype. The existing
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:97-97
+  - recalls: 0
+  - status: staged
+- Candidate: public URL and booking flow remain intact, while Naturaleza, Eventos, Música and Ceremonias now drive the hero video, facts, imagery, amenities, contact copy and suggested quote type. Synced the six source videos and six gallery assets. TypeScript, focused ESLint, production buil
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:98-101
+  - recalls: 0
+  - status: staged
+- Candidate: merged the full follow-up branch into `main` at `c768b8b2c`. GitHub safe-install/build/test and Datadog workflows passed, as did the Vercel deployment; Cloudflare was still reporting in progress at the last check.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:102-104
+  - recalls: 0
+  - status: staged
+- Candidate: Repaired the post-merge backend compile failure by restoring the Persistent `ArtistPromoSlot`
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:105-105
+  - recalls: 0
+  - status: staged
+- Candidate: entity and `TimeOfDay` import in `TDF.Models`. Verified a clean full Stack build/link in an isolated worktree, committed `02242fcd4` (`Restore artist promotion persistence model`), pushed it directly to `main` under explicit authorization, and confirmed it remains an ancestor of
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:106-109
+  - recalls: 0
+  - status: staged
+- Candidate: published successfully with manifest-list digest `sha256:f58ed4e51c26af5c6ea25b3e6ec8ccb3de8dc627d955b11880a3d998ccc9f759`. The subsequent backend merge at `48c2bde07` independently passed the same gates and published its image at digest `sha256:68b787d287d1390f1cf3176ba46c763765
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:110-113
+  - recalls: 0
+  - status: staged
+- Candidate: Continued platform internationalization on `codex/i18n-ui-extraction-followup`. Published
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:114-114
+  - recalls: 0
+  - status: staged
+- Candidate: `31ffcc908` with localized promo-code, refund, and shared pagination UI across en/es/fr/de/pt; refund responses now carry the original order currency and render through `Intl`. Backend production/test binaries compiled, the focused RefundDTO contract passed, focused web suites pa
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:115-118
+  - recalls: 0
+  - status: staged
+- Candidate: CPU-active without suite output for more than ten minutes; all suites reported before that point
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:119-119
+  - recalls: 0
+  - status: staged
+- Candidate: Published `4e60843eb` with localized artist fan lists and party-related history across all five
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:121-121
+  - recalls: 0
+  - status: staged
+- Candidate: locales, including compatibility with both canonical English and legacy Spanish relationship role values. Locale parity/interpolation tests, focused popover tests, and the production build passed. The branch and `origin/codex/i18n-ui-extraction-followup` both point to `4e60843eb`
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:122-124
+  - recalls: 0
+  - status: staged
+- Candidate: Diagnosed the production version mismatch shown on `/acerca`. The Web UI is current at `f8992bd`,
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:125-125
+  - recalls: 0
+  - status: staged
+- Candidate: but both Fly API Machines still run release `v2069`, source commit `393bf4fc`, and image digest `sha256:4664e57e556a75057732f6c971d9aca98bf73e524ec86c8b26573dbd587db273`. The latest backend image workflow at `352394ed` failed before Docker build on two ESLint errors; `5772c91b8`
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:126-129
+  - recalls: 0
+  - status: staged
+- Candidate: workflow. Successful images through `48c2bde07` were published but never promoted because the guarded Fly release lane is manual; the last attempted canary had also been rejected for missing Fly organization billing information.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:130-132
+  - recalls: 0
+  - status: staged
+- Candidate: Implemented city-subscription-based event discovery across Ticketmaster,
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:3-3
+  - recalls: 0
+  - status: staged
+- Candidate: Buen Plan Ecuador, and structured venue-owned iCalendar/JSON feeds.
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:4-4
+  - recalls: 0
+  - status: staged
+- Candidate: Event discovery now runs in isolated six-hour provider slots with a PostgreSQL
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:5-5
+  - recalls: 0
+  - status: staged
+- Candidate: leader lock, per-source health/error tracking, a 24-hour circuit-breaker cooldown after repeated failures, and a two-run missing-event grace period.
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:6-7
+  - recalls: 0
+  - status: staged
+- Candidate: Added canonical multi-source event matching so ticketing platforms can attach
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:8-8
+  - recalls: 0
+  - status: staged
+- Candidate: separate purchase options without duplicating the public event. Ticketmaster, Buen Plan, and venue sources use configurable priorities.
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:9-10
+  - recalls: 0
+  - status: staged
+- Candidate: Added country-aware event-city/subscription APIs and mobile UI. The Events tab
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:11-11
+  - recalls: 0
+  - status: staged
+- Candidate: defaults to subscribed cities, supports Explore-all and saved-event scopes, and lets users add/remove global cities by ISO-2 country code.
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:12-13
+  - recalls: 0
+  - status: staged
+- Candidate: Added mobile multi-platform purchase choices to event detail.; Added strict-admin source management APIs and the HQ page at
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:14-15
+  - recalls: 0
+  - status: staged
+- Candidate: `/configuracion/fuentes-eventos` for enabling providers and registering city-bound HTTPS iCalendar/JSON venue feeds.
+  - confidence: 0.62
+  - evidence: memory/2026-07-30.md:16-17
+  - recalls: 0
+  - status: staged

--- a/memory/dreaming/light/2026-08-09.md
+++ b/memory/dreaming/light/2026-08-09.md
@@ -1,0 +1,382 @@
+# Light Sleep
+
+- Candidate: Continued the feature-discoverability and authorization audit on `codex/feature-discoverability-audit-20260806` without touching production.; Root draft PR: https://github.com/diegueins680/tdf-app/pull/140. Mobile draft PR: https://github.com/diegueins680/TDF-mobile/pull/21.; Pus
+  - confidence: 0.62
+  - evidence: memory/2026-08-07.md:3-6
+  - recalls: 0
+  - status: staged
+- Candidate: Patched a newly published DOMPurify advisory to 3.4.13 after `CI Safe Install` exposed it; local `audit-ci`, clean installs, web/mobile tests, lint, type checks, web build, and Expo export pass.; Mobile PR checks are green. Root checks except the long quality gate are green at th
+  - confidence: 0.62
+  - evidence: memory/2026-08-07.md:7-10
+  - recalls: 0
+  - status: staged
+- Candidate: Audited local and `origin` feature/fix branches against `main`. All branches were already contained except `origin/agent/collaborative-event-creator` (PR #136).; Merged the collaborative event creator and event logistics work into local `main` with merge commit `b55cb29a387789473
+  - confidence: 0.62
+  - evidence: memory/2026-08-03.md:3-6
+  - recalls: 0
+  - status: staged
+- Candidate: Preserved the pre-existing untracked `DREAMS.md`, `memory/.dreams/`, and `memory/dreaming/` files.
+  - confidence: 0.62
+  - evidence: memory/2026-08-03.md:7-7
+  - recalls: 0
+  - status: staged
+- Candidate: With explicit authorization, pushed merge commit `b55cb29a3877894738b7b483d1c625809aae0c76` from local `main` to `origin/main` as a fast-forward. GitHub reported that the direct push bypassed the pull-request-only branch rule.; Verified local `main` and `origin/main` are identical after the push. PR #136 is now marked merged.; Post-push GitHub status: Datadog synthetic tests passed; `Build Image` and `CI Safe Install` started and were still in progress at handoff.; Left the existing `MEMORY.md` modification and untracked dreaming files untouched.
+  - confidence: 0.62
+  - evidence: memory/2026-08-04.md:3-6
+  - recalls: 0
+  - status: staged
+- Candidate: Continued unfinished work from GitHub Actions `Build Image` run `31015290751`, which failed in
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:3-3
+  - recalls: 0
+  - status: staged
+- Candidate: the quality job while compiling the newly added DDEX ERN 4.3.2 specs. The immediate errors were a missing `Data.Text.Text` import and missing `RecordWildCards` in `ParseSpec.hs`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:4-5
+  - recalls: 0
+  - status: staged
+- Candidate: Kept the repair isolated in worktree `.tmp/ddex-ui-typecheck-repair` on branch
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:6-6
+  - recalls: 0
+  - status: staged
+- Candidate: `fix/ddex-ui-typecheck` at `6f5ef3468`. No commit, push, PR, or other remote mutation was made.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:7-7
+  - recalls: 0
+  - status: staged
+- Candidate: Added the DDEX parser and business-rule specs to the main Hspec runner; they had been declared in
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:8-8
+  - recalls: 0
+  - status: staged
+- Candidate: Cabal but were not executed by `test/Spec.hs`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:9-9
+  - recalls: 0
+  - status: staged
+- Candidate: Fixed the DDEX parser to select the real XML document root instead of XML Light's `?xml`
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:10-10
+  - recalls: 0
+  - status: staged
+- Candidate: pseudo-element, match child elements by local name across the default DDEX namespace, follow nested required-field paths, and correctly parse party names, release references, deal terms, and ISO-8601 durations with omitted components.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:11-13
+  - recalls: 0
+  - status: staged
+- Candidate: Completed the feature discoverability and authorization audit in isolated worktree `.tmp/feature-discoverability-audit-20260806` on branch `codex/feature-discoverability-audit-20260806`.; Root draft PR: https://github.com/diegueins680/tdf-app/pull/140 (`1e1387d56`, `b662a813b`).
+  - confidence: 0.62
+  - evidence: memory/2026-08-06.md:3-6
+  - recalls: 0
+  - status: staged
+- Candidate: Production rollout remains blocked until a second coherent emergency-administrator path is verified, both PRs are reviewed through protected branches, encrypted backups are taken, historical seed credentials are rotated securely, and dependency findings plus remaining full-flow a
+  - confidence: 0.62
+  - evidence: memory/2026-08-06.md:7-7
+  - recalls: 0
+  - status: staged
+- Candidate: Verification in the cached main checkout passed: HQ UI TypeScript typecheck, HQ executable Stack
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:14-14
+  - recalls: 0
+  - status: staged
+- Candidate: build, DDEX parser tests (20 examples), DDEX business-rule tests (11 examples), and the complete Haskell suite (2,272 examples). `git diff --check` also passed in the repair worktree.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:15-16
+  - recalls: 0
+  - status: staged
+- Candidate: Restored the temporary validation mirror from the main checkout after testing. Main was clean
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:17-17
+  - recalls: 0
+  - status: staged
+- Candidate: before this daily memory note was added; the code repair remains uncommitted only in the isolated worktree.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:18-19
+  - recalls: 0
+  - status: staged
+- Candidate: The continuous-improvement supervisor remains stopped/preflight-blocked because its config targets
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:20-20
+  - recalls: 0
+  - status: staged
+- Candidate: `main` while `allowPushToMain` is false. It was not restarted because doing so could create remote changes without explicit authorization.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:21-22
+  - recalls: 0
+  - status: staged
+- Candidate: Committed the DDEX repair as `061d5e25c584da855614bd7854758d767a489355`
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:23-23
+  - recalls: 0
+  - status: staged
+- Candidate: (`DDEX: Fix ERN parser and wire tests`) and pushed branch `fix/ddex-ui-typecheck` to `origin`. No PR was created and no branch workflow had started at verification time.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:24-25
+  - recalls: 0
+  - status: staged
+- Candidate: Detected the unfinished artist-promotion worktree `.tmp/artist-promotion-feature`, whose base was
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:26-26
+  - recalls: 0
+  - status: staged
+- Candidate: already an ancestor of `main` and 3,335 commits behind. Preserved that worktree unchanged and ported its changes into `.tmp/artist-promotion-report-current` on current-main branch `feat/artist-promotion-report`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:27-29
+  - recalls: 0
+  - status: staged
+- Candidate: Completed the artist-promotion integration with admin CRUD/report/PDF routes, the Label Artists
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:30-30
+  - recalls: 0
+  - status: staged
+- Candidate: schedule UI, backend/UI tests, documentation, and the registered production migration `2026-08-05_artist_promotion_slots`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:31-32
+  - recalls: 0
+  - status: staged
+- Candidate: Artist-promotion verification passed: focused UI tests (3), ESLint, TypeScript, production UI
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:33-33
+  - recalls: 0
+  - status: staged
+- Candidate: bundle, production-release contract tests (21), isolated promotion backend specs (4), isolated ServerAdmin specs (95), and the full Haskell executable build/link. The aggregate Haskell test target remains blocked on the DDEX test compile defect already fixed by the pushed DDEX br
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:34-36
+  - recalls: 0
+  - status: staged
+- Candidate: The artist-promotion branch remains local and uncommitted pending separate publication authority.; Diagnosed the Codex CLI `MCP startup interrupted` banner from `logs_2.sqlite`. The original
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:37-38
+  - recalls: 0
+  - status: staged
+- Candidate: launch occurred while Docker Desktop was unavailable; `codex_apps` and `openaiDeveloperDocs` initialized successfully and were later cancelled as the short-lived CLI process exited.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:39-40
+  - recalls: 0
+  - status: staged
+- Candidate: Fixed Docker MCP's blocked Git backend by adding the exact tdf-app workspace to
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:41-41
+  - recalls: 0
+  - status: staged
+- Candidate: `MCP_GATEWAY_DOCKER_BIND_ALLOW_WRITABLE_PATHS` under the global `MCP_DOCKER` environment. Backed up the prior config as `~/.codex/config.toml.pre-mcp-fix-20260805`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:42-43
+  - recalls: 0
+  - status: staged
+- Candidate: Verified unrestricted Codex Doctor connectivity, Docker MCP discovery of Playwright plus Git
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:44-44
+  - recalls: 0
+  - status: staged
+- Candidate: (34 backend tools), and a clean end-to-end Codex launch in which `MCP_DOCKER`, `codex_apps`, and `openaiDeveloperDocs` all initialized without startup, interruption, or unsafe-volume errors.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:45-46
+  - recalls: 0
+  - status: staged
+- Candidate: After authorization, committed the completed artist-promotion feature as
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:47-47
+  - recalls: 0
+  - status: staged
+- Candidate: `45bd44ec73787b71b491bcfb9a43c4cde1b62a59` (`Add artist promotion schedule reporting`) and pushed `feat/artist-promotion-report` to `origin`. The remote ref was verified at the exact SHA; no PR or branch workflow existed afterward.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:48-50
+  - recalls: 0
+  - status: staged
+- Candidate: A later unfinished-work audit found the detached platform-auth proof worktree clean and 5,170
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:51-51
+  - recalls: 0
+  - status: staged
+- Candidate: commits behind current `origin/main`, and the original artist-promotion worktree superseded by the published branch. The root internationalization batch was intentionally left untouched because five active Codex/Qwen processes had the root checkout as their working directory.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:52-54
+  - recalls: 0
+  - status: staged
+- Candidate: Audited all remote branches against `origin/main`. Six feature/fix branches were already fully
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:55-55
+  - recalls: 0
+  - status: staged
+- Candidate: contained in main; the only valuable unmerged work was `fix/ddex-ui-typecheck` and `feat/artist-promotion-report`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:56-57
+  - recalls: 0
+  - status: staged
+- Candidate: Created clean integration worktree `.tmp/integrate-valuable-branches-20260805` on local branch
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:58-58
+  - recalls: 0
+  - status: staged
+- Candidate: `integrate/valuable-branches-20260805`, based on `origin/main` at `6f5ef3468`, to avoid disturbing the concurrently edited root checkout.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:59-60
+  - recalls: 0
+  - status: staged
+- Candidate: Merged the DDEX branch in `c311478e1` and the artist-promotion branch in `ada8b9a02`. Resolved the
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:61-61
+  - recalls: 0
+  - status: staged
+- Candidate: sole conflict in `tdf-hq/test/Spec.hs` by retaining the API, DDEX parser/business-rule, artist promotion, and event discovery specs in the aggregate test runner.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:62-63
+  - recalls: 0
+  - status: staged
+- Candidate: The integrated branch is clean and four commits ahead of `origin/main`; both source branches are
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:64-64
+  - recalls: 0
+  - status: staged
+- Candidate: verified ancestors and `git diff --check` passes. Validation passed: production UI build, focused Label Artists tests (3), targeted artist-file ESLint, production-release tests (21), and the full Haskell suite (2,277 examples, zero failures). The integration branch remains local
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:65-68
+  - recalls: 0
+  - status: staged
+- Candidate: After explicit authorization, pushed `integrate/valuable-branches-20260805` to `origin` and
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:69-69
+  - recalls: 0
+  - status: staged
+- Candidate: verified the remote ref at exact merge SHA `ada8b9a02ca52232425a0f237324e2cfdacf8293`. GitHub reported no open PRs and no branch workflow runs; no PR was created.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:70-71
+  - recalls: 0
+  - status: staged
+- Candidate: The post-push audit found no local or remote branches outside the integration branch with unique
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:72-72
+  - recalls: 0
+  - status: staged
+- Candidate: committed work. The remaining unfinished batch is the large uncommitted internationalization change set in the root checkout. It was left untouched because three Codex sessions, three Codex code-mode hosts, and multiple Qwen processes currently have that checkout as their working
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:73-76
+  - recalls: 0
+  - status: staged
+- Candidate: Adopted all three running Qwen sessions by reading their persisted runtime metadata and final
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:77-77
+  - recalls: 0
+  - status: staged
+- Candidate: transcripts. Session `b15c00ed-e624-4a1d-842f-212512579948` had completed and pushed the DDEX implementation; `a9193ef4-def5-49c5-adc4-3c8d9424ac3b` had completed and pushed the storefront implementation before its follow-up hit the weekly quota; and `f511ae11-f234-41ad-9fbb-1d79
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:78-81
+  - recalls: 0
+  - status: staged
+- Candidate: `STOREFRONT-4`, with its final lint and TypeScript checks passing before the same quota error.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:82-82
+  - recalls: 0
+  - status: staged
+- Candidate: Gracefully stopped the three Qwen process groups and terminated their orphaned leaf workers after
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:83-83
+  - recalls: 0
+  - status: staged
+- Candidate: confirming there were no active child shell commands. Rechecked the process table and confirmed that no `qwen-code` process remains. Their JSONL transcripts and file-history snapshots remain available under `~/.qwen`; no working-tree files changed during shutdown.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:84-86
+  - recalls: 0
+  - status: staged
+- Candidate: Adopted the remaining internationalization Codex owner after confirming no live Qwen process
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:87-87
+  - recalls: 0
+  - status: staged
+- Candidate: remained. It published `0fa785aa8` (legacy date/currency localization) and `403380ad7` (locale-aware course and artist-promotion reports) on `codex/platform-internationalization-followup`; production web build and focused UI tests passed.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:88-90
+  - recalls: 0
+  - status: staged
+- Candidate: Added the missing `2026-08-05_platform_internationalization` entry to
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:91-91
+  - recalls: 0
+  - status: staged
+- Candidate: `scripts/production-migrations.json`. JSON parsing, migration-batch rendering, and `git diff --check` pass. Published it as `77c461f57` on the follow-up branch.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:92-93
+  - recalls: 0
+  - status: staged
+- Candidate: Finished the Haskell verification after the optimized Stack build released its lock. The full
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:94-94
+  - recalls: 0
+  - status: staged
+- Candidate: test suite compiled and linked; focused promotion, server-admin and standalone DDEX parser specs passed. Published the cleanup as `140c7842e`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:95-96
+  - recalls: 0
+  - status: staged
+- Candidate: Updated the public Domo del Pululahua page from the local `Kimi_Agent` prototype. The existing
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:97-97
+  - recalls: 0
+  - status: staged
+- Candidate: public URL and booking flow remain intact, while Naturaleza, Eventos, Música and Ceremonias now drive the hero video, facts, imagery, amenities, contact copy and suggested quote type. Synced the six source videos and six gallery assets. TypeScript, focused ESLint, production buil
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:98-101
+  - recalls: 0
+  - status: staged
+- Candidate: merged the full follow-up branch into `main` at `c768b8b2c`. GitHub safe-install/build/test and Datadog workflows passed, as did the Vercel deployment; Cloudflare was still reporting in progress at the last check.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:102-104
+  - recalls: 0
+  - status: staged
+- Candidate: Repaired the post-merge backend compile failure by restoring the Persistent `ArtistPromoSlot`
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:105-105
+  - recalls: 0
+  - status: staged
+- Candidate: entity and `TimeOfDay` import in `TDF.Models`. Verified a clean full Stack build/link in an isolated worktree, committed `02242fcd4` (`Restore artist promotion persistence model`), pushed it directly to `main` under explicit authorization, and confirmed it remains an ancestor of
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:106-109
+  - recalls: 0
+  - status: staged
+- Candidate: published successfully with manifest-list digest `sha256:f58ed4e51c26af5c6ea25b3e6ec8ccb3de8dc627d955b11880a3d998ccc9f759`. The subsequent backend merge at `48c2bde07` independently passed the same gates and published its image at digest `sha256:68b787d287d1390f1cf3176ba46c763765
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:110-113
+  - recalls: 0
+  - status: staged
+- Candidate: Continued platform internationalization on `codex/i18n-ui-extraction-followup`. Published
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:114-114
+  - recalls: 0
+  - status: staged
+- Candidate: `31ffcc908` with localized promo-code, refund, and shared pagination UI across en/es/fr/de/pt; refund responses now carry the original order currency and render through `Intl`. Backend production/test binaries compiled, the focused RefundDTO contract passed, focused web suites pa
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:115-118
+  - recalls: 0
+  - status: staged
+- Candidate: CPU-active without suite output for more than ten minutes; all suites reported before that point
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:119-119
+  - recalls: 0
+  - status: staged
+- Candidate: Published `4e60843eb` with localized artist fan lists and party-related history across all five
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:121-121
+  - recalls: 0
+  - status: staged
+- Candidate: locales, including compatibility with both canonical English and legacy Spanish relationship role values. Locale parity/interpolation tests, focused popover tests, and the production build passed. The branch and `origin/codex/i18n-ui-extraction-followup` both point to `4e60843eb`
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:122-124
+  - recalls: 0
+  - status: staged
+- Candidate: Diagnosed the production version mismatch shown on `/acerca`. The Web UI is current at `f8992bd`,
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:125-125
+  - recalls: 0
+  - status: staged
+- Candidate: but both Fly API Machines still run release `v2069`, source commit `393bf4fc`, and image digest `sha256:4664e57e556a75057732f6c971d9aca98bf73e524ec86c8b26573dbd587db273`. The latest backend image workflow at `352394ed` failed before Docker build on two ESLint errors; `5772c91b8`
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:126-129
+  - recalls: 0
+  - status: staged
+- Candidate: workflow. Successful images through `48c2bde07` were published but never promoted because the guarded Fly release lane is manual; the last attempted canary had also been rejected for missing Fly organization billing information.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:130-132
+  - recalls: 0
+  - status: staged

--- a/memory/dreaming/light/2026-08-10.md
+++ b/memory/dreaming/light/2026-08-10.md
@@ -1,0 +1,77 @@
+# Light Sleep
+
+- Candidate: Audited local and `origin` feature/fix branches against `main`. All branches were already contained except `origin/agent/collaborative-event-creator` (PR #136).; Merged the collaborative event creator and event logistics work into local `main` with merge commit `b55cb29a387789473
+  - confidence: 0.62
+  - evidence: memory/2026-08-03.md:3-6
+  - recalls: 0
+  - status: staged
+- Candidate: Preserved the pre-existing untracked `DREAMS.md`, `memory/.dreams/`, and `memory/dreaming/` files.
+  - confidence: 0.62
+  - evidence: memory/2026-08-03.md:7-7
+  - recalls: 0
+  - status: staged
+- Candidate: With explicit authorization, pushed merge commit `b55cb29a3877894738b7b483d1c625809aae0c76` from local `main` to `origin/main` as a fast-forward. GitHub reported that the direct push bypassed the pull-request-only branch rule.; Verified local `main` and `origin/main` are identica
+  - confidence: 0.62
+  - evidence: memory/2026-08-04.md:3-6
+  - recalls: 0
+  - status: staged
+- Candidate: Continued unfinished work from GitHub Actions `Build Image` run `31015290751`, which failed in
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:3-3
+  - recalls: 0
+  - status: staged
+- Candidate: the quality job while compiling the newly added DDEX ERN 4.3.2 specs. The immediate errors were a missing `Data.Text.Text` import and missing `RecordWildCards` in `ParseSpec.hs`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:4-5
+  - recalls: 0
+  - status: staged
+- Candidate: Kept the repair isolated in worktree `.tmp/ddex-ui-typecheck-repair` on branch
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:6-6
+  - recalls: 0
+  - status: staged
+- Candidate: `fix/ddex-ui-typecheck` at `6f5ef3468`. No commit, push, PR, or other remote mutation was made.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:7-7
+  - recalls: 0
+  - status: staged
+- Candidate: Added the DDEX parser and business-rule specs to the main Hspec runner; they had been declared in
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:8-8
+  - recalls: 0
+  - status: staged
+- Candidate: Cabal but were not executed by `test/Spec.hs`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:9-9
+  - recalls: 0
+  - status: staged
+- Candidate: Fixed the DDEX parser to select the real XML document root instead of XML Light's `?xml`
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:10-10
+  - recalls: 0
+  - status: staged
+- Candidate: pseudo-element, match child elements by local name across the default DDEX namespace, follow nested required-field paths, and correctly parse party names, release references, deal terms, and ISO-8601 durations with omitted components.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:11-13
+  - recalls: 0
+  - status: staged
+- Candidate: Completed the feature discoverability and authorization audit in isolated worktree `.tmp/feature-discoverability-audit-20260806` on branch `codex/feature-discoverability-audit-20260806`.; Root draft PR: https://github.com/diegueins680/tdf-app/pull/140 (`1e1387d56`, `b662a813b`).
+  - confidence: 0.62
+  - evidence: memory/2026-08-06.md:3-6
+  - recalls: 0
+  - status: staged
+- Candidate: Production rollout remains blocked until a second coherent emergency-administrator path is verified, both PRs are reviewed through protected branches, encrypted backups are taken, historical seed credentials are rotated securely, and dependency findings plus remaining full-flow a
+  - confidence: 0.62
+  - evidence: memory/2026-08-06.md:7-7
+  - recalls: 0
+  - status: staged
+- Candidate: Continued the feature-discoverability and authorization audit on `codex/feature-discoverability-audit-20260806` without touching production.; Root draft PR: https://github.com/diegueins680/tdf-app/pull/140. Mobile draft PR: https://github.com/diegueins680/TDF-mobile/pull/21.; Pus
+  - confidence: 0.62
+  - evidence: memory/2026-08-07.md:3-6
+  - recalls: 0
+  - status: staged
+- Candidate: Patched a newly published DOMPurify advisory to 3.4.13 after `CI Safe Install` exposed it; local `audit-ci`, clean installs, web/mobile tests, lint, type checks, web build, and Expo export pass.; Mobile PR checks are green. Root checks except the long quality gate are green at th
+  - confidence: 0.62
+  - evidence: memory/2026-08-07.md:7-10
+  - recalls: 0
+  - status: staged

--- a/memory/dreaming/light/2026-08-11.md
+++ b/memory/dreaming/light/2026-08-11.md
@@ -1,0 +1,87 @@
+# Light Sleep
+
+- Candidate: With explicit authorization, pushed merge commit `b55cb29a3877894738b7b483d1c625809aae0c76` from local `main` to `origin/main` as a fast-forward. GitHub reported that the direct push bypassed the pull-request-only branch rule.; Verified local `main` and `origin/main` are identica
+  - confidence: 0.62
+  - evidence: memory/2026-08-04.md:3-6
+  - recalls: 0
+  - status: staged
+- Candidate: Continued unfinished work from GitHub Actions `Build Image` run `31015290751`, which failed in
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:3-3
+  - recalls: 0
+  - status: staged
+- Candidate: the quality job while compiling the newly added DDEX ERN 4.3.2 specs. The immediate errors were a missing `Data.Text.Text` import and missing `RecordWildCards` in `ParseSpec.hs`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:4-5
+  - recalls: 0
+  - status: staged
+- Candidate: Kept the repair isolated in worktree `.tmp/ddex-ui-typecheck-repair` on branch
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:6-6
+  - recalls: 0
+  - status: staged
+- Candidate: `fix/ddex-ui-typecheck` at `6f5ef3468`. No commit, push, PR, or other remote mutation was made.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:7-7
+  - recalls: 0
+  - status: staged
+- Candidate: Added the DDEX parser and business-rule specs to the main Hspec runner; they had been declared in
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:8-8
+  - recalls: 0
+  - status: staged
+- Candidate: Cabal but were not executed by `test/Spec.hs`.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:9-9
+  - recalls: 0
+  - status: staged
+- Candidate: Fixed the DDEX parser to select the real XML document root instead of XML Light's `?xml`
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:10-10
+  - recalls: 0
+  - status: staged
+- Candidate: pseudo-element, match child elements by local name across the default DDEX namespace, follow nested required-field paths, and correctly parse party names, release references, deal terms, and ISO-8601 durations with omitted components.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:11-13
+  - recalls: 0
+  - status: staged
+- Candidate: Verification in the cached main checkout passed: HQ UI TypeScript typecheck, HQ executable Stack
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:14-14
+  - recalls: 0
+  - status: staged
+- Candidate: build, DDEX parser tests (20 examples), DDEX business-rule tests (11 examples), and the complete Haskell suite (2,272 examples). `git diff --check` also passed in the repair worktree.
+  - confidence: 0.62
+  - evidence: memory/2026-08-05.md:15-16
+  - recalls: 0
+  - status: staged
+- Candidate: Completed the feature discoverability and authorization audit in isolated worktree `.tmp/feature-discoverability-audit-20260806` on branch `codex/feature-discoverability-audit-20260806`.; Root draft PR: https://github.com/diegueins680/tdf-app/pull/140 (`1e1387d56`, `b662a813b`).
+  - confidence: 0.62
+  - evidence: memory/2026-08-06.md:3-6
+  - recalls: 0
+  - status: staged
+- Candidate: - Production rollout remains blocked until a second coherent emergency-administrator path is verified, both PRs are reviewed through protected branches, encrypted backups are taken, historical seed credentials are rotated securely, and dependency findings plus remaining full-flow accessibility/E2E acceptance work are resolved.
+  - confidence: 0.62
+  - evidence: memory/2026-08-06.md:7-7
+  - recalls: 0
+  - status: staged
+- Candidate: Continued the feature-discoverability and authorization audit on `codex/feature-discoverability-audit-20260806` without touching production.; Root draft PR: https://github.com/diegueins680/tdf-app/pull/140. Mobile draft PR: https://github.com/diegueins680/TDF-mobile/pull/21.; Pushed root dependency-remediation commits `c919107c4` and `10f03a084`; pushed mobile commit `87d307f`.; Reduced root dependency audit from 23 findings (1 critical/17 high) to 13 (0 critical/7 high), and mobile from 52 (2 critical/18 high) to 16 moderate findings (0 critical/0 high).
+  - confidence: 0.62
+  - evidence: memory/2026-08-07.md:3-6
+  - recalls: 0
+  - status: staged
+- Candidate: Patched a newly published DOMPurify advisory to 3.4.13 after `CI Safe Install` exposed it; local `audit-ci`, clean installs, web/mobile tests, lint, type checks, web build, and Expo export pass.; Mobile PR checks are green. Root checks except the long quality gate are green at the time of this note; the superseded CI run was cancelled.; Production remains intentionally untouched because only one coherent emergency-administrator path is verified and the protected draft PRs are unmerged/unreviewed. Before rollout: verify a second emergency admin path, review/merge through protected branches, take encrypted authorization/preferences backups, then execute the documented bounded release plan.; Artist-enrichment PR #139 was marked ready for review at `d120aa39f`; it is mergeable but blocked by t
+  - confidence: 0.62
+  - evidence: memory/2026-08-07.md:7-10
+  - recalls: 0
+  - status: staged
+- Candidate: Audited local and `origin` feature/fix branches against `main`. All branches were already contained except `origin/agent/collaborative-event-creator` (PR #136).; Merged the collaborative event creator and event logistics work into local `main` with merge commit `b55cb29a387789473
+  - confidence: 0.62
+  - evidence: memory/2026-08-03.md:3-6
+  - recalls: 0
+  - status: staged
+- Candidate: Preserved the pre-existing untracked `DREAMS.md`, `memory/.dreams/`, and `memory/dreaming/` files.
+  - confidence: 0.62
+  - evidence: memory/2026-08-03.md:7-7
+  - recalls: 0
+  - status: staged

--- a/memory/dreaming/rem/2026-08-06.md
+++ b/memory/dreaming/rem/2026-08-06.md
@@ -1,0 +1,9 @@
+# REM Sleep
+
+### Reflections
+- No strong patterns surfaced.
+
+### Possible Lasting Truths
+- Audited local and `origin` feature/fix branches against `main`. All branches were already contained except `origin/agent/collaborative-event-creator` (PR #136).; Merged the collaborative event creator and event logistics work into local `main` with merge commit `b55cb29a387789473 [confidence=0.58 evidence=memory/2026-08-03.md:3-6]
+- Preserved the pre-existing untracked `DREAMS.md`, `memory/.dreams/`, and `memory/dreaming/` files. [confidence=0.58 evidence=memory/2026-08-03.md:7-7]
+- With explicit authorization, pushed merge commit `b55cb29a3877894738b7b483d1c625809aae0c76` from local `main` to `origin/main` as a fast-forward. GitHub reported that the direct push bypassed the pull-request-only branch rule.; Verified local `main` and `origin/main` are identica [confidence=0.51 evidence=memory/2026-08-04.md:3-6]

--- a/memory/dreaming/rem/2026-08-07.md
+++ b/memory/dreaming/rem/2026-08-07.md
@@ -1,0 +1,9 @@
+# REM Sleep
+
+### Reflections
+- No strong patterns surfaced.
+
+### Possible Lasting Truths
+- Audited local and `origin` feature/fix branches against `main`. All branches were already contained except `origin/agent/collaborative-event-creator` (PR #136).; Merged the collaborative event creator and event logistics work into local `main` with merge commit `b55cb29a387789473 [confidence=0.58 evidence=memory/2026-08-03.md:3-6]
+- Preserved the pre-existing untracked `DREAMS.md`, `memory/.dreams/`, and `memory/dreaming/` files. [confidence=0.58 evidence=memory/2026-08-03.md:7-7]
+- With explicit authorization, pushed merge commit `b55cb29a3877894738b7b483d1c625809aae0c76` from local `main` to `origin/main` as a fast-forward. GitHub reported that the direct push bypassed the pull-request-only branch rule.; Verified local `main` and `origin/main` are identica [confidence=0.58 evidence=memory/2026-08-04.md:3-6]

--- a/memory/dreaming/rem/2026-08-08.md
+++ b/memory/dreaming/rem/2026-08-08.md
@@ -1,0 +1,9 @@
+# REM Sleep
+
+### Reflections
+- No strong patterns surfaced.
+
+### Possible Lasting Truths
+- `fix/ddex-ui-typecheck` at `6f5ef3468`. No commit, push, PR, or other remote mutation was made. [confidence=0.58 evidence=memory/2026-08-05.md:7-7]
+- Added the DDEX parser and business-rule specs to the main Hspec runner; they had been declared in [confidence=0.58 evidence=memory/2026-08-05.md:8-8]
+- Cabal but were not executed by `test/Spec.hs`. [confidence=0.58 evidence=memory/2026-08-05.md:9-9]

--- a/memory/dreaming/rem/2026-08-09.md
+++ b/memory/dreaming/rem/2026-08-09.md
@@ -1,0 +1,9 @@
+# REM Sleep
+
+### Reflections
+- No strong patterns surfaced.
+
+### Possible Lasting Truths
+- `fix/ddex-ui-typecheck` at `6f5ef3468`. No commit, push, PR, or other remote mutation was made. [confidence=0.58 evidence=memory/2026-08-05.md:7-7]
+- Added the DDEX parser and business-rule specs to the main Hspec runner; they had been declared in [confidence=0.58 evidence=memory/2026-08-05.md:8-8]
+- Cabal but were not executed by `test/Spec.hs`. [confidence=0.58 evidence=memory/2026-08-05.md:9-9]

--- a/memory/dreaming/rem/2026-08-10.md
+++ b/memory/dreaming/rem/2026-08-10.md
@@ -1,0 +1,9 @@
+# REM Sleep
+
+### Reflections
+- No strong patterns surfaced.
+
+### Possible Lasting Truths
+- Completed the feature discoverability and authorization audit in isolated worktree `.tmp/feature-discoverability-audit-20260806` on branch `codex/feature-discoverability-audit-20260806`.; Root draft PR: https://github.com/diegueins680/tdf-app/pull/140 (`1e1387d56`, `b662a813b`). [confidence=0.58 evidence=memory/2026-08-06.md:3-6]
+- Continued the feature-discoverability and authorization audit on `codex/feature-discoverability-audit-20260806` without touching production.; Root draft PR: https://github.com/diegueins680/tdf-app/pull/140. Mobile draft PR: https://github.com/diegueins680/TDF-mobile/pull/21.; Pus [confidence=0.58 evidence=memory/2026-08-07.md:3-6]
+- Continued unfinished work from GitHub Actions `Build Image` run `31015290751`, which failed in [confidence=0.58 evidence=memory/2026-08-05.md:3-3]

--- a/memory/dreaming/rem/2026-08-11.md
+++ b/memory/dreaming/rem/2026-08-11.md
@@ -1,0 +1,8 @@
+# REM Sleep
+
+### Reflections
+- No strong patterns surfaced.
+
+### Possible Lasting Truths
+- build, DDEX parser tests (20 examples), DDEX business-rule tests (11 examples), and the complete Haskell suite (2,272 examples). `git diff --check` also passed in the repair worktree. [confidence=0.58 evidence=memory/2026-08-05.md:15-16]
+- Verification in the cached main checkout passed: HQ UI TypeScript typecheck, HQ executable Stack [confidence=0.58 evidence=memory/2026-08-05.md:14-14]

--- a/tdf-hq-ui/src/analytics/growthAttribution.test.ts
+++ b/tdf-hq-ui/src/analytics/growthAttribution.test.ts
@@ -1,0 +1,131 @@
+import {
+  __growthAttributionTestUtils,
+  captureGrowthAttribution,
+  captureGrowthEvent,
+  getGrowthAttribution,
+  growthAttributionProperties,
+} from './growthAttribution';
+import type { AnalyticsClient } from './posthog';
+
+const makeStorage = () => {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+    values,
+  };
+};
+
+describe('growth attribution', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('captures campaign and referral data without storing unrelated query parameters', () => {
+    const storage = makeStorage();
+    const attribution = captureGrowthAttribution({
+      search: '?utm_source=instagram&utm_medium=organic&utm_campaign=fundadores&ref=TDF-DIEGO&email=private@example.com',
+      pathname: '/tdf',
+      storage,
+      now: new Date('2026-08-07T12:00:00.000Z'),
+    });
+
+    expect(attribution).toEqual({
+      source: 'instagram',
+      medium: 'organic',
+      campaign: 'fundadores',
+      referralCode: 'TDF-DIEGO',
+      landingPath: '/tdf',
+      capturedAt: '2026-08-07T12:00:00.000Z',
+    });
+    expect(storage.values.get(__growthAttributionTestUtils.storageKey)).not.toContain('private@example.com');
+  });
+
+  it('keeps attribution while the visitor navigates without new campaign parameters', () => {
+    const storage = makeStorage();
+    captureGrowthAttribution({
+      search: '?utm_source=tiktok&utm_campaign=busco_musico',
+      pathname: '/tdf',
+      storage,
+      now: new Date('2026-08-07T12:00:00.000Z'),
+    });
+
+    const next = captureGrowthAttribution({
+      search: '?signup=1&roles=Fan',
+      pathname: '/login',
+      storage,
+      now: new Date('2026-08-07T13:00:00.000Z'),
+    });
+
+    expect(next.source).toBe('tiktok');
+    expect(next.campaign).toBe('busco_musico');
+    expect(next.landingPath).toBe('/tdf');
+    expect(next.capturedAt).toBe('2026-08-07T12:00:00.000Z');
+  });
+
+  it('refreshes attribution when a later explicit campaign is received', () => {
+    const storage = makeStorage();
+    captureGrowthAttribution({
+      search: '?utm_source=instagram&utm_campaign=first',
+      pathname: '/tdf',
+      storage,
+      now: new Date('2026-08-07T12:00:00.000Z'),
+    });
+    captureGrowthAttribution({
+      search: '?utm_source=whatsapp&utm_campaign=ambassadors',
+      pathname: '/login',
+      storage,
+      now: new Date('2026-08-08T12:00:00.000Z'),
+    });
+
+    expect(getGrowthAttribution(storage)).toMatchObject({
+      source: 'whatsapp',
+      campaign: 'ambassadors',
+      landingPath: '/login',
+      capturedAt: '2026-08-08T12:00:00.000Z',
+    });
+  });
+
+  it('flattens attribution into stable analytics properties', () => {
+    expect(growthAttributionProperties({
+      source: 'instagram',
+      referralCode: 'TDF-01',
+      landingPath: '/tdf',
+      capturedAt: '2026-08-07T12:00:00.000Z',
+    })).toEqual({
+      attribution_source: 'instagram',
+      referral_code: 'TDF-01',
+      attribution_landing_path: '/tdf',
+      attribution_captured_at: '2026-08-07T12:00:00.000Z',
+    });
+  });
+
+  it('adds attribution to growth events and lets event-specific properties win', () => {
+    const storage = makeStorage();
+    captureGrowthAttribution({
+      search: '?utm_source=instagram',
+      pathname: '/tdf',
+      storage,
+    });
+    const capture = jest.fn();
+    const analytics = {
+      ready: true,
+      capture,
+      identify: jest.fn(),
+      reset: jest.fn(),
+      page: jest.fn(),
+    } satisfies AnalyticsClient;
+
+    // Use an explicit browser-like storage entry because captureGrowthEvent reads browser storage.
+    window.localStorage.setItem(
+      __growthAttributionTestUtils.storageKey,
+      storage.values.get(__growthAttributionTestUtils.storageKey) ?? '',
+    );
+    captureGrowthEvent(analytics, 'signup_started', { route: '/login' });
+
+    expect(capture).toHaveBeenCalledWith('signup_started', expect.objectContaining({
+      attribution_source: 'instagram',
+      route: '/login',
+    }));
+  });
+});

--- a/tdf-hq-ui/src/analytics/growthAttribution.ts
+++ b/tdf-hq-ui/src/analytics/growthAttribution.ts
@@ -1,0 +1,144 @@
+import type { AnalyticsClient } from './posthog';
+
+const STORAGE_KEY = 'tdf:growth-attribution:v1';
+const MAX_VALUE_LENGTH = 160;
+
+const ATTRIBUTION_PARAM_MAP = {
+  utm_source: 'source',
+  utm_medium: 'medium',
+  utm_campaign: 'campaign',
+  utm_content: 'content',
+  utm_term: 'term',
+  ref: 'referralCode',
+  referral: 'referralCode',
+  referral_code: 'referralCode',
+} as const;
+
+export interface GrowthAttribution {
+  source?: string;
+  medium?: string;
+  campaign?: string;
+  content?: string;
+  term?: string;
+  referralCode?: string;
+  landingPath: string;
+  capturedAt: string;
+}
+
+interface CaptureGrowthAttributionOptions {
+  search: string;
+  pathname: string;
+  storage?: Pick<Storage, 'getItem' | 'setItem'> | null;
+  now?: Date;
+}
+
+const cleanValue = (value: string | null): string | undefined => {
+  const cleaned = value?.trim().replace(/[\u0000-\u001f\u007f]/g, '').slice(0, MAX_VALUE_LENGTH);
+  return cleaned ? cleaned : undefined;
+};
+
+const safePath = (pathname: string): string => {
+  const cleaned = cleanValue(pathname);
+  return cleaned?.startsWith('/') ? cleaned : '/';
+};
+
+const browserStorage = (): Pick<Storage, 'getItem' | 'setItem'> | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+};
+
+const parseStoredAttribution = (
+  storage: Pick<Storage, 'getItem'> | null,
+): GrowthAttribution | null => {
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<GrowthAttribution>;
+    if (typeof parsed.landingPath !== 'string' || typeof parsed.capturedAt !== 'string') return null;
+    return {
+      source: cleanValue(parsed.source ?? null),
+      medium: cleanValue(parsed.medium ?? null),
+      campaign: cleanValue(parsed.campaign ?? null),
+      content: cleanValue(parsed.content ?? null),
+      term: cleanValue(parsed.term ?? null),
+      referralCode: cleanValue(parsed.referralCode ?? null),
+      landingPath: safePath(parsed.landingPath),
+      capturedAt: parsed.capturedAt,
+    };
+  } catch {
+    return null;
+  }
+};
+
+export function captureGrowthAttribution({
+  search,
+  pathname,
+  storage = browserStorage(),
+  now = new Date(),
+}: CaptureGrowthAttributionOptions): GrowthAttribution {
+  const previous = parseStoredAttribution(storage);
+  const params = new URLSearchParams(search);
+  const incoming: Partial<GrowthAttribution> = {};
+
+  Object.entries(ATTRIBUTION_PARAM_MAP).forEach(([queryParam, property]) => {
+    const value = cleanValue(params.get(queryParam));
+    if (value) (incoming as Record<string, string>)[property] = value;
+  });
+
+  const hasIncomingCampaign = Object.keys(incoming).length > 0;
+  const attribution: GrowthAttribution = {
+    ...(hasIncomingCampaign ? {} : previous ?? {}),
+    ...incoming,
+    landingPath: hasIncomingCampaign || !previous ? safePath(pathname) : previous.landingPath,
+    capturedAt: hasIncomingCampaign || !previous ? now.toISOString() : previous.capturedAt,
+  };
+
+  try {
+    storage?.setItem(STORAGE_KEY, JSON.stringify(attribution));
+  } catch {
+    // Analytics attribution must never block navigation or signup.
+  }
+  return attribution;
+}
+
+export function getGrowthAttribution(
+  storage: Pick<Storage, 'getItem'> | null = browserStorage(),
+): GrowthAttribution | null {
+  return parseStoredAttribution(storage);
+}
+
+export function growthAttributionProperties(
+  attribution: GrowthAttribution | null = getGrowthAttribution(),
+): Record<string, string> {
+  if (!attribution) return {};
+  return {
+    ...(attribution.source ? { attribution_source: attribution.source } : {}),
+    ...(attribution.medium ? { attribution_medium: attribution.medium } : {}),
+    ...(attribution.campaign ? { attribution_campaign: attribution.campaign } : {}),
+    ...(attribution.content ? { attribution_content: attribution.content } : {}),
+    ...(attribution.term ? { attribution_term: attribution.term } : {}),
+    ...(attribution.referralCode ? { referral_code: attribution.referralCode } : {}),
+    attribution_landing_path: attribution.landingPath,
+    attribution_captured_at: attribution.capturedAt,
+  };
+}
+
+export function captureGrowthEvent(
+  analytics: AnalyticsClient,
+  event: string,
+  properties: Record<string, unknown> = {},
+): void {
+  analytics.capture(event, {
+    ...growthAttributionProperties(),
+    ...properties,
+  });
+}
+
+export const __growthAttributionTestUtils = {
+  storageKey: STORAGE_KEY,
+};

--- a/tdf-hq-ui/src/features/fans/useFanProfile.ts
+++ b/tdf-hq-ui/src/features/fans/useFanProfile.ts
@@ -14,9 +14,11 @@ const emptyFanProfileDraft: FanProfileUpdate = {
 export function useFanProfile({
   enabled,
   viewerId,
+  onProfileSaved,
 }: {
   enabled: boolean;
   viewerId: number | null;
+  onProfileSaved?: (profile: FanProfileUpdate) => void;
 }) {
   const qc = useQueryClient();
   const profileQuery = useQuery({
@@ -40,8 +42,9 @@ export function useFanProfile({
 
   const updateProfileMutation = useMutation({
     mutationFn: Fans.updateProfile,
-    onSuccess: () => {
+    onSuccess: (_profile, variables) => {
       void qc.invalidateQueries({ queryKey: ['fan-profile', viewerId] });
+      onProfileSaved?.(variables);
     },
   });
 

--- a/tdf-hq-ui/src/pages/FanHubPage.tsx
+++ b/tdf-hq-ui/src/pages/FanHubPage.tsx
@@ -65,6 +65,8 @@ import { FollowedArtists } from '../features/fans/FollowedArtists';
 import { ProfileSectionCard } from '../features/fans/ProfileSectionCard';
 import { useFanProfile } from '../features/fans/useFanProfile';
 import { FanClubPreview } from '../features/fanclubs/FanClubPreview';
+import { useAnalytics } from '../analytics/useAnalytics';
+import { captureGrowthEvent } from '../analytics/growthAttribution';
 
 const FAN_AVATAR_MAX_BYTES = 10 * 1024 * 1024; // 10 MB; keep in sync with UX copy below
 const ARTIST_CATALOG_INITIAL_ROWS_PER_PAGE: number = 3 * 4;
@@ -134,6 +136,7 @@ const FAN_HUB_RECOVERY_CARDS: CatalogRecoveryCard[] = [
 ];
 
 export default function FanHubPage({ focusArtist }: { focusArtist?: boolean }) {
+  const analytics = useAnalytics();
   const { session, login } = useSession();
   const navigate = useNavigate();
   const location = useLocation();
@@ -240,6 +243,13 @@ export default function FanHubPage({ focusArtist }: { focusArtist?: boolean }) {
   } = useFanProfile({
     enabled: Boolean(viewerId && isFan && hasAuthToken && !isHomeManagerView),
     viewerId,
+    onProfileSaved: (profile) => {
+      const completedFields = Object.values(profile).filter((value) => Boolean(String(value ?? '').trim())).length;
+      captureGrowthEvent(analytics, 'fan_profile_saved', {
+        party_id: viewerId,
+        completed_fields: completedFields,
+      });
+    },
   });
 
   const followsQuery = useQuery({
@@ -332,8 +342,14 @@ export default function FanHubPage({ focusArtist }: { focusArtist?: boolean }) {
 
   const updateArtistProfileMutation = useMutation({
     mutationFn: Fans.updateMyArtistProfile,
-    onSuccess: () => {
+    onSuccess: (_profile, payload) => {
       void qc.invalidateQueries({ queryKey: ['artist-profile', viewerId] });
+      const completedFields = Object.values(payload).filter((value) => Boolean(String(value ?? '').trim())).length;
+      captureGrowthEvent(analytics, 'artist_profile_saved', {
+        party_id: viewerId,
+        completed_fields: completedFields,
+        has_public_slug: Boolean(payload.apuSlug?.trim()),
+      });
       setArtistToast('Perfil de artista actualizado.');
     },
     onError: (error) => {
@@ -350,23 +366,33 @@ export default function FanHubPage({ focusArtist }: { focusArtist?: boolean }) {
       await qc.invalidateQueries({ queryKey: ['fan-follows', viewerId] });
     },
     onSuccess: () => {
+      captureGrowthEvent(analytics, 'fan_role_enabled', { party_id: viewerId });
       setFanRoleToast('Rol Fan activado. Refrescamos tu feed.');
     },
   });
 
   const followMutation = useMutation({
     mutationFn: (artistId: number) => Fans.follow(artistId),
-    onSuccess: () => {
+    onSuccess: (_follow, artistId) => {
       void qc.invalidateQueries({ queryKey: ['fan-follows', viewerId] });
       void qc.invalidateQueries({ queryKey: ['fan-artists'] });
+      captureGrowthEvent(analytics, 'artist_followed', {
+        party_id: viewerId,
+        artist_id: artistId,
+        is_first_follow: followsQuery.data?.length === 0,
+      });
     },
   });
 
   const unfollowMutation = useMutation({
     mutationFn: (artistId: number) => Fans.unfollow(artistId),
-    onSuccess: () => {
+    onSuccess: (_result, artistId) => {
       void qc.invalidateQueries({ queryKey: ['fan-follows', viewerId] });
       void qc.invalidateQueries({ queryKey: ['fan-artists'] });
+      captureGrowthEvent(analytics, 'artist_unfollowed', {
+        party_id: viewerId,
+        artist_id: artistId,
+      });
     },
   });
 

--- a/tdf-hq-ui/src/pages/LoginPage.tsx
+++ b/tdf-hq-ui/src/pages/LoginPage.tsx
@@ -56,6 +56,8 @@ import { buildSignupPayload, deriveEffectiveRoles, normalizeSignupRoles } from '
 import { parsePositiveSafeInt } from '../utils/ids';
 import { parseGoogleIdToken } from '../utils/googleIdToken';
 import { pickLandingPath, readSafeRedirectPath } from '../utils/loginRouting';
+import { useAnalytics } from '../analytics/useAnalytics';
+import { captureGrowthAttribution, captureGrowthEvent } from '../analytics/growthAttribution';
 
 const LANDING_LABELS: Record<string, string> = {
   '/configuracion/roles-permisos': 'Roles y permisos',
@@ -162,6 +164,7 @@ const parseNonNegativeSafeInt = (value: string): number | undefined => {
 
 export default function LoginPage() {
   const { t } = useTranslation();
+  const analytics = useAnalytics();
   const servicePreparingMessage = 'Estamos activando el servicio. Apenas termine podrás iniciar sesión.';
   const [identifier, setIdentifier] = useState('');
   const [password, setPassword] = useState('');
@@ -337,6 +340,19 @@ export default function LoginPage() {
   }, [location.search]);
 
   const appliedSignupPresetRef = useRef<string | null>(null);
+  const trackedAuthViewRef = useRef<string | null>(null);
+  useEffect(() => {
+    captureGrowthAttribution({ search: location.search, pathname: location.pathname });
+    const viewKey = `${location.pathname}${location.search}`;
+    if (trackedAuthViewRef.current === viewKey) return;
+    trackedAuthViewRef.current = viewKey;
+    captureGrowthEvent(analytics, 'auth_page_viewed', {
+      route: location.pathname,
+      signup_requested: signupPreset.openSignup,
+      preset_roles: signupPreset.roles,
+    });
+  }, [analytics, location.pathname, location.search, signupPreset.openSignup, signupPreset.roles]);
+
   useEffect(() => {
     if (!signupPreset.openSignup) return;
     if (appliedSignupPresetRef.current === location.search) return;
@@ -359,7 +375,13 @@ export default function LoginPage() {
     setFavoriteArtistIds([]);
     setClaimArtistId(signupPreset.claimArtistId);
     signupMutation.reset();
-  }, [location.search, signupPreset.claimArtistId, signupPreset.openSignup, signupPreset.roles, signupMutation]);
+    captureGrowthEvent(analytics, 'signup_started', {
+      route: '/login',
+      trigger: 'campaign_link',
+      preset_roles: signupPreset.roles,
+      has_artist_claim: Boolean(signupPreset.claimArtistId),
+    });
+  }, [analytics, location.search, signupPreset.claimArtistId, signupPreset.openSignup, signupPreset.roles, signupMutation]);
 
   const fanArtistsQuery = useQuery({
     queryKey: ['signup', 'artists'],
@@ -443,6 +465,7 @@ export default function LoginPage() {
     const normalizedIdentifier = identifier.trim();
     const normalizedPassword = password.trim();
     if (!normalizedIdentifier || !normalizedPassword) {
+      captureGrowthEvent(analytics, 'login_validation_failed', { reason: 'missing_credentials' });
       setFormError('Ingresa tu usuario o correo y la contraseña.');
       return;
     }
@@ -451,6 +474,7 @@ export default function LoginPage() {
       normalizedIdentifier.charAt(0).toUpperCase() + normalizedIdentifier.slice(1);
 
     try {
+      captureGrowthEvent(analytics, 'login_submitted', { method: 'password' });
       const response = await loginMutation.mutateAsync({
         username: normalizedIdentifier,
         password: normalizedPassword,
@@ -467,9 +491,15 @@ export default function LoginPage() {
       const targetPath = redirectPath ?? landingPath;
 
       login(nextSession, { remember: rememberDevice });
+      captureGrowthEvent(analytics, 'login_completed', {
+        method: 'password',
+        landing_path: targetPath,
+        roles: nextSession.roles,
+      });
       navigate(targetPath, { replace: true });
     } catch (error) {
       const message = error instanceof Error ? error.message : 'No se pudo iniciar sesión.';
+      captureGrowthEvent(analytics, 'login_failed', { method: 'password' });
       setFormError(message.trim() === '' ? 'No se pudo iniciar sesión.' : message);
     }
   };
@@ -513,11 +543,17 @@ export default function LoginPage() {
         const landingPath = pickLandingPath(nextSession.roles, nextSession.modules);
         const targetPath = redirectPath ?? landingPath;
         login(nextSession, { remember: rememberDevice });
+        captureGrowthEvent(analytics, 'authentication_completed', {
+          method: 'google',
+          landing_path: targetPath,
+          roles: nextSession.roles,
+        });
         setSignupDialogOpen(false);
         setSignupFeedback(null);
         navigate(targetPath, { replace: true });
       } catch (err) {
         const message = err instanceof Error ? err.message : 'No pudimos iniciar sesión con Google.';
+        captureGrowthEvent(analytics, 'authentication_failed', { method: 'google' });
         setGoogleError(message);
         if (signupDialogOpen) {
           setSignupFeedback({ type: 'error', message });
@@ -528,7 +564,7 @@ export default function LoginPage() {
         setGoogleStatus(null);
       }
     },
-    [buildResolvedSession, googleLoginMutation, login, navigate, redirectPath, rememberDevice, servicePreparing, signupDialogOpen],
+    [analytics, buildResolvedSession, googleLoginMutation, login, navigate, redirectPath, rememberDevice, servicePreparing, signupDialogOpen],
   );
 
   useEffect(() => {
@@ -683,9 +719,20 @@ export default function LoginPage() {
     setFavoriteArtistIds([]);
     setClaimArtistId(null);
     signupMutation.reset();
+    captureGrowthEvent(analytics, 'signup_started', {
+      route: '/login',
+      trigger: 'auth_page',
+      preset_roles: roles,
+      has_artist_claim: false,
+    });
   };
 
   const closeSignupDialog = () => {
+    captureGrowthEvent(analytics, 'signup_abandoned', {
+      route: '/login',
+      selected_roles: signupRoles,
+      selected_artist_count: favoriteArtistIds.length,
+    });
     setSignupDialogOpen(false);
     setSignupFeedback(null);
     setShowSignupPassword(false);
@@ -697,6 +744,7 @@ export default function LoginPage() {
 
   const handleSignupRoleChange = (event: SelectChangeEvent<SignupRole[]>) => {
     const nextRoles = normalizeSignupRoles(event.target.value);
+    captureGrowthEvent(analytics, 'signup_roles_selected', { roles: nextRoles });
     setSignupRoles(nextRoles);
     if (!nextRoles.includes('Fan')) {
       setFavoriteArtistIds([]);
@@ -705,17 +753,20 @@ export default function LoginPage() {
 
   const handleSignupSubmit = async () => {
     if (servicePreparing) {
+      captureGrowthEvent(analytics, 'signup_blocked', { reason: 'service_preparing' });
       setSignupFeedback({ type: 'error', message: servicePreparingMessage });
       return;
     }
 
     const claimIsValid = claimArtistId ? claimableArtists.some((artist) => artist.apArtistId === claimArtistId) : true;
     if (!claimIsValid) {
+      captureGrowthEvent(analytics, 'signup_validation_failed', { reason: 'artist_claim_unavailable' });
       setSignupFeedback({ type: 'error', message: 'El perfil seleccionado ya no está disponible para reclamar.' });
       return;
     }
 
     if (requiredHoursError) {
+      captureGrowthEvent(analytics, 'signup_validation_failed', { reason: 'invalid_internship_hours' });
       setSignupFeedback({ type: 'error', message: requiredHoursError });
       return;
     }
@@ -723,15 +774,23 @@ export default function LoginPage() {
     const payload = buildSignupPayload(signupForm, signupRoles, favoriteArtistIds, claimArtistId ?? undefined);
     const selectedRoles = payload.roles ?? [];
     if (!payload.email || !payload.password || (!payload.firstName && !payload.lastName)) {
+      captureGrowthEvent(analytics, 'signup_validation_failed', { reason: 'missing_required_fields' });
       setSignupFeedback({ type: 'error', message: 'Completa nombre, correo y una contraseña segura (8+ caracteres).' });
       return;
     }
     if (payload.password.length < 8) {
+      captureGrowthEvent(analytics, 'signup_validation_failed', { reason: 'password_too_short' });
       setSignupFeedback({ type: 'error', message: 'La contraseña debe tener al menos 8 caracteres.' });
       return;
     }
     setSignupFeedback(null);
     try {
+      captureGrowthEvent(analytics, 'signup_submitted', {
+        method: 'password',
+        selected_roles: selectedRoles,
+        selected_artist_count: favoriteArtistIds.length,
+        has_artist_claim: Boolean(claimArtistId),
+      });
       const response = await signupMutation.mutateAsync(payload);
       const effectiveRoles = deriveEffectiveRoles(response.roles, selectedRoles);
       const landingPath = pickLandingPath(effectiveRoles, response.modules);
@@ -747,6 +806,13 @@ export default function LoginPage() {
         partyId: response.partyId,
       });
       login(nextSession, { remember: rememberDevice });
+      captureGrowthEvent(analytics, 'signup_completed', {
+        method: 'password',
+        party_id: response.partyId,
+        roles: effectiveRoles,
+        selected_artist_count: selectedFanArtistIds.length,
+        landing_path: targetPath,
+      });
       if (shouldFollowArtists) {
         void Promise.all(
           selectedFanArtistIds.map((artistId) =>
@@ -758,6 +824,10 @@ export default function LoginPage() {
       }
       navigate(targetPath, { replace: true });
     } catch (err) {
+      captureGrowthEvent(analytics, 'signup_failed', {
+        method: 'password',
+        selected_roles: selectedRoles,
+      });
       setSignupFeedback({
         type: 'error',
         message: err instanceof Error ? err.message : 'No pudimos crear la cuenta. Intenta de nuevo.',

--- a/tdf-hq-ui/src/pages/TdfPlatformPage.tsx
+++ b/tdf-hq-ui/src/pages/TdfPlatformPage.tsx
@@ -25,10 +25,11 @@ import StorefrontIcon from '@mui/icons-material/Storefront';
 import { useQuery } from '@tanstack/react-query';
 import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, useLocation } from 'react-router-dom';
 
 import { Fans } from '../api/fans';
 import { useAnalytics } from '../analytics/useAnalytics';
+import { captureGrowthAttribution, captureGrowthEvent } from '../analytics/growthAttribution';
 import type { ArtistProfileDTO } from '../api/types';
 import { STUDIO_MAP_URL } from '../config/appConfig';
 import { recordings, releases } from '../constants/recordsContent';
@@ -618,6 +619,7 @@ function ArtistCarousel({
 }
 
 export default function TdfPlatformPage() {
+  const location = useLocation();
   const { t } = useTranslation();
   const analytics = useAnalytics();
   const heroVideoRef = useRef<HTMLVideoElement | null>(null);
@@ -647,8 +649,9 @@ export default function TdfPlatformPage() {
   }, []);
 
   useEffect(() => {
-    analytics.capture('acquisition_landing_viewed', { route: '/tdf' });
-  }, [analytics]);
+    captureGrowthAttribution({ search: location.search, pathname: location.pathname });
+    captureGrowthEvent(analytics, 'acquisition_landing_viewed', { route: '/tdf' });
+  }, [analytics, location.pathname, location.search]);
 
   const toggleHeroVideo = () => {
     const video = heroVideoRef.current;
@@ -795,7 +798,7 @@ export default function TdfPlatformPage() {
                 variant="contained"
                 size="large"
                 startIcon={<AccountCircleIcon />}
-                onClick={() => analytics.capture('acquisition_cta_clicked', { route: '/tdf', intent: 'general' })}
+                onClick={() => captureGrowthEvent(analytics, 'acquisition_cta_clicked', { route: '/tdf', intent: 'general' })}
                 sx={{
                   bgcolor: COLOR_TDF_GOLD,
                   color: COLOR_ON_GOLD,
@@ -813,7 +816,7 @@ export default function TdfPlatformPage() {
                 to={FAN_SIGNUP_PATH}
                 variant="outlined"
                 size="large"
-                onClick={() => analytics.capture('acquisition_cta_clicked', { route: '/tdf', intent: 'fan' })}
+                onClick={() => captureGrowthEvent(analytics, 'acquisition_cta_clicked', { route: '/tdf', intent: 'fan' })}
                 sx={{ color: COLOR_TEXT_PRIMARY, borderColor: COLOR_OUTLINE_ON_DARK, textTransform: 'none' }}
               >
                 {copy.fanProfile}
@@ -824,7 +827,7 @@ export default function TdfPlatformPage() {
                 to={ARTIST_SIGNUP_PATH}
                 variant="text"
                 size="large"
-                onClick={() => analytics.capture('acquisition_cta_clicked', { route: '/tdf', intent: 'artist' })}
+                onClick={() => captureGrowthEvent(analytics, 'acquisition_cta_clicked', { route: '/tdf', intent: 'artist' })}
                 sx={{ color: COLOR_CYAN_TEXT, textTransform: 'none' }}
               >
                 {copy.artistProfile}


### PR DESCRIPTION
## Resumen

Establece las bases técnicas y operativas para medir y lanzar el crecimiento de la comunidad TDF bajo el concepto **“Tu escena, conectada.”**

- añade atribución persistente para UTM y códigos de referido, con lista permitida de parámetros;
- propaga la atribución a los eventos de crecimiento sin almacenar correo, teléfono ni parámetros arbitrarios;
- instrumenta el recorrido desde landing y CTA hasta registro, perfil completado y primera relación artista–fan;
- documenta el contrato de analítica y los eventos canónicos;
- incluye pruebas de la lógica de atribución;
- incorpora la estrategia integral de 90 días, la economía STC propuesta, el plan tecnológico, el calendario editorial, guiones, presupuesto y experimentos.

## Eventos instrumentados

- `acquisition_landing_viewed`
- `acquisition_cta_clicked`
- `auth_page_viewed`
- `signup_started`
- `signup_roles_selected`
- `signup_submitted`
- `signup_completed`
- `signup_abandoned`
- `signup_validation_failed`
- `signup_failed`
- `fan_profile_saved`
- `artist_profile_saved`
- `fan_role_enabled`
- `artist_followed`
- `artist_unfollowed`

## Privacidad y seguridad

La atribución conserva únicamente parámetros aprobados (`utm_*` y `ref`). No guarda correos, teléfonos ni parámetros arbitrarios de la URL.

## Verificación

- [x] revisión específica de TypeScript en los archivos añadidos/modificados;
- [x] prueba funcional de atribución;
- [x] `git diff --check`;
- [x] árbol remoto verificado contra el commit local;
- [ ] suite y typecheck globales.

La verificación global no pudo completarse en el entorno de trabajo porque la instalación de dependencias recibió paquetes con checksums inválidos y quedó faltando `@fullcalendar/interaction`. No se declara el build global como aprobado.

## Fuera de alcance de este PR

El ledger general de STC, los referidos transaccionales, antifraude, insignias de Fundadores 500 y el dashboard de crecimiento están especificados en la estrategia, pero quedan para fases posteriores.