### PR TITLE
fix(ui): tolerate legacy locale preferences

### DIFF
--- a/tdf-hq-ui/src/contexts/LocalePreferencesContext.test.ts
+++ b/tdf-hq-ui/src/contexts/LocalePreferencesContext.test.ts
@@ -1,0 +1,45 @@
+import type { LocalePreferences } from '../api/preferences';
+import { normalizePreferences } from './LocalePreferencesContext';
+
+const fallback: LocalePreferences = {
+  localeId: '',
+  locale: 'en',
+  currencyId: '',
+  currency: 'USD',
+  timezone: 'UTC',
+  countryId: null,
+  countryCode: null,
+};
+
+describe('normalizePreferences', () => {
+  it('accepts the legacy production response without canonical catalog ids', () => {
+    expect(normalizePreferences({
+      locale: ' es ',
+      currency: ' usd ',
+      timezone: ' America/Guayaquil ',
+      countryCode: ' ec ',
+      supportedLocales: ['es', 'en'],
+      supportedCurrencies: ['USD'],
+    }, fallback)).toEqual({
+      localeId: '',
+      locale: 'es',
+      currencyId: '',
+      currency: 'USD',
+      timezone: 'America/Guayaquil',
+      countryId: null,
+      countryCode: 'EC',
+    });
+  });
+
+  it('falls back safely when a response contains absent or malformed fields', () => {
+    expect(normalizePreferences({
+      localeId: undefined,
+      locale: null,
+      currencyId: 42,
+      currency: '',
+      timezone: undefined,
+      countryId: false,
+      countryCode: [],
+    }, fallback)).toEqual(fallback);
+  });
+});

--- a/tdf-hq-ui/src/contexts/LocalePreferencesContext.test.ts
+++ b/tdf-hq-ui/src/contexts/LocalePreferencesContext.test.ts
@@ -18,8 +18,6 @@ describe('normalizePreferences', () => {
       currency: ' usd ',
       timezone: ' America/Guayaquil ',
       countryCode: ' ec ',
-      supportedLocales: ['es', 'en'],
-      supportedCurrencies: ['USD'],
     }, fallback)).toEqual({
       localeId: '',
       locale: 'es',

--- a/tdf-hq-ui/src/contexts/LocalePreferencesContext.tsx
+++ b/tdf-hq-ui/src/contexts/LocalePreferencesContext.tsx
@@ -53,17 +53,33 @@ function readStoredPreferences(): LocalePreferences {
   }
 }
 
-function normalizePreferences(value: LocalePreferences, fallback: LocalePreferences): LocalePreferences {
-  const locale = normalizeLocale(value.locale) ?? normalizeLocale(fallback.locale) ?? 'en';
-  const currency = value.currency.toUpperCase();
-  const countryId = value.countryId?.trim();
-  const countryCode = value.countryCode?.trim().toUpperCase();
+export function normalizePreferences(value: unknown, fallback: LocalePreferences): LocalePreferences {
+  // During a coordinated rollout the previous backend can still return the legacy
+  // code-only shape, without localeId, currencyId, or countryId.
+  const source = value && typeof value === 'object' ? value as Record<string, unknown> : {};
+  const localeId = typeof source['localeId'] === 'string' ? source['localeId'].trim() : fallback.localeId;
+  const locale = normalizeLocale(typeof source['locale'] === 'string' ? source['locale'] : undefined)
+    ?? normalizeLocale(fallback.locale)
+    ?? 'en';
+  const currencyId = typeof source['currencyId'] === 'string'
+    ? source['currencyId'].trim()
+    : fallback.currencyId;
+  const currency = typeof source['currency'] === 'string' && source['currency'].trim()
+    ? source['currency'].trim().toUpperCase()
+    : fallback.currency;
+  const timezone = typeof source['timezone'] === 'string' && source['timezone'].trim()
+    ? source['timezone'].trim()
+    : fallback.timezone;
+  const countryId = typeof source['countryId'] === 'string' ? source['countryId'].trim() : fallback.countryId;
+  const countryCode = typeof source['countryCode'] === 'string'
+    ? source['countryCode'].trim().toUpperCase()
+    : fallback.countryCode;
   return {
-    localeId: value.localeId.trim(),
+    localeId,
     locale,
-    currencyId: value.currencyId.trim(),
+    currencyId,
     currency,
-    timezone: value.timezone.trim() || fallback.timezone,
+    timezone,
     countryId: countryId && countryId.length > 0 ? countryId : null,
     countryCode: countryCode && countryCode.length > 0 ? countryCode : null,
   };


### PR DESCRIPTION
## Summary
- accept the legacy production locale-preference payload during the coordinated catalog rollout
- use safe defaults for absent or malformed preference fields instead of crashing React
- add regression coverage for the exact code-only backend response

## Production incident
The catalog-enabled UI is live while the backend still serves the previous contract. Authenticated session hydration therefore omits `localeId` and `currencyId`; calling `.trim()` on those missing fields causes the blank page. `/catalogs/batch` remains unavailable until the backend rollout and safely falls back where supported. Browser-extension `window.cardano` errors are unrelated.

## Verification
- `npm test -- --runTestsByPath src/contexts/LocalePreferencesContext.test.ts`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run build`