### PR TITLE
fix(ui): gate radio widget on authenticated session

### DIFF
--- a/tdf-hq-ui/src/App.tsx
+++ b/tdf-hq-ui/src/App.tsx
@@ -5,14 +5,16 @@ import AppErrorBoundary from './routes/AppErrorBoundary';
 import RouteLoadingFallback from './routes/RouteLoadingFallback';
 import { renderProtectedRoutes } from './routes/protectedRoutes';
 import { renderPublicRoutes } from './routes/publicRoutes';
+import { useSession } from './session/SessionContext';
 import { lazyWithReload } from './utils/lazyWithReload';
-import { shouldHideRadioForRoute } from './utils/radioRouteVisibility';
+import { shouldRenderRadioWidget } from './utils/radioRouteVisibility';
 
 const RadioWidget = lazyWithReload(() => import('./components/RadioWidget'));
 
 function RoutedRadioWidget() {
   const location = useLocation();
-  if (shouldHideRadioForRoute(location.pathname, location.hash)) return null;
+  const { session, loading } = useSession();
+  if (!shouldRenderRadioWidget(location.pathname, location.hash, Boolean(session), loading)) return null;
   return (
     <Suspense fallback={null}>
       <RadioWidget />

--- a/tdf-hq-ui/src/utils/radioRouteVisibility.test.ts
+++ b/tdf-hq-ui/src/utils/radioRouteVisibility.test.ts
@@ -1,4 +1,4 @@
-import { shouldHideRadioForRoute } from './radioRouteVisibility';
+import { shouldHideRadioForRoute, shouldRenderRadioWidget } from './radioRouteVisibility';
 
 describe('shouldHideRadioForRoute', () => {
   it('keeps the radio widget off the dense course registrations admin page', () => {
@@ -16,5 +16,12 @@ describe('shouldHideRadioForRoute', () => {
     expect(shouldHideRadioForRoute('/tdf')).toBe(true);
     expect(shouldHideRadioForRoute('/tdf/artistas')).toBe(true);
     expect(shouldHideRadioForRoute('/tdf', '#radio')).toBe(false);
+  });
+
+  it('does not mount the protected radio client before an authenticated session is ready', () => {
+    expect(shouldRenderRadioWidget('/domo-del-pululahua', '', false, false)).toBe(false);
+    expect(shouldRenderRadioWidget('/domo-del-pululahua', '', true, true)).toBe(false);
+    expect(shouldRenderRadioWidget('/domo-del-pululahua', '', true, false)).toBe(true);
+    expect(shouldRenderRadioWidget('/login', '', true, false)).toBe(false);
   });
 });

--- a/tdf-hq-ui/src/utils/radioRouteVisibility.ts
+++ b/tdf-hq-ui/src/utils/radioRouteVisibility.ts
@@ -23,3 +23,14 @@ export const shouldHideRadioForRoute = (pathname: string, hash = '') => (
     && hash !== '#radio'
   )
 );
+
+export const shouldRenderRadioWidget = (
+  pathname: string,
+  hash: string,
+  authenticated: boolean,
+  sessionLoading: boolean,
+) => (
+  authenticated
+  && !sessionLoading
+  && !shouldHideRadioForRoute(pathname, hash)
+);


### PR DESCRIPTION
## Summary

- gate the global radio widget until session loading completes
- render the widget only for authenticated sessions
- prevent public pages such as Domo del Pululahua from loading protected radio APIs and chunks

## Validation

- focused Jest: 4/4 passed
- TypeScript typecheck passed
- ESLint passed (pre-existing warnings only)
- production build passed
- bundle budget passed: 402,744 bytes gzip initial JS
- local Playwright against production API: Domo quote visible, zero /radio/* requests, zero RadioWidget chunk downloads