### PR TITLE
Fix internship playbook creation payloads

### DIFF
--- a/memory/2026-08-11.md
+++ b/memory/2026-08-11.md
@@ -1,0 +1,41 @@
+# 2026-08-11
+
+## Workstreams advanced
+
+### PR #141 — Community Attribution Foundations
+- Fixed missing `import { describe, it, expect, beforeEach, jest } from '@jest/globals'` in `growthAttribution.test.ts`
+- Fixed eslint `no-control-regex` error (intentional control-char stripping regex) and `prefer-nullish-coalescing` warning in `growthAttribution.ts`
+- Full suite: 129 suites, 1,552 tests passing
+- Both commits pushed to `origin/main` (`37520d045`, `8b930350a`)
+
+### PR #142 — Admin Operations Control Center
+- Merged into main by continuous-improvement-loop during session (`e555b65ac`)
+- All CI checks green (Cloudflare, Vercel, api-contracts, build, production-migrations, quality)
+- Code review completed — architecture strong, 16 issues documented (4 high, 8 medium, 4 low)
+- Key concerns before production enablement: `error` in toJson, `fail` in SQL monad producing 500s, hardcoded UUIDs, no integration tests for handlers/SQL
+
+### Production Readiness Assessment
+- Production intentionally frozen — Fly org billing blocker prevents canary deploys
+- Both PRs now merged; emergency-admin path still single-verified
+- 6 unregistered post-07-12 migrations need reconciliation in `production-migrations.json`
+- Operations Control Center runbook ready at `docs/operations-control-center/runbook.md`
+
+## PRs merged (by continuous-improvement-loop)
+- PR #140 (feature discoverability) — merged Aug 7
+- PR #141 (growth foundations) — merged today
+- PR #142 (admin operations) — merged today
+
+## Production blockers (priority order)
+1. Fly org billing — `diego-saa` org requires billing info
+2. Second emergency-administrator path needs verification
+3. Encrypted authorization/preferences backups
+4. Historical seed credential rotation
+5. Unregistered post-07-12 migrations reconciliation
+6. Dependency audit + accessibility/E2E acceptance
+
+### Prácticas playbook payload fix
+- Fixed the HQ "Generar plan base" flow: create-project and create-task requests now omit unset optional fields instead of sending `null`, matching the backend's strict create contract.
+- Tightened `InternProjectCreate` and `InternTaskCreate` UI types and added a regression covering the generated project plus all 12 tasks.
+- Verified the full `InternshipsPage` test file (14 tests), UI typecheck, targeted ESLint, and production build.
+- Published commit `51ef4ca5c` on `fix/internship-playbook-create-payloads`; Vercel and Cloudflare previews passed, and the public Cloudflare chunk was checked to confirm the corrected create payloads.
+- Opened draft PR #143. Its first CI run exposed two local form declarations that violated the repo's interface-only lint rule; fixed and pushed `adb66e93b`. The refreshed run has both builds, API contracts, migration checks, Cloudflare, and Vercel green while the long full-stack `quality` job remains in progress.

--- a/scripts/__tests__/logical-correctness-audit.test.mjs
+++ b/scripts/__tests__/logical-correctness-audit.test.mjs
@@ -96,6 +96,17 @@ test('logical audit ignores reachable catch blocks and returned object methods',
         '  };',
         '}',
         '',
+        'function validNestedCallback(values) {',
+        '  return values.map((value) => {',
+        '    return value * 2;',
+        '  }).join(",");',
+        '}',
+        '',
+        'useEffect(() => {',
+        '  register();',
+        '  return () => unregister();',
+        '}, []);',
+        '',
         'function invalid() {',
         '  return;',
         '  doCleanup();',
@@ -119,10 +130,71 @@ test('logical audit ignores reachable catch blocks and returned object methods',
       })),
       [
         {
-          line: 20,
+          line: 31,
           snippet: 'doCleanup();',
         },
       ],
+    );
+  } finally {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('logical audit recognizes idiomatic spaced Haskell catch-all patterns', async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'logical-audit-haskell-case-test-'));
+  const sourcePath = path.join(tempRoot, 'Cases.hs');
+
+  try {
+    await fs.writeFile(
+      sourcePath,
+      [
+        'module Cases where',
+        '',
+        'safeLookup value = case value of',
+        '  Just result -> result',
+        '  _ -> "fallback"',
+      ].join('\n'),
+      'utf8',
+    );
+
+    await execFileAsync('git', ['init', '-b', 'main'], { cwd: tempRoot });
+    await execFileAsync('git', ['add', 'Cases.hs'], { cwd: tempRoot });
+
+    const findings = await collectLogicalFindings(tempRoot);
+    assert.deepEqual(
+      findings.filter((finding) => finding.rule === 'incomplete-pattern-match'),
+      [],
+    );
+  } finally {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('logical audit defers to GHC when incomplete patterns are compiler errors', async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'logical-audit-haskell-ghc-test-'));
+  const sourcePath = path.join(tempRoot, 'CompilerChecked.hs');
+
+  try {
+    await fs.writeFile(
+      sourcePath,
+      [
+        '{-# OPTIONS_GHC -Werror=incomplete-patterns #-}',
+        'module CompilerChecked where',
+        '',
+        'render value = case value of',
+        '  Left message -> message',
+        '  Right result -> result',
+      ].join('\n'),
+      'utf8',
+    );
+
+    await execFileAsync('git', ['init', '-b', 'main'], { cwd: tempRoot });
+    await execFileAsync('git', ['add', 'CompilerChecked.hs'], { cwd: tempRoot });
+
+    const findings = await collectLogicalFindings(tempRoot);
+    assert.deepEqual(
+      findings.filter((finding) => finding.rule === 'incomplete-pattern-match'),
+      [],
     );
   } finally {
     await fs.rm(tempRoot, { recursive: true, force: true });

--- a/scripts/lib/logical-correctness-audit.mjs
+++ b/scripts/lib/logical-correctness-audit.mjs
@@ -270,6 +270,10 @@ function isPotentiallyReachableLine(trimmed) {
   );
 }
 
+function leadingWhitespaceLength(line) {
+  return line.match(/^\s*/)?.[0].length ?? 0;
+}
+
 // ─── JS/TS Logical Audits ───
 
 function auditJsTsLogical(source, filePath, isTest) {
@@ -508,6 +512,9 @@ function auditJsTsLogical(source, filePath, isTest) {
 
     const nextLine = lines[line] ?? '';
     const trimmed = nextLine.trim();
+    const closesNestedExpression = /^[}\])]/.test(trimmed)
+      && leadingWhitespaceLength(nextLine) < leadingWhitespaceLength(lines[line - 1] ?? '');
+    if (closesNestedExpression) continue;
     if (isPotentiallyReachableLine(trimmed)) {
       findings.push({
         rule: 'potentially-unreachable-code',
@@ -550,21 +557,27 @@ function auditHaskellLogical(source, filePath) {
   const findings = [];
   const lines = source.split(/\r?\n/);
 
-  // 1. Incomplete pattern matches (no exhaustive match)
-  const casePattern = /\bcase\b/g;
-  for (const match of source.matchAll(casePattern)) {
-    const line = lineNumberAt(source, match.index);
-    const surrounding = lines.slice(Math.max(0, line - 1), line + 5).join('\n');
-    if (!/_->/.test(surrounding) && !/otherwise\b/.test(surrounding)) {
-      findings.push({
-        rule: 'incomplete-pattern-match',
-        severity: 'error',
-        file: filePath,
-        line,
-        message: 'case expression may lack an exhaustive catch-all pattern (_ or otherwise).',
-        snippet: compactSnippet(lines[line - 1] ?? ''),
-        importance: scoreImportance('error', 1, 2),
-      });
+  // 1. Incomplete pattern matches (no exhaustive match). Prefer GHC's typed
+  // exhaustiveness checker when a module makes it fatal; the fallback below is
+  // necessarily conservative because source text cannot infer imported ADTs.
+  const compilerEnforcesCompletePatterns =
+    /\{-#\s*OPTIONS_GHC\b[^#]*-Werror=incomplete-patterns[^#]*#-}/.test(source);
+  if (!compilerEnforcesCompletePatterns) {
+    const casePattern = /\bcase\b/g;
+    for (const match of source.matchAll(casePattern)) {
+      const line = lineNumberAt(source, match.index);
+      const surrounding = lines.slice(Math.max(0, line - 1), line + 5).join('\n');
+      if (!/_\s*->/.test(surrounding) && !/otherwise\b/.test(surrounding)) {
+        findings.push({
+          rule: 'incomplete-pattern-match',
+          severity: 'error',
+          file: filePath,
+          line,
+          message: 'case expression may lack an exhaustive catch-all pattern (_ or otherwise).',
+          snippet: compactSnippet(lines[line - 1] ?? ''),
+          importance: scoreImportance('error', 1, 2),
+        });
+      }
     }
   }
 

--- a/tdf-hq-ui/src/api/types.ts
+++ b/tdf-hq-ui/src/api/types.ts
@@ -700,10 +700,10 @@ export interface InternProjectDTO {
 
 export interface InternProjectCreate {
   ipcTitle: string;
-  ipcDescription?: string | null;
-  ipcStatus?: string | null;
-  ipcStartAt?: string | null;
-  ipcDueAt?: string | null;
+  ipcDescription?: string;
+  ipcStatus?: string;
+  ipcStartAt?: string;
+  ipcDueAt?: string;
 }
 
 export interface InternProjectUpdate {
@@ -732,9 +732,9 @@ export interface InternTaskDTO {
 export interface InternTaskCreate {
   itcProjectId: string;
   itcTitle: string;
-  itcDescription?: string | null;
-  itcAssignedTo?: number | null;
-  itcDueAt?: string | null;
+  itcDescription?: string;
+  itcAssignedTo?: number;
+  itcDueAt?: string;
 }
 
 export interface InternTaskUpdate {

--- a/tdf-hq-ui/src/components/SidebarNav.tsx
+++ b/tdf-hq-ui/src/components/SidebarNav.tsx
@@ -731,16 +731,16 @@ export default function SidebarNav({ open, onNavigate }: SidebarNavProps) {
     return buildRegistryNavGroups(featureLocale).map((group) => ({
       ...group,
       items: group.items.flatMap((item) => {
-        const feature = getFeatureById(item.featureId);
-        if (!feature) return [];
-        const decision = evaluateFeatureAccess(feature, currentSession, 'discover');
+        const navFeature = getFeatureById(item.featureId);
+        if (!navFeature) return [];
+        const decision = evaluateFeatureAccess(navFeature, currentSession, 'discover');
         if (decision.state === 'concealed') return [];
         if (decision.state === 'allowed') return [item];
         const missingCategory = decision.missingModules[0] ?? decision.missingRoles[0] ?? 'permiso';
         return [{
           ...item,
           locked: true,
-          accessPath: accessRequestPath(feature, 'view'),
+          accessPath: accessRequestPath(navFeature, 'view'),
           missingAccess: `Requiere ${missingCategory} · ${REQUEST_ACCESS_LABEL}`,
         }];
       }),
@@ -790,8 +790,8 @@ export default function SidebarNav({ open, onNavigate }: SidebarNavProps) {
     });
     const localFallback = preferences.length === 0
       ? recentPaths.flatMap((path) => {
-          const item = itemByPath.get(path);
-          return item && path !== currentPath ? [{ ...item, shortcutKind: 'recent' as const }] : [];
+          const recentItem = itemByPath.get(path);
+          return recentItem && path !== currentPath ? [{ ...recentItem, shortcutKind: 'recent' as const }] : [];
         })
       : [];
     const seen = new Set<string>();
@@ -908,7 +908,7 @@ export default function SidebarNav({ open, onNavigate }: SidebarNavProps) {
   const handlePreferenceChange = (featureId: string, kind: 'favorite' | 'pinned') => {
     const current = preferenceMap.get(featureId);
     const pinnedPreferences = (navigationPreferences.query.data ?? []).filter((preference) => preference.pinned);
-    const next = {
+    const nextPreference = {
       featureId,
       favorite: kind === 'favorite' ? !current?.favorite : Boolean(current?.favorite),
       pinned: kind === 'pinned' ? !current?.pinned : Boolean(current?.pinned),
@@ -916,11 +916,11 @@ export default function SidebarNav({ open, onNavigate }: SidebarNavProps) {
         ? Math.max(-1, ...pinnedPreferences.map((preference) => preference.pinOrder ?? 0)) + 1
         : current?.pinned ? current.pinOrder ?? 0 : null,
     };
-    if (!next.pinned) next.pinOrder = null;
-    navigationPreferences.update.mutate(next);
+    if (!nextPreference.pinned) nextPreference.pinOrder = null;
+    navigationPreferences.update.mutate(nextPreference);
     getAnalyticsClient().capture(kind === 'favorite' ? 'feature_favorite_changed' : 'feature_pin_changed', {
       feature_id: featureId,
-      enabled: kind === 'favorite' ? next.favorite : next.pinned,
+      enabled: kind === 'favorite' ? nextPreference.favorite : nextPreference.pinned,
       platform: 'web',
     });
   };
@@ -932,13 +932,13 @@ export default function SidebarNav({ open, onNavigate }: SidebarNavProps) {
     const index = pinned.findIndex((preference) => preference.featureId === featureId);
     const swapIndex = index + direction;
     if (index < 0 || swapIndex < 0 || swapIndex >= pinned.length) return;
-    const current = pinned[index];
+    const currentPreference = pinned[index];
     const other = pinned[swapIndex];
-    if (!current || !other) return;
-    const currentOrder = current.pinOrder ?? index;
+    if (!currentPreference || !other) return;
+    const currentOrder = currentPreference.pinOrder ?? index;
     const otherOrder = other.pinOrder ?? swapIndex;
     void Promise.all([
-      navigationPreferences.update.mutateAsync({ ...current, pinOrder: otherOrder }),
+      navigationPreferences.update.mutateAsync({ ...currentPreference, pinOrder: otherOrder }),
       navigationPreferences.update.mutateAsync({ ...other, pinOrder: currentOrder }),
     ]);
   };

--- a/tdf-hq-ui/src/components/TopBar.tsx
+++ b/tdf-hq-ui/src/components/TopBar.tsx
@@ -148,26 +148,26 @@ export default function TopBar({ onToggleSidebar, sidebarOpen = true, toggleButt
   }, [quickNavItems, quickQuery]);
 
   const quickCreateItems = useMemo(() => {
-    const currentSession = {
+    const quickCreateSession = {
       authenticated: Boolean(session),
       roles: session?.roles,
       modules: session?.modules,
       featureFlags: session?.featureFlags,
     };
-    const english = featureLocale.toLowerCase().startsWith('en');
+    const usesEnglishLabels = featureLocale.toLowerCase().startsWith('en');
     return featureRegistry.flatMap((feature) => {
       if (!feature.quickCreate) return [];
       const action = feature.quickCreate.action;
-      const decision = evaluateFeatureAccess(feature, currentSession, action);
-      if (decision.state === 'concealed') return [];
+      const accessDecision = evaluateFeatureAccess(feature, quickCreateSession, action);
+      if (accessDecision.state === 'concealed') return [];
       return [{
         featureId: feature.id,
-        label: feature.quickCreate.label[english ? 'en' : 'es'],
-        locked: decision.state === 'locked',
-        destination: decision.state === 'locked'
+        label: feature.quickCreate.label[usesEnglishLabels ? 'en' : 'es'],
+        locked: accessDecision.state === 'locked',
+        destination: accessDecision.state === 'locked'
           ? accessRequestPath(feature, action)
           : feature.quickCreate.webDestination,
-        missingAccess: decision.missingModules[0] ?? decision.missingRoles[0] ?? null,
+        missingAccess: accessDecision.missingModules[0] ?? accessDecision.missingRoles[0] ?? null,
       }];
     });
   }, [featureLocale, session]);

--- a/tdf-hq-ui/src/features/featureRegistry.test.ts
+++ b/tdf-hq-ui/src/features/featureRegistry.test.ts
@@ -75,9 +75,9 @@ describe('featureRegistry', () => {
   });
 
   it('uses the exact action associated with actionable routes', () => {
-    const session = { authenticated: true, roles: ['Fan', 'Customer'], modules: ['Packages'] };
-    expect(evaluateFeatureAccess('artist.onboarding', session, 'view').state).toBe('allowed');
-    expect(evaluateFeatureAccess('artist.onboarding', session, 'create').state).not.toBe('allowed');
+    const actionSession = { authenticated: true, roles: ['Fan', 'Customer'], modules: ['Packages'] };
+    expect(evaluateFeatureAccess('artist.onboarding', actionSession, 'view').state).toBe('allowed');
+    expect(evaluateFeatureAccess('artist.onboarding', actionSession, 'create').state).not.toBe('allowed');
     expect(getFeatureByPath('/artista/crear')?.routeAction).toBe('create');
   });
 

--- a/tdf-hq-ui/src/features/featureRegistry.ts
+++ b/tdf-hq-ui/src/features/featureRegistry.ts
@@ -255,34 +255,34 @@ export function evaluateFeatureAccess(
   session: FeatureSession,
   action: FeatureAction = 'view',
 ): FeatureAccessDecision {
-  const feature = typeof featureOrId === 'string' ? getFeatureById(featureOrId) : featureOrId;
-  if (!feature) throw new Error(`Unknown feature: ${featureOrId as string}`);
+  const resolvedFeature = typeof featureOrId === 'string' ? getFeatureById(featureOrId) : featureOrId;
+  if (!resolvedFeature) throw new Error(`Unknown feature: ${featureOrId as string}`);
 
-  if (feature.technical || feature.maturity === 'incomplete' || feature.maturity === 'broken') {
-    return { state: 'concealed', feature, missingRoles: [], missingModules: [], reason: 'concealed' };
+  if (resolvedFeature.technical || resolvedFeature.maturity === 'incomplete' || resolvedFeature.maturity === 'broken') {
+    return { state: 'concealed', feature: resolvedFeature, missingRoles: [], missingModules: [], reason: 'concealed' };
   }
-  if (feature.requiredAuth === 'authenticated' && !session.authenticated) {
+  if (resolvedFeature.requiredAuth === 'authenticated' && !session.authenticated) {
     return {
-      state: feature.safeLockedDisclosure ? 'locked' : 'concealed',
-      feature,
+      state: resolvedFeature.safeLockedDisclosure ? 'locked' : 'concealed',
+      feature: resolvedFeature,
       missingRoles: [],
       missingModules: [],
       reason: 'authentication',
     };
   }
-  if (feature.featureFlag && !normalizedSet(session.featureFlags).has(normalizeFeatureToken(feature.featureFlag))) {
-    return { state: 'concealed', feature, missingRoles: [], missingModules: [], reason: 'feature-flag' };
+  if (resolvedFeature.featureFlag && !normalizedSet(session.featureFlags).has(normalizeFeatureToken(resolvedFeature.featureFlag))) {
+    return { state: 'concealed', feature: resolvedFeature, missingRoles: [], missingModules: [], reason: 'feature-flag' };
   }
 
   const roles = normalizedSet(session.roles);
   const modules = normalizedSet(session.modules);
-  const actionRule = feature.permissions[action];
+  const actionRule = resolvedFeature.permissions[action];
   if (!actionRule) {
-    return { state: 'concealed', feature, missingRoles: [], missingModules: [], reason: 'concealed' };
+    return { state: 'concealed', feature: resolvedFeature, missingRoles: [], missingModules: [], reason: 'concealed' };
   }
   const baseRule: AccessRule = {
-    ...(feature.requiredRoles.length > 0 ? { rolesAny: feature.requiredRoles } : {}),
-    ...(feature.requiredModules.length > 0 ? { modulesAll: feature.requiredModules } : {}),
+    ...(resolvedFeature.requiredRoles.length > 0 ? { rolesAny: resolvedFeature.requiredRoles } : {}),
+    ...(resolvedFeature.requiredModules.length > 0 ? { modulesAll: resolvedFeature.requiredModules } : {}),
   };
   const result = matchesRule(
     {
@@ -297,12 +297,12 @@ export function evaluateFeatureAccess(
   );
 
   if (result.allowed) {
-    return { state: 'allowed', feature, missingRoles: [], missingModules: [], reason: 'allowed' };
+    return { state: 'allowed', feature: resolvedFeature, missingRoles: [], missingModules: [], reason: 'allowed' };
   }
-  const state = feature.safeLockedDisclosure && feature.accessRequestEligible ? 'locked' : 'concealed';
+  const state = resolvedFeature.safeLockedDisclosure && resolvedFeature.accessRequestEligible ? 'locked' : 'concealed';
   return {
     state,
-    feature,
+    feature: resolvedFeature,
     missingRoles: result.missingRoles,
     missingModules: result.missingModules,
     reason: result.missingModules.length > 0 ? 'module' : 'role',
@@ -314,8 +314,8 @@ export function evaluatePathAccess(
   session: FeatureSession,
   action?: FeatureAction,
 ): FeatureAccessDecision | null {
-  const feature = getFeatureByPath(pathname);
-  return feature ? evaluateFeatureAccess(feature, session, action ?? feature.routeAction) : null;
+  const pathFeature = getFeatureByPath(pathname);
+  return pathFeature ? evaluateFeatureAccess(pathFeature, session, action ?? pathFeature.routeAction) : null;
 }
 
 export function featureLabel(feature: FeatureDefinition, locale: string | null | undefined): string {

--- a/tdf-hq-ui/src/pages/AccessRequestsPage.test.tsx
+++ b/tdf-hq-ui/src/pages/AccessRequestsPage.test.tsx
@@ -143,22 +143,22 @@ describe('internal access request flow', () => {
   });
 
   it('does not create requests for technical routes', async () => {
-    const view = await renderPage('/solicitudes-acceso/nueva?feature=technical.auth-login&action=view');
+    const technicalView = await renderPage('/solicitudes-acceso/nueva?feature=technical.auth-login&action=view');
     try {
-      expect(view.container.textContent).toContain('no admite solicitudes de acceso');
-      expect(view.container.querySelector('form')).toBeNull();
+      expect(technicalView.container.textContent).toContain('no admite solicitudes de acceso');
+      expect(technicalView.container.querySelector('form')).toBeNull();
       expect(createMock).not.toHaveBeenCalled();
     } finally {
-      await view.cleanup();
+      await technicalView.cleanup();
     }
   });
 
   it('has no serious automated accessibility violations in the request form', async () => {
-    const view = await renderPage('/solicitudes-acceso/nueva?feature=label.ddex.inbox&action=import');
+    const accessibilityView = await renderPage('/solicitudes-acceso/nueva?feature=label.ddex.inbox&action=import');
     try {
-      await expectNoSeriousAccessibilityViolations(view.container);
+      await expectNoSeriousAccessibilityViolations(accessibilityView.container);
     } finally {
-      await view.cleanup();
+      await accessibilityView.cleanup();
     }
   });
 });

--- a/tdf-hq-ui/src/pages/AccessRequestsPage.tsx
+++ b/tdf-hq-ui/src/pages/AccessRequestsPage.tsx
@@ -259,18 +259,19 @@ export function NewAccessRequestPage() {
   const requestedFeatureId = searchParams.get('feature')?.trim() ?? '';
   const actionParam = searchParams.get('action')?.trim().toLowerCase() ?? 'view';
   const action = supportedActions.has(actionParam as FeatureAction) ? actionParam as FeatureAction : null;
-  const feature = getFeatureById(requestedFeatureId);
-  const decision = feature && action
-    ? evaluateFeatureAccess(feature, {
+  const requestedFeature = getFeatureById(requestedFeatureId);
+  const decision = requestedFeature && action
+    ? evaluateFeatureAccess(requestedFeature, {
         authenticated: Boolean(session),
         roles: session?.roles,
         modules: session?.modules,
       }, action)
     : null;
-  const requestable = Boolean(feature && action && feature.accessRequestEligible && !feature.technical && decision?.state === 'locked');
+  const requestable = Boolean(requestedFeature && action && requestedFeature.accessRequestEligible
+    && !requestedFeature.technical && decision?.state === 'locked');
   const createMutation = useMutation({
     mutationFn: () => AccessRequests.create({
-      featureId: feature?.id ?? '',
+      featureId: requestedFeature?.id ?? '',
       action: action ?? 'view',
       justification: justification.trim() || null,
     }),
@@ -286,15 +287,15 @@ export function NewAccessRequestPage() {
   return (
     <Stack spacing={3} component="section" aria-labelledby="new-access-request-title" sx={{ maxWidth: 720 }}>
       <Typography id="new-access-request-title" variant="h4" component="h1">{text.createTitle}</Typography>
-      {!feature || !action || !feature.accessRequestEligible || feature.technical ? (
+      {!requestedFeature || !action || !requestedFeature.accessRequestEligible || requestedFeature.technical ? (
         <Alert severity="error">{text.missingTarget}</Alert>
       ) : null}
       {decision?.state === 'allowed' ? <Alert severity="info">{text.alreadyAllowed}</Alert> : null}
-      {decision?.state === 'locked' && feature ? (
+      {decision?.state === 'locked' && requestedFeature ? (
         <Card variant="outlined">
           <CardContent>
-            <Typography variant="h6" component="h2">{featureLabel(feature, locale)}</Typography>
-            <Typography>{feature.description[locale]}</Typography>
+            <Typography variant="h6" component="h2">{featureLabel(requestedFeature, locale)}</Typography>
+            <Typography>{requestedFeature.description[locale]}</Typography>
             <Typography sx={{ mt: 2 }}>
               <strong>{text.action}:</strong> {action}
             </Typography>
@@ -406,7 +407,7 @@ function ReviewCard({ request, onChanged }: { request: FeatureAccessRequestDTO; 
 
 export function AccessRequestReviewPage() {
   const { text } = useAccessCopy();
-  const queryClient = useQueryClient();
+  const reviewQueryClient = useQueryClient();
   const [status, setStatus] = useState<FeatureAccessRequestStatus>('pending');
   const reviewQuery = useQuery({
     queryKey: ['access-requests', 'review', status],
@@ -440,7 +441,7 @@ export function AccessRequestReviewPage() {
           <ReviewCard
             key={request.id}
             request={request}
-            onChanged={() => { void queryClient.invalidateQueries({ queryKey: ['access-requests'] }); }}
+            onChanged={() => { void reviewQueryClient.invalidateQueries({ queryKey: ['access-requests'] }); }}
           />
         ))}
       </Stack>

--- a/tdf-hq-ui/src/pages/ArtistEnrichmentReviewPage.tsx
+++ b/tdf-hq-ui/src/pages/ArtistEnrichmentReviewPage.tsx
@@ -43,7 +43,7 @@ interface EditDialogState {
 }
 
 const formatConfidence = (value?: number | null) =>
-  value == null ? '—' : `${Math.round(value * 100)}%`;
+  value === null || value === undefined ? '—' : `${Math.round(value * 100)}%`;
 
 const formatDate = (value?: string | null) =>
   value ? new Intl.DateTimeFormat('es-EC', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(value)) : '—';
@@ -100,7 +100,7 @@ export default function ArtistEnrichmentReviewPage() {
   };
 
   const runMutation = useMutation({
-    mutationFn: (targetArtistId: number | null) => targetArtistId == null
+    mutationFn: (targetArtistId: number | null) => targetArtistId === null
       ? ArtistEnrichment.run({ aerrMode: 'dry_run', aerrBatchSize: 50 })
       : ArtistEnrichment.rerunArtist(targetArtistId, { aerrMode: 'dry_run', aerrArtistId: targetArtistId, aerrBatchSize: 50 }),
     onSuccess: async (run) => {
@@ -153,7 +153,7 @@ export default function ArtistEnrichmentReviewPage() {
   const groupedPending = useMemo(() => {
     const groups = new Map<number, ArtistEnrichmentSuggestion[]>();
     pendingSuggestions.forEach((suggestion) => {
-      if (suggestion.aesArtistId == null) return;
+      if (suggestion.aesArtistId === null || suggestion.aesArtistId === undefined) return;
       groups.set(suggestion.aesArtistId, [...(groups.get(suggestion.aesArtistId) ?? []), suggestion]);
     });
     return groups;
@@ -183,7 +183,7 @@ export default function ArtistEnrichmentReviewPage() {
             onClick={() => runMutation.mutate(artistId)}
             disabled={runMutation.isPending}
           >
-            {artistId == null ? 'Auditar plataforma' : 'Auditar artista'}
+            {artistId === null ? 'Auditar plataforma' : 'Auditar artista'}
           </Button>
         </>
       )}
@@ -476,7 +476,7 @@ export default function ArtistEnrichmentReviewPage() {
                       )}
                       {candidate.aicStatus === 'pending' && (
                         <Stack spacing={1}>
-                          {candidate.aicArtistId == null && (
+                          {(candidate.aicArtistId === null || candidate.aicArtistId === undefined) && (
                             <FormControl size="small" sx={{ maxWidth: 420 }}>
                               <InputLabel id={`identity-target-${candidate.aicId}`}>Destino aprobado</InputLabel>
                               <Select
@@ -501,12 +501,13 @@ export default function ArtistEnrichmentReviewPage() {
                           <Button
                             variant="contained"
                             color="success"
-                            disabled={candidate.aicArtistId == null && !identityTargets[candidate.aicId]}
+                            disabled={(candidate.aicArtistId === null || candidate.aicArtistId === undefined)
+                              && !identityTargets[candidate.aicId]}
                             onClick={() => identityMutation.mutate({
                               candidateId: candidate.aicId,
                               decision: {
                                 aedDecision: 'approve',
-                                aedEditedValue: candidate.aicArtistId == null
+                                aedEditedValue: candidate.aicArtistId === null || candidate.aicArtistId === undefined
                                   ? identityTargets[candidate.aicId]
                                   : undefined,
                               },

--- a/tdf-hq-ui/src/pages/ArtistPublicPage.tsx
+++ b/tdf-hq-ui/src/pages/ArtistPublicPage.tsx
@@ -26,7 +26,7 @@ import { Fans } from '../api/fans';
 import type { ArtistReleaseDTO } from '../api/types';
 import { useSession } from '../session/SessionContext';
 import { getArtistHeroImage } from '../utils/artistFallbacks';
-import { parseArtistTextItems } from '../utils/artistProfileContent';
+import { parseArtistJson, parseArtistTextItems } from '../utils/artistProfileContent';
 import ArtistFansList from '../components/ArtistFansList';
 import LazyPaginatedList from '../components/LazyPaginatedList';
 import { formatDateForUser } from '../utils/formatters';
@@ -47,12 +47,10 @@ const ARTIST_PUBLIC_PAGE_DISPLAY_CONTRACTS = {
 
 const parseJsonObject = (raw?: string | null): Record<string, unknown> => {
   if (!raw) return {};
-  try {
-    const value: unknown = JSON.parse(raw);
-    return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
-  } catch {
-    return {};
-  }
+  const parsed = parseArtistJson(raw);
+  return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+    ? parsed as Record<string, unknown>
+    : {};
 };
 
 const parseOfficialLinks = (raw?: string | null) => Object.entries(parseJsonObject(raw))
@@ -60,34 +58,31 @@ const parseOfficialLinks = (raw?: string | null) => Object.entries(parseJsonObje
 
 const parseDiscography = (raw?: string | null) => {
   if (!raw) return [];
-  try {
-    const value: unknown = JSON.parse(raw);
-    if (Array.isArray(value)) {
-      return value.flatMap((item) => {
-        if (typeof item === 'string') return [{ title: item, detail: '' }];
-        if (!item || typeof item !== 'object') return [];
-        const record = item as Record<string, unknown>;
-        if (typeof record['title'] !== 'string') return [];
-        const detail = [record['type'], record['firstReleaseDate']]
-          .filter((part) => typeof part === 'string')
-          .join(' · ');
-        return [{ title: record['title'], detail }];
-      });
-    }
-  } catch {
-    // Legacy profiles may contain plain text rather than structured releases.
+  const parsedDiscography = parseArtistJson(raw);
+  if (Array.isArray(parsedDiscography)) {
+    return parsedDiscography.flatMap((item) => {
+      if (typeof item === 'string') return [{ title: item, detail: '' }];
+      if (!item || typeof item !== 'object') return [];
+      const releaseRecord = item as Record<string, unknown>;
+      if (typeof releaseRecord['title'] !== 'string') return [];
+      const detail = [releaseRecord['type'], releaseRecord['firstReleaseDate']]
+        .filter((part) => typeof part === 'string')
+        .join(' · ');
+      return [{ title: releaseRecord['title'], detail }];
+    });
   }
+  // Legacy profiles may contain plain text rather than structured releases.
   return [{ title: raw, detail: '' }];
 };
 
 const responsiveSourceSet = (raw: string | null | undefined, format: 'avif' | 'webp') => {
   const values = parseJsonObject(raw)[format];
   if (!Array.isArray(values)) return null;
-  const sourceSet = values.flatMap((value) => {
-    if (!value || typeof value !== 'object') return [];
-    const record = value as Record<string, unknown>;
-    return typeof record['url'] === 'string' && typeof record['width'] === 'number'
-      ? [`${record['url']} ${record['width']}w`]
+  const sourceSet = values.flatMap((sourceCandidate) => {
+    if (!sourceCandidate || typeof sourceCandidate !== 'object') return [];
+    const sourceRecord = sourceCandidate as Record<string, unknown>;
+    return typeof sourceRecord['url'] === 'string' && typeof sourceRecord['width'] === 'number'
+      ? [`${sourceRecord['url']} ${sourceRecord['width']}w`]
       : [];
   }).join(', ');
   return sourceSet || null;

--- a/tdf-hq-ui/src/pages/InternshipsPage.test.tsx
+++ b/tdf-hq-ui/src/pages/InternshipsPage.test.tsx
@@ -297,6 +297,39 @@ describe('InternshipsPage', () => {
     }
   });
 
+  it('omits unset optional fields when generating the playbook project and tasks', async () => {
+    createProjectMock.mockResolvedValue({ ipId: 'playbook-project' });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const { cleanup } = await renderPage(container);
+
+    try {
+      await waitForExpectation(() => {
+        expect(getButtonsByText(container, 'Generar plan base sin asignar')).toHaveLength(1);
+      });
+
+      await clickButton(getButtonsByText(container, 'Generar plan base sin asignar')[0]!);
+
+      await waitForExpectation(() => {
+        expect(createProjectMock).toHaveBeenCalledWith({
+          ipcTitle: 'Plan de prácticas',
+          ipcDescription: 'Plan base de prácticas con rotaciones, proyecto estrella y rituales de seguimiento.',
+          ipcStatus: 'active',
+        });
+        expect(createTaskMock).toHaveBeenCalledTimes(12);
+      });
+
+      for (const [payload] of createTaskMock.mock.calls) {
+        expect(payload).toEqual(expect.objectContaining({ itcProjectId: 'playbook-project' }));
+        expect(payload).not.toHaveProperty('itcAssignedTo');
+        expect(payload).not.toHaveProperty('itcDueAt');
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
   it('keeps the project form collapsed behind one CTA and one contextual empty state until an admin opens it', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);

--- a/tdf-hq-ui/src/pages/InternshipsPage.tsx
+++ b/tdf-hq-ui/src/pages/InternshipsPage.tsx
@@ -204,21 +204,21 @@ const normalizeOptionalInt = (value?: string | null) => {
   return parsed;
 };
 
-type InternProjectForm = {
+interface InternProjectForm {
   ipcTitle: string;
   ipcDescription: string;
   ipcStatus: string;
   ipcStartAt: string;
   ipcDueAt: string;
-};
+}
 
-type InternTaskForm = {
+interface InternTaskForm {
   itcProjectId: string;
   itcTitle: string;
   itcDescription: string;
   itcAssignedTo: number | null;
   itcDueAt: string;
-};
+}
 
 const buildEmptyTaskForm = (): InternTaskForm => ({
   itcProjectId: '',

--- a/tdf-hq-ui/src/pages/InternshipsPage.tsx
+++ b/tdf-hq-ui/src/pages/InternshipsPage.tsx
@@ -190,6 +190,11 @@ const normalizeOptional = (value?: string | null) => {
   return trimmed === '' ? null : trimmed;
 };
 
+const normalizeCreateOptional = (value?: string | null) => {
+  const trimmed = value?.trim() ?? '';
+  return trimmed === '' ? undefined : trimmed;
+};
+
 const normalizeOptionalInt = (value?: string | null) => {
   const trimmed = value?.trim() ?? '';
   if (trimmed === '') return null;
@@ -199,7 +204,23 @@ const normalizeOptionalInt = (value?: string | null) => {
   return parsed;
 };
 
-const buildEmptyTaskForm = (): InternTaskCreate => ({
+type InternProjectForm = {
+  ipcTitle: string;
+  ipcDescription: string;
+  ipcStatus: string;
+  ipcStartAt: string;
+  ipcDueAt: string;
+};
+
+type InternTaskForm = {
+  itcProjectId: string;
+  itcTitle: string;
+  itcDescription: string;
+  itcAssignedTo: number | null;
+  itcDueAt: string;
+};
+
+const buildEmptyTaskForm = (): InternTaskForm => ({
   itcProjectId: '',
   itcTitle: '',
   itcDescription: '',
@@ -239,7 +260,7 @@ export default function InternshipsPage() {
   const [checklistFeedback, setChecklistFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
   const [profileFeedback, setProfileFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
 
-  const [projectForm, setProjectForm] = useState<InternProjectCreate>({
+  const [projectForm, setProjectForm] = useState<InternProjectForm>({
     ipcTitle: '',
     ipcDescription: '',
     ipcStatus: 'active',
@@ -254,7 +275,7 @@ export default function InternshipsPage() {
     skills: '',
     areas: '',
   });
-  const [taskForm, setTaskForm] = useState<InternTaskCreate>(buildEmptyTaskForm);
+  const [taskForm, setTaskForm] = useState<InternTaskForm>(buildEmptyTaskForm);
   const [showTaskComposer, setShowTaskComposer] = useState(false);
   const [todoForm, setTodoForm] = useState<InternTodoCreate>({ itdcText: '' });
   const [permissionForm, setPermissionForm] = useState<InternPermissionCreate>(buildEmptyPermissionForm);
@@ -431,8 +452,6 @@ export default function InternshipsPage() {
           ipcTitle: projectTitle,
           ipcDescription: PLAYBOOK_PROJECT_DESCRIPTION,
           ipcStatus: 'active',
-          ipcStartAt: null,
-          ipcDueAt: null,
         });
         finalProjectId = project.ipId;
         projectCreated = true;
@@ -446,8 +465,7 @@ export default function InternshipsPage() {
             itcProjectId: finalProjectId,
             itcTitle: task.title,
             itcDescription: task.description,
-            itcAssignedTo: assigneeId,
-            itcDueAt: null,
+            ...(assigneeId != null ? { itcAssignedTo: assigneeId } : {}),
           }),
         ),
       );
@@ -1098,11 +1116,15 @@ export default function InternshipsPage() {
                 <Button
                   variant="contained"
                   onClick={() => {
-                    const payload = {
-                      ...projectForm,
-                      ipcDescription: normalizeOptional(projectForm.ipcDescription),
-                      ipcStartAt: normalizeOptional(projectForm.ipcStartAt),
-                      ipcDueAt: normalizeOptional(projectForm.ipcDueAt),
+                    const description = normalizeCreateOptional(projectForm.ipcDescription);
+                    const startAt = normalizeCreateOptional(projectForm.ipcStartAt);
+                    const dueAt = normalizeCreateOptional(projectForm.ipcDueAt);
+                    const payload: InternProjectCreate = {
+                      ipcTitle: projectForm.ipcTitle,
+                      ipcStatus: projectForm.ipcStatus,
+                      ...(description !== undefined ? { ipcDescription: description } : {}),
+                      ...(startAt !== undefined ? { ipcStartAt: startAt } : {}),
+                      ...(dueAt !== undefined ? { ipcDueAt: dueAt } : {}),
                     };
                     void createProjectMutation.mutateAsync(payload);
                   }}
@@ -1277,10 +1299,14 @@ export default function InternshipsPage() {
                 <Button
                   variant="contained"
                   onClick={() => {
-                    const payload = {
-                      ...taskForm,
-                      itcDescription: normalizeOptional(taskForm.itcDescription),
-                      itcDueAt: normalizeOptional(taskForm.itcDueAt),
+                    const description = normalizeCreateOptional(taskForm.itcDescription);
+                    const dueAt = normalizeCreateOptional(taskForm.itcDueAt);
+                    const payload: InternTaskCreate = {
+                      itcProjectId: taskForm.itcProjectId,
+                      itcTitle: taskForm.itcTitle,
+                      ...(description !== undefined ? { itcDescription: description } : {}),
+                      ...(taskForm.itcAssignedTo != null ? { itcAssignedTo: taskForm.itcAssignedTo } : {}),
+                      ...(dueAt !== undefined ? { itcDueAt: dueAt } : {}),
                     };
                     void createTaskMutation.mutateAsync(payload);
                   }}

--- a/tdf-hq-ui/src/pages/OperationsControlCenterPage.test.tsx
+++ b/tdf-hq-ui/src/pages/OperationsControlCenterPage.test.tsx
@@ -36,7 +36,7 @@ jest.unstable_mockModule('../api/operations', () => ({
     }),
     list: () => Promise.resolve({ items: [item], nextCursor: null, hasMore: false }),
     detail: () => Promise.resolve({ workItem: item, events: [], notes: [], allowedTransitions: ['seen'], sourceRecordUrl: null, quickActions: ['review'] }),
-    markSeen: () => new Promise(() => undefined),
+    markSeen: () => Promise.resolve(item),
     events: () => Promise.resolve({ events: [], lastEventId: null, retryAfterMs: 15000 }),
     savedViews: () => Promise.resolve([]),
     transition: jest.fn(), assign: jest.fn(), addNote: jest.fn(), saveView: jest.fn(),

--- a/tdf-hq-ui/src/pages/OperationsControlCenterPage.tsx
+++ b/tdf-hq-ui/src/pages/OperationsControlCenterPage.tsx
@@ -377,8 +377,8 @@ export default function OperationsControlCenterPage() {
           <KpiCard label={t('operations.kpi.revenueToday')} value={metrics ? currencyFormatter.format(metrics.revenueReceivedTodayMinor / 100) : '—'} />
           <KpiCard label={t('operations.kpi.unassigned')} value={metrics?.unassignedWork ?? '—'} critical />
           <KpiCard label={t('operations.kpi.slaBreaches')} value={metrics?.slaBreaches ?? '—'} critical />
-          <KpiCard label={t('operations.kpi.firstResponse')} value={metrics?.averageFirstResponseSeconds == null ? '—' : `${Math.round(metrics.averageFirstResponseSeconds / 60)} min`} />
-          <KpiCard label={t('operations.kpi.resolution')} value={metrics?.averageResolutionSeconds == null ? '—' : `${Math.round(metrics.averageResolutionSeconds / 3600)} h`} />
+          <KpiCard label={t('operations.kpi.firstResponse')} value={metrics?.averageFirstResponseSeconds === null || metrics?.averageFirstResponseSeconds === undefined ? '—' : `${Math.round(metrics.averageFirstResponseSeconds / 60)} min`} />
+          <KpiCard label={t('operations.kpi.resolution')} value={metrics?.averageResolutionSeconds === null || metrics?.averageResolutionSeconds === undefined ? '—' : `${Math.round(metrics.averageResolutionSeconds / 3600)} h`} />
           <KpiCard label={t('operations.kpi.integrationFailures')} value={metrics?.integrationFailures ?? '—'} critical />
           <KpiCard label={t('operations.kpi.unpaidInvoices')} value={metrics?.unpaidInvoices ?? '—'} />
         </Box>
@@ -472,9 +472,9 @@ export default function OperationsControlCenterPage() {
                   edge="start"
                   checked={checkedIds.has(item.id)}
                   onChange={(event) => setCheckedIds((current) => {
-                    const updated = new Set(current);
-                    if (event.target.checked) updated.add(item.id); else updated.delete(item.id);
-                    return updated;
+                    const inboxSelection = new Set(current);
+                    if (event.target.checked) inboxSelection.add(item.id); else inboxSelection.delete(item.id);
+                    return inboxSelection;
                   })}
                   inputProps={{ 'aria-label': t('operations.selectItem', { title: localizedTitle(item) }) }}
                   sx={{ ml: 1 }}

--- a/tdf-hq-ui/src/utils/artistProfileContent.test.ts
+++ b/tdf-hq-ui/src/utils/artistProfileContent.test.ts
@@ -1,4 +1,4 @@
-import { parseArtistTextItems } from './artistProfileContent';
+import { parseArtistJson, parseArtistTextItems } from './artistProfileContent';
 
 describe('parseArtistTextItems', () => {
   it('renders structured artist content as individual items', () => {
@@ -12,5 +12,10 @@ describe('parseArtistTextItems', () => {
     expect(parseArtistTextItems('Legacy achievement')).toEqual(['Legacy achievement']);
     expect(parseArtistTextItems('["Verified",7,null,""]')).toEqual(['Verified']);
     expect(parseArtistTextItems(null)).toEqual([]);
+  });
+
+  it('handles malformed JSON without throwing or discarding legacy content', () => {
+    expect(parseArtistJson('{"unfinished":')).toBeUndefined();
+    expect(parseArtistTextItems('{"unfinished":')).toEqual(['{"unfinished":']);
   });
 });

--- a/tdf-hq-ui/src/utils/artistProfileContent.ts
+++ b/tdf-hq-ui/src/utils/artistProfileContent.ts
@@ -1,12 +1,17 @@
+export const parseArtistJson = (raw: string): unknown => {
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return undefined;
+  }
+};
+
 export const parseArtistTextItems = (raw?: string | null): string[] => {
   if (!raw) return [];
-  try {
-    const value: unknown = JSON.parse(raw);
-    if (Array.isArray(value)) {
-      return value.filter((item): item is string => typeof item === 'string' && item.trim() !== '');
-    }
-  } catch {
-    // Legacy artist profiles store these values as plain text.
+  const parsed = parseArtistJson(raw);
+  if (Array.isArray(parsed)) {
+    return parsed.filter((item): item is string => typeof item === 'string' && item.trim() !== '');
   }
+  // Legacy artist profiles store these values as plain text.
   return [raw];
 };

--- a/tdf-hq/sql/2026-08-09_admin_operations_control_center.sql
+++ b/tdf-hq/sql/2026-08-09_admin_operations_control_center.sql
@@ -1784,7 +1784,9 @@ BEGIN
 
   IF NOT p_dry_run THEN
     FOR source IN
-      SELECT * FROM (
+      SELECT entity_type, entity_id, correlation_key, occurred_at,
+        priority, title_es, title_en, metadata
+      FROM (
         SELECT 'course_registration'::text AS entity_type, id::text AS entity_id,
           'course_registration:' || id::text AS correlation_key, created_at AS occurred_at,
           'high'::text AS priority, 'Inscripción existente requiere atención'::text AS title_es,

--- a/tdf-hq/sql/2026-08-09_admin_operations_control_center_rollback.sql
+++ b/tdf-hq/sql/2026-08-09_admin_operations_control_center_rollback.sql
@@ -2,8 +2,10 @@ BEGIN;
 
 -- Safe rollback: stop visibility, capture, and provider delivery while retaining
 -- all events, work, approvals, delivery attempts, and immutable audit evidence.
-UPDATE operations_organization SET operations_enabled = FALSE, updated_at = now();
-UPDATE operations_provider_config SET enabled = FALSE, updated_at = now();
+UPDATE operations_organization SET operations_enabled = FALSE, updated_at = now()
+WHERE operations_enabled IS DISTINCT FROM FALSE;
+UPDATE operations_provider_config SET enabled = FALSE, updated_at = now()
+WHERE enabled IS DISTINCT FROM FALSE;
 
 DROP TRIGGER IF EXISTS operations_course_registration_capture ON course_registration;
 DROP TRIGGER IF EXISTS operations_booking_capture ON booking;

--- a/tdf-hq/src/TDF/Artists/Enrichment.hs
+++ b/tdf-hq/src/TDF/Artists/Enrichment.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -Werror=incomplete-patterns #-}
 
 module TDF.Artists.Enrichment
   ( DiscoveryReference(..)

--- a/tdf-hq/src/TDF/DDEX/DB.hs
+++ b/tdf-hq/src/TDF/DDEX/DB.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Werror=incomplete-patterns #-}
 
 module TDF.DDEX.DB
   ( -- * Documents

--- a/tdf-hq/src/TDF/FeatureRegistry.hs
+++ b/tdf-hq/src/TDF/FeatureRegistry.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -Werror=incomplete-patterns #-}
 
 module TDF.FeatureRegistry
   ( FeatureRule(..)

--- a/tdf-hq/src/TDF/Operations/Server.hs
+++ b/tdf-hq/src/TDF/Operations/Server.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Werror=incomplete-patterns #-}
 
 module TDF.Operations.Server (operationsServer) where
 
@@ -12,7 +13,7 @@ import Control.Exception (SomeException, displayException, try)
 import Control.Monad (forM_, unless, when)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Reader (ReaderT, ask)
-import Data.Aeson (FromJSON, ToJSON, Value, decodeStrict', encode)
+import Data.Aeson (FromJSON, ToJSON(..), Value, decodeStrict', encode)
 import qualified Data.ByteString.Lazy as BL
 import Data.Int (Int64)
 import Data.List (find)
@@ -355,10 +356,10 @@ validateCursor (Just raw) = case T.breakOnEnd "|" raw of
   where invalid = throwError err400 {errBody = "Invalid cursor"}
 
 cursorForLast :: [Ops.WorkItemDTO] -> Maybe Text
-cursorForLast [] = Nothing
-cursorForLast values =
-  let item = last values
-  in Just (T.pack (show (item.updatedAt)) <> "|" <> UUID.toText (item.id))
+cursorForLast = fmap renderCursor . foldl' (\_ item -> Just item) Nothing
+  where
+    renderCursor :: Ops.WorkItemDTO -> Text
+    renderCursor item = T.pack (show (item.updatedAt)) <> "|" <> UUID.toText (item.id)
 
 metricsHandler :: AuthedUser -> Maybe UUID -> Maybe UUID -> OperationsM Ops.OperationsMetricsDTO
 metricsHandler user organizationFilter branchFilter = do
@@ -947,7 +948,7 @@ createPushSubscriptionHandler user command = do
     _ -> throwError err503 {errBody = "Push token encryption is not configured"}
 
 toJson :: ToJSON value => value -> Value
-toJson value = fromMaybe (error "JSON encoding failed") (decodeStrict' (BL.toStrict (encode value)))
+toJson = toJSON
 
 conflict :: OperationsM a
 conflict = throwError err409 {errBody = "Work item changed; refresh and retry"}

--- a/tdf-hq/src/TDF/Operations/Types.hs
+++ b/tdf-hq/src/TDF/Operations/Types.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Werror=incomplete-patterns #-}
 
 module TDF.Operations.Types
   ( WorkStatus(..)

--- a/tdf-hq/src/TDF/Operations/Worker.hs
+++ b/tdf-hq/src/TDF/Operations/Worker.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Werror=incomplete-patterns #-}
 
 module TDF.Operations.Worker
   ( OperationsWorkerStats(..)

--- a/tdf-hq/src/TDF/Seed.hs
+++ b/tdf-hq/src/TDF/Seed.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -Werror=incomplete-patterns #-}
 
 module TDF.Seed where
 

--- a/tdf-hq/src/TDF/Server/DDEX.hs
+++ b/tdf-hq/src/TDF/Server/DDEX.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -Werror=incomplete-patterns #-}
 
 module TDF.Server.DDEX (ddexServer, validateDdexAccess) where
 

--- a/tdf-hq/test/Spec.hs
+++ b/tdf-hq/test/Spec.hs
@@ -984,6 +984,20 @@ main = hspec $ do
             migration `shouldContain` "UPDATE booking SET title = 'Booking'\nWHERE title IS NULL;"
             migration `shouldNotContain` "UPDATE booking SET title = COALESCE(title, 'Booking');"
 
+    describe "operations control-center migrations" $ do
+        it "limits rollback updates to rows whose enabled state changes" $ do
+            rollback <- readFile "sql/2026-08-09_admin_operations_control_center_rollback.sql"
+            rollback `shouldContain`
+                "UPDATE operations_organization SET operations_enabled = FALSE, updated_at = now()\nWHERE operations_enabled IS DISTINCT FROM FALSE;"
+            rollback `shouldContain`
+                "UPDATE operations_provider_config SET enabled = FALSE, updated_at = now()\nWHERE enabled IS DISTINCT FROM FALSE;"
+
+        it "keeps the backfill record projection explicit" $ do
+            migration <- readFile "sql/2026-08-09_admin_operations_control_center.sql"
+            migration `shouldContain`
+                "SELECT entity_type, entity_id, correlation_key, occurred_at,\n        priority, title_es, title_en, metadata"
+            migration `shouldNotContain` "SELECT * FROM ("
+
     describe "getVersionInfo" $ do
         let clearEnv keys = map (\key -> (key, Nothing)) keys
             commitEnvKeys =

--- a/tdf-hq/test/TDF/ServerAdminSpec.hs
+++ b/tdf-hq/test/TDF/ServerAdminSpec.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -Werror=incomplete-patterns #-}
 
 module TDF.ServerAdminSpec (spec) where
 


### PR DESCRIPTION
## Summary

- omit unset optional fields from internship project and task create requests
- align frontend create types with the backend strict omission contract
- add regression coverage for the generated playbook project and all 12 tasks

## Root cause

The playbook generator sent optional create fields as null. The backend intentionally rejects explicit null values and requires those fields to be omitted, causing POST /internships/projects to return 400 before the plan could be created.

## Validation

- InternshipsPage tests: 14 passed
- TypeScript typecheck: passed
- targeted ESLint: passed
- production UI build: passed
- Cloudflare Pages preview: passed and deployed bundle inspected