### PR TITLE
fix(catalogs): resume interrupted production cutover

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,6 +280,8 @@ jobs:
       - name: Verify pristine production preflight
         run: |
           node scripts/render-production-schema-preflight.mjs | psql "$PGURL" -v ON_ERROR_STOP=1
+          security_report="$(psql "$PGURL" -X -qAt -v ON_ERROR_STOP=1 -f tdf-hq/sql/preflight_security_emergency_readiness.sql)"
+          node -e 'const report=JSON.parse(process.argv[1]); if (report.schemaMode!=="legacy" || !report.preMigrationReady || report.authenticatableParties!==2) process.exit(1)' "$security_report"
 
       - name: Apply the authoritative migration batch twice
         env:
@@ -289,6 +291,8 @@ jobs:
           node scripts/render-production-migration-batch.mjs | psql "$PGURL" -v ON_ERROR_STOP=1
           expected_migrations="$(node -p "require('./scripts/production-migrations.json').migrations.length")"
           test "$(psql "$PGURL" -Atqc 'SELECT COUNT(*) FROM public.tdf_schema_migration')" = "$expected_migrations"
+          security_report="$(psql "$PGURL" -X -qAt -v ON_ERROR_STOP=1 -f tdf-hq/sql/preflight_security_emergency_readiness.sql)"
+          node -e 'const report=JSON.parse(process.argv[1]); if (report.schemaMode!=="canonical" || !report.databaseReady || report.databaseCoherentPaths!==2) process.exit(1)' "$security_report"
 
       - name: Verify catalog dry-runs and raw cutover idempotency
         env:

--- a/docs/catalog-persistence/catalog-list-decisions.json
+++ b/docs/catalog-persistence/catalog-list-decisions.json
@@ -6494,7 +6494,7 @@
       "reviewed": true
     },
     {
-      "id": "470693b769b0b47b4836",
+      "id": "133de626674b6f7f0f25",
       "classification": "genuine-technical-constant",
       "disposition": "retain-in-code",
       "specializedModel": "technical_constant_allowlist",

--- a/scripts/__tests__/fixtures/catalog-production-source-fixture.sql
+++ b/scripts/__tests__/fixtures/catalog-production-source-fixture.sql
@@ -1,6 +1,32 @@
 -- Synthetic, non-production source rows required to exercise the fail-closed
 -- Records migration from the schema-only production baseline.
 
+INSERT INTO public.party (display_name, is_org, created_at)
+VALUES
+  ('Catalog recovery fixture A', false, now()),
+  ('Catalog recovery fixture B', false, now());
+
+INSERT INTO public.user_credential (party_id, username, password_hash, active)
+SELECT
+  id,
+  CASE display_name
+    WHEN 'Catalog recovery fixture A' THEN 'catalog-recovery-a'
+    ELSE 'catalog-recovery-b'
+  END,
+  'non-production-fixture-hash',
+  true
+FROM public.party
+WHERE display_name IN ('Catalog recovery fixture A', 'Catalog recovery fixture B');
+
+ALTER TABLE public.party_role DISABLE TRIGGER operations_party_role_scope_sync;
+
+INSERT INTO public.party_role (party_id, role, active)
+SELECT id, 'Admin', true
+FROM public.party
+WHERE display_name IN ('Catalog recovery fixture A', 'Catalog recovery fixture B');
+
+ALTER TABLE public.party_role ENABLE TRIGGER operations_party_role_scope_sync;
+
 INSERT INTO public.supported_currencies
   (currency_code, symbol, decimal_places, decimal_separator, thousands_separator, enabled)
 VALUES ('USD', '$', 2, '.', ',', true)

--- a/scripts/__tests__/fixtures/catalog-production-source-fixture.sql
+++ b/scripts/__tests__/fixtures/catalog-production-source-fixture.sql
@@ -42,6 +42,11 @@ INSERT INTO public.user_locale_preferences
 SELECT id, 'es', 'USD', 'America/Guayaquil', 'EC'
 FROM fixture_party;
 
+INSERT INTO public.pipeline_card
+  (service_kind, title, stage, sort_order)
+VALUES
+  ('Recording', 'Catalog pipeline recovery fixture', 'inquiry', 1);
+
 INSERT INTO public.cms_content
   (slug, locale, version, status, title, payload, published_at)
 VALUES

--- a/scripts/__tests__/fixtures/catalog-production-source-fixture.sql
+++ b/scripts/__tests__/fixtures/catalog-production-source-fixture.sql
@@ -1,6 +1,21 @@
 -- Synthetic, non-production source rows required to exercise the fail-closed
 -- Records migration from the schema-only production baseline.
 
+INSERT INTO public.supported_currencies
+  (currency_code, symbol, decimal_places, decimal_separator, thousands_separator, enabled)
+VALUES ('USD', '$', 2, '.', ',', true)
+ON CONFLICT (currency_code) DO NOTHING;
+
+WITH fixture_party AS (
+  INSERT INTO public.party (display_name, is_org, created_at)
+  VALUES ('Catalog migration fixture', false, now())
+  RETURNING id
+)
+INSERT INTO public.user_locale_preferences
+  (user_id, locale, currency, timezone, country_code)
+SELECT id, 'es', 'USD', 'America/Guayaquil', 'EC'
+FROM fixture_party;
+
 INSERT INTO public.cms_content
   (slug, locale, version, status, title, payload, published_at)
 VALUES

--- a/scripts/__tests__/production-release.test.mjs
+++ b/scripts/__tests__/production-release.test.mjs
@@ -223,6 +223,8 @@ test('security emergency readiness requires canonical coherence after migration'
     activeEmergencyAssignments: 2,
     distinctAssignedParties: 2,
     authenticatableParties: 2,
+    legacyAuthenticatableParties: 0,
+    coherentLegacyTargetRoles: 1,
     databaseCoherentPaths: 2,
     preMigrationReady: true,
     databaseReady: true,
@@ -247,6 +249,77 @@ test('security emergency readiness requires canonical coherence after migration'
     ),
     /1 coherent paths; 2 are required/i,
   );
+});
+
+test('partial canonical security may resume from legacy paths but cannot pass the post-migration gate', () => {
+  const report = parseSecurityEmergencyReadinessOutput(JSON.stringify({
+    kind: 'security-emergency-readiness',
+    schemaMode: 'canonical',
+    transactionReadOnly: 'on',
+    requiredIndependentPaths: 2,
+    activeEmergencyAssignments: 0,
+    distinctAssignedParties: 0,
+    authenticatableParties: 0,
+    legacyAuthenticatableParties: 2,
+    coherentLegacyTargetRoles: 1,
+    databaseCoherentPaths: 0,
+    preMigrationReady: true,
+    databaseReady: false,
+  }));
+
+  assert.equal(securityEmergencyReadinessBlocker(report), undefined);
+  assert.match(
+    securityEmergencyReadinessBlocker(report, { requireCanonical: true }),
+    /0 coherent paths; 2 are required/i,
+  );
+});
+
+test('partial canonical security cannot claim readiness without a coherent mapped target role', () => {
+  assert.throws(
+    () => parseSecurityEmergencyReadinessOutput(JSON.stringify({
+      kind: 'security-emergency-readiness',
+      schemaMode: 'canonical',
+      transactionReadOnly: 'on',
+      requiredIndependentPaths: 2,
+      activeEmergencyAssignments: 0,
+      distinctAssignedParties: 0,
+      authenticatableParties: 0,
+      legacyAuthenticatableParties: 2,
+      coherentLegacyTargetRoles: 0,
+      databaseCoherentPaths: 0,
+      preMigrationReady: true,
+      databaseReady: false,
+    })),
+    /inconsistent gate evidence/i,
+  );
+});
+
+test('catalog resume migration only relaxes copied preference evidence columns', () => {
+  const sql = readFileSync(
+    new URL('../../tdf-hq/sql/2026-08-16_catalog_locale_preference_resume.sql', import.meta.url),
+    'utf8',
+  );
+
+  assert.match(sql, /locale_id[\s\S]*data_type = 'uuid'/i);
+  assert.match(sql, /currency_id[\s\S]*data_type = 'uuid'/i);
+  assert.match(sql, /ALTER COLUMN locale DROP NOT NULL/i);
+  assert.match(sql, /ALTER COLUMN currency DROP NOT NULL/i);
+  assert.doesNotMatch(sql, /\b(?:UPDATE|DELETE|INSERT)\b/i);
+});
+
+test('security readiness SQL keeps legacy recovery only as a pre-migration fallback', () => {
+  const sql = readFileSync(
+    new URL('../../tdf-hq/sql/preflight_security_emergency_readiness.sql', import.meta.url),
+    'utf8',
+  );
+
+  assert.match(sql, /legacy_authenticatable_party/i);
+  assert.match(sql, /role\.code = 'admin'/i);
+  assert.match(
+    sql,
+    /preMigrationReady',[\s\S]*legacy_authenticatable_parties >= 2[\s\S]*coherent_legacy_target_roles = 1/i,
+  );
+  assert.match(sql, /databaseReady', database_coherent_paths >= 2/i);
 });
 
 test('security emergency readiness parser rejects missing, writable, and malformed reports', () => {

--- a/scripts/__tests__/production-release.test.mjs
+++ b/scripts/__tests__/production-release.test.mjs
@@ -337,6 +337,30 @@ test('catalog backfill confines the pipeline trigger bypass to its transaction',
   assert.ok(enableIndex > updateIndex, 'pipeline integrity trigger must be re-enabled after mapping');
 });
 
+test('pending canonical cutovers relax legacy evidence columns before clearing them', () => {
+  const pipelineSql = readFileSync(
+    new URL('../../tdf-hq/sql/2026-08-11_pipeline_workflow_cutover_apply.sql', import.meta.url),
+    'utf8',
+  );
+  const ddexSql = readFileSync(
+    new URL('../../tdf-hq/sql/2026-08-12_ddex_operational_cutover_apply.sql', import.meta.url),
+    'utf8',
+  );
+
+  for (const column of ['service_kind', 'stage']) {
+    assert.match(pipelineSql, new RegExp(`ALTER COLUMN ${column} DROP NOT NULL`, 'i'));
+  }
+  for (const clause of [
+    'ddex_import_plan ALTER COLUMN status',
+    'ddex_import_run ALTER COLUMN status',
+    'ddex_job ALTER COLUMN job_type',
+    'ddex_job ALTER COLUMN status',
+    'ddex_import_change ALTER COLUMN operation',
+  ]) {
+    assert.match(ddexSql, new RegExp(`ALTER TABLE ${clause} DROP NOT NULL`, 'i'));
+  }
+});
+
 test('security readiness SQL keeps legacy recovery only as a pre-migration fallback', () => {
   const sql = readFileSync(
     new URL('../../tdf-hq/sql/preflight_security_emergency_readiness.sql', import.meta.url),

--- a/scripts/__tests__/production-release.test.mjs
+++ b/scripts/__tests__/production-release.test.mjs
@@ -115,11 +115,15 @@ test('production migration manifest uses immutable full commit SHAs', () => {
   const resumeIndex = manifest.migrations.findIndex(
     ({ id }) => id === '2026-08-16_catalog_locale_preference_resume',
   );
+  const writerResumeIndex = manifest.migrations.findIndex(
+    ({ id }) => id === '2026-08-16_catalog_transitional_writer_resume',
+  );
   const backfillIndex = manifest.migrations.findIndex(
     ({ id }) => id === '2026-08-07_catalog_backfill_apply',
   );
   assert.ok(resumeIndex >= 0, 'resume migration must be registered');
-  assert.equal(backfillIndex, resumeIndex + 1, 'resume migration must run immediately before backfill');
+  assert.equal(writerResumeIndex, resumeIndex + 1, 'writer resume must follow locale recovery');
+  assert.equal(backfillIndex, writerResumeIndex + 1, 'writer resume must run immediately before backfill');
 });
 
 test('production release refuses to omit a migration outside the release ancestry', () => {

--- a/scripts/__tests__/production-release.test.mjs
+++ b/scripts/__tests__/production-release.test.mjs
@@ -316,6 +316,27 @@ test('catalog resume migration only relaxes copied preference evidence columns',
   assert.doesNotMatch(sql, /\b(?:UPDATE|DELETE|INSERT)\b/i);
 });
 
+test('catalog backfill confines the pipeline trigger bypass to its transaction', () => {
+  const sql = readFileSync(
+    new URL('../../tdf-hq/sql/2026-08-07_catalog_backfill_apply.sql', import.meta.url),
+    'utf8',
+  );
+
+  const disableIndex = sql.indexOf(
+    'ALTER TABLE pipeline_card DISABLE TRIGGER catalog_pipeline_card_integrity;',
+  );
+  const updateIndex = sql.indexOf(
+    'UPDATE pipeline_card target SET service_offering_id=offering.id',
+  );
+  const enableIndex = sql.indexOf(
+    'ALTER TABLE pipeline_card ENABLE TRIGGER catalog_pipeline_card_integrity;',
+  );
+
+  assert.ok(disableIndex >= 0, 'pipeline integrity trigger must be disabled');
+  assert.ok(updateIndex > disableIndex, 'pipeline mapping must run after the trigger is disabled');
+  assert.ok(enableIndex > updateIndex, 'pipeline integrity trigger must be re-enabled after mapping');
+});
+
 test('security readiness SQL keeps legacy recovery only as a pre-migration fallback', () => {
   const sql = readFileSync(
     new URL('../../tdf-hq/sql/preflight_security_emergency_readiness.sql', import.meta.url),

--- a/scripts/__tests__/production-release.test.mjs
+++ b/scripts/__tests__/production-release.test.mjs
@@ -111,6 +111,15 @@ test('production migration manifest uses immutable full commit SHAs', () => {
   for (const migration of manifest.migrations) {
     assert.equal(normalizeFullSha(migration.introducedBy), migration.introducedBy);
   }
+
+  const resumeIndex = manifest.migrations.findIndex(
+    ({ id }) => id === '2026-08-16_catalog_locale_preference_resume',
+  );
+  const backfillIndex = manifest.migrations.findIndex(
+    ({ id }) => id === '2026-08-07_catalog_backfill_apply',
+  );
+  assert.ok(resumeIndex >= 0, 'resume migration must be registered');
+  assert.equal(backfillIndex, resumeIndex + 1, 'resume migration must run immediately before backfill');
 });
 
 test('production release refuses to omit a migration outside the release ancestry', () => {

--- a/scripts/__tests__/production-release.test.mjs
+++ b/scripts/__tests__/production-release.test.mjs
@@ -303,7 +303,7 @@ test('partial canonical security cannot claim readiness without a coherent mappe
   );
 });
 
-test('catalog resume migration only relaxes copied preference evidence columns', () => {
+test('catalog resume migration performs bounded schema recovery without row writes', () => {
   const sql = readFileSync(
     new URL('../../tdf-hq/sql/2026-08-16_catalog_locale_preference_resume.sql', import.meta.url),
     'utf8',
@@ -313,28 +313,26 @@ test('catalog resume migration only relaxes copied preference evidence columns',
   assert.match(sql, /currency_id[\s\S]*data_type = 'uuid'/i);
   assert.match(sql, /ALTER COLUMN locale DROP NOT NULL/i);
   assert.match(sql, /ALTER COLUMN currency DROP NOT NULL/i);
+  assert.match(sql, /DROP TRIGGER IF EXISTS catalog_pipeline_card_integrity ON pipeline_card/i);
+  assert.match(sql, /DROP TRIGGER IF EXISTS social_event_type_integrity ON social_event/i);
+  assert.match(sql, /DROP TRIGGER IF EXISTS social_event_workflow_state_integrity ON social_event/i);
   assert.doesNotMatch(sql, /\b(?:UPDATE|DELETE|INSERT)\b/i);
 });
 
-test('catalog backfill confines the pipeline trigger bypass to its transaction', () => {
+test('catalog backfill locks pipeline writers around the transitional mapping', () => {
   const sql = readFileSync(
     new URL('../../tdf-hq/sql/2026-08-07_catalog_backfill_apply.sql', import.meta.url),
     'utf8',
   );
 
-  const disableIndex = sql.indexOf(
-    'ALTER TABLE pipeline_card DISABLE TRIGGER catalog_pipeline_card_integrity;',
+  const lockIndex = sql.indexOf(
+    'LOCK TABLE pipeline_card IN SHARE ROW EXCLUSIVE MODE;',
   );
   const updateIndex = sql.indexOf(
     'UPDATE pipeline_card target SET service_offering_id=offering.id',
   );
-  const enableIndex = sql.indexOf(
-    'ALTER TABLE pipeline_card ENABLE TRIGGER catalog_pipeline_card_integrity;',
-  );
-
-  assert.ok(disableIndex >= 0, 'pipeline integrity trigger must be disabled');
-  assert.ok(updateIndex > disableIndex, 'pipeline mapping must run after the trigger is disabled');
-  assert.ok(enableIndex > updateIndex, 'pipeline integrity trigger must be re-enabled after mapping');
+  assert.ok(lockIndex >= 0, 'pipeline writers must be locked');
+  assert.ok(updateIndex > lockIndex, 'pipeline mapping must run after the writer lock');
 });
 
 test('pending canonical cutovers relax legacy evidence columns before clearing them', () => {
@@ -359,6 +357,24 @@ test('pending canonical cutovers relax legacy evidence columns before clearing t
   ]) {
     assert.match(ddexSql, new RegExp(`ALTER TABLE ${clause} DROP NOT NULL`, 'i'));
   }
+});
+
+test('social event cutovers remove transitional triggers before canonical updates', () => {
+  const typeSql = readFileSync(
+    new URL('../../tdf-hq/sql/2026-08-11_social_event_type_cutover_apply.sql', import.meta.url),
+    'utf8',
+  );
+  const workflowSql = readFileSync(
+    new URL('../../tdf-hq/sql/2026-08-11_social_event_workflow_cutover_apply.sql', import.meta.url),
+    'utf8',
+  );
+
+  assert.ok(typeSql.indexOf('DROP TRIGGER IF EXISTS social_event_type_integrity ON social_event;')
+    < typeSql.indexOf('UPDATE social_event target SET'));
+  assert.ok(typeSql.indexOf('DROP TRIGGER IF EXISTS social_event_workflow_state_integrity ON social_event;')
+    < typeSql.indexOf('UPDATE social_event target SET'));
+  assert.ok(workflowSql.indexOf('DROP TRIGGER IF EXISTS social_event_workflow_state_integrity ON social_event;')
+    < workflowSql.indexOf('UPDATE social_event target SET'));
 });
 
 test('security readiness SQL keeps legacy recovery only as a pre-migration fallback', () => {

--- a/scripts/__tests__/production-release.test.mjs
+++ b/scripts/__tests__/production-release.test.mjs
@@ -303,7 +303,7 @@ test('partial canonical security cannot claim readiness without a coherent mappe
   );
 });
 
-test('catalog resume migration performs bounded schema recovery without row writes', () => {
+test('catalog locale resume migration only relaxes copied preference evidence columns', () => {
   const sql = readFileSync(
     new URL('../../tdf-hq/sql/2026-08-16_catalog_locale_preference_resume.sql', import.meta.url),
     'utf8',
@@ -313,6 +313,15 @@ test('catalog resume migration performs bounded schema recovery without row writ
   assert.match(sql, /currency_id[\s\S]*data_type = 'uuid'/i);
   assert.match(sql, /ALTER COLUMN locale DROP NOT NULL/i);
   assert.match(sql, /ALTER COLUMN currency DROP NOT NULL/i);
+  assert.doesNotMatch(sql, /\b(?:UPDATE|DELETE|INSERT)\b/i);
+});
+
+test('catalog writer resume migration only removes premature canonical triggers', () => {
+  const sql = readFileSync(
+    new URL('../../tdf-hq/sql/2026-08-16_catalog_transitional_writer_resume.sql', import.meta.url),
+    'utf8',
+  );
+
   assert.match(sql, /DROP TRIGGER IF EXISTS catalog_pipeline_card_integrity ON pipeline_card/i);
   assert.match(sql, /DROP TRIGGER IF EXISTS social_event_type_integrity ON social_event/i);
   assert.match(sql, /DROP TRIGGER IF EXISTS social_event_workflow_state_integrity ON social_event/i);
@@ -332,6 +341,11 @@ test('catalog backfill locks pipeline writers around the transitional mapping', 
     'UPDATE pipeline_card target SET service_offering_id=offering.id',
   );
   assert.ok(lockIndex >= 0, 'pipeline writers must be locked');
+  assert.match(
+    sql,
+    /FROM pipeline_card source\s+WHERE source\.service_kind IS NOT NULL/i,
+    'reruns must skip pipeline rows whose legacy evidence was already cleared',
+  );
   assert.ok(updateIndex > lockIndex, 'pipeline mapping must run after the writer lock');
 });
 

--- a/scripts/lib/production-release.mjs
+++ b/scripts/lib/production-release.mjs
@@ -127,6 +127,8 @@ export function parseSecurityEmergencyReadinessOutput(output) {
     'activeEmergencyAssignments',
     'distinctAssignedParties',
     'authenticatableParties',
+    'legacyAuthenticatableParties',
+    'coherentLegacyTargetRoles',
     'databaseCoherentPaths',
   ]) {
     if (report[field] !== undefined
@@ -134,6 +136,22 @@ export function parseSecurityEmergencyReadinessOutput(output) {
         && (!Number.isInteger(report[field]) || report[field] < 0)) {
       throw new Error(`Security emergency readiness preflight returned an invalid ${field}.`);
     }
+  }
+  if (report.schemaMode === 'canonical') {
+    if (!Number.isInteger(report.legacyAuthenticatableParties)
+        || !Number.isInteger(report.coherentLegacyTargetRoles)) {
+      throw new Error('Canonical security emergency readiness omitted transition evidence.');
+    }
+    const canonicalReady = (report.databaseCoherentPaths ?? 0) >= 2;
+    const legacyResumeReady = report.legacyAuthenticatableParties >= 2
+      && report.coherentLegacyTargetRoles === 1;
+    if (report.databaseReady !== canonicalReady
+        || report.preMigrationReady !== (canonicalReady || legacyResumeReady)) {
+      throw new Error('Canonical security emergency readiness returned inconsistent gate evidence.');
+    }
+  } else if (report.schemaMode === 'legacy'
+      && report.preMigrationReady !== ((report.authenticatableParties ?? 0) >= 2)) {
+    throw new Error('Legacy security emergency readiness returned inconsistent gate evidence.');
   }
   return report;
 }
@@ -149,7 +167,12 @@ export function securityEmergencyReadinessBlocker(report, options = {}) {
     return undefined;
   }
   if (!report.preMigrationReady) {
-    return `emergency recovery has ${report.authenticatableParties ?? 0} independently authenticatable parties; 2 are required before migration`;
+    const canonical = report.authenticatableParties ?? 0;
+    const legacy = report.legacyAuthenticatableParties;
+    const observed = legacy === undefined || legacy === null
+      ? `${canonical}`
+      : `${canonical} canonical and ${legacy} legacy`;
+    return `emergency recovery has ${observed} independently authenticatable parties; 2 are required before migration`;
   }
   return undefined;
 }

--- a/scripts/production-migrations.json
+++ b/scripts/production-migrations.json
@@ -107,6 +107,11 @@
       "introducedBy": "15d0d0b607344e62025f39208861c313c08b7eaa"
     },
     {
+      "id": "2026-08-16_catalog_locale_preference_resume",
+      "path": "tdf-hq/sql/2026-08-16_catalog_locale_preference_resume.sql",
+      "introducedBy": "07c76a2b59aec66997924c7b2809d6c66b451898"
+    },
+    {
       "id": "2026-08-07_catalog_backfill_apply",
       "path": "tdf-hq/sql/2026-08-07_catalog_backfill_apply.sql",
       "introducedBy": "451bc99e0c96d1922b19f463be4a4c3cc1e1ff39"

--- a/scripts/production-migrations.json
+++ b/scripts/production-migrations.json
@@ -112,6 +112,11 @@
       "introducedBy": "07c76a2b59aec66997924c7b2809d6c66b451898"
     },
     {
+      "id": "2026-08-16_catalog_transitional_writer_resume",
+      "path": "tdf-hq/sql/2026-08-16_catalog_transitional_writer_resume.sql",
+      "introducedBy": "2562222e99580202c7675f1d58aa5c942f308223"
+    },
+    {
       "id": "2026-08-07_catalog_backfill_apply",
       "path": "tdf-hq/sql/2026-08-07_catalog_backfill_apply.sql",
       "introducedBy": "451bc99e0c96d1922b19f463be4a4c3cc1e1ff39"

--- a/scripts/test-catalog-production-cutover.sh
+++ b/scripts/test-catalog-production-cutover.sh
@@ -64,3 +64,15 @@ psql "$TDF_CATALOG_TEST_DATABASE_URL" -X -v ON_ERROR_STOP=1 -Atqc "
   FROM catalog_backfill_run
   WHERE candidate_revision='${TDF_CATALOG_TEST_REVISION}' AND NOT dry_run AND status='completed';
 " | grep -qx ok
+
+security_report="$(
+  psql "$TDF_CATALOG_TEST_DATABASE_URL" -X -qAt -v ON_ERROR_STOP=1 \
+    -f "$TDF_CATALOG_TEST_ROOT/tdf-hq/sql/preflight_security_emergency_readiness.sql" \
+    | tail -1
+)"
+node -e '
+  const report = JSON.parse(process.argv[1]);
+  if (report.schemaMode !== "canonical"
+      || report.databaseCoherentPaths < 2
+      || report.databaseReady !== true) process.exit(1);
+' "$security_report"

--- a/tdf-hq/sql/2026-08-07_catalog_backfill_apply.sql
+++ b/tdf-hq/sql/2026-08-07_catalog_backfill_apply.sql
@@ -776,12 +776,10 @@ FROM currency_reference currency
 WHERE currency.code=target.currency AND currency.active
   AND target.currency_id IS DISTINCT FROM currency.id;
 
--- The canonical integrity trigger is already present when an interrupted
--- production cutover resumes. Keep it disabled only inside this transaction
--- while the legacy service label is paired with its canonical offering. The
--- ALTER TABLE lock prevents concurrent writers from observing the temporary
--- mixed representation, and a rollback restores the enabled trigger state.
-ALTER TABLE pipeline_card DISABLE TRIGGER catalog_pipeline_card_integrity;
+-- The resume migration restores legacy-writer semantics before this pending
+-- backfill. Block concurrent writers while pairing the copied service label
+-- with its canonical offering so the mapping snapshot stays coherent.
+LOCK TABLE pipeline_card IN SHARE ROW EXCLUSIVE MODE;
 
 UPDATE pipeline_card target SET service_offering_id=offering.id
 FROM service_offering offering
@@ -790,8 +788,6 @@ WHERE offering.code=CASE target.service_kind::text
   WHEN 'Mastering' THEN 'mastering' WHEN 'Rehearsal' THEN 'rehearsal'
   WHEN 'Classes' THEN 'classes' WHEN 'EventProduction' THEN 'event-production' END
   AND target.service_offering_id IS DISTINCT FROM offering.id;
-
-ALTER TABLE pipeline_card ENABLE TRIGGER catalog_pipeline_card_integrity;
 
 -- Bootstrap provenance is reserved for the reviewed legacy migration. Existing
 -- canonical grants always win and are never overwritten by a rerun.

--- a/tdf-hq/sql/2026-08-07_catalog_backfill_apply.sql
+++ b/tdf-hq/sql/2026-08-07_catalog_backfill_apply.sql
@@ -776,6 +776,13 @@ FROM currency_reference currency
 WHERE currency.code=target.currency AND currency.active
   AND target.currency_id IS DISTINCT FROM currency.id;
 
+-- The canonical integrity trigger is already present when an interrupted
+-- production cutover resumes. Keep it disabled only inside this transaction
+-- while the legacy service label is paired with its canonical offering. The
+-- ALTER TABLE lock prevents concurrent writers from observing the temporary
+-- mixed representation, and a rollback restores the enabled trigger state.
+ALTER TABLE pipeline_card DISABLE TRIGGER catalog_pipeline_card_integrity;
+
 UPDATE pipeline_card target SET service_offering_id=offering.id
 FROM service_offering offering
 WHERE offering.code=CASE target.service_kind::text
@@ -783,6 +790,8 @@ WHERE offering.code=CASE target.service_kind::text
   WHEN 'Mastering' THEN 'mastering' WHEN 'Rehearsal' THEN 'rehearsal'
   WHEN 'Classes' THEN 'classes' WHEN 'EventProduction' THEN 'event-production' END
   AND target.service_offering_id IS DISTINCT FROM offering.id;
+
+ALTER TABLE pipeline_card ENABLE TRIGGER catalog_pipeline_card_integrity;
 
 -- Bootstrap provenance is reserved for the reviewed legacy migration. Existing
 -- canonical grants always win and are never overwritten by a rerun.

--- a/tdf-hq/sql/2026-08-07_catalog_backfill_apply.sql
+++ b/tdf-hq/sql/2026-08-07_catalog_backfill_apply.sql
@@ -259,6 +259,7 @@ WITH reference_sources(source_table, source_column, source_record_id, original_v
       WHEN 'Mastering' THEN 'mastering' WHEN 'Rehearsal' THEN 'rehearsal'
       WHEN 'Classes' THEN 'classes' WHEN 'EventProduction' THEN 'event-production' END AND active)
   FROM pipeline_card source
+  WHERE source.service_kind IS NOT NULL
 )
 INSERT INTO catalog_migration_mapping (
   id, run_id, source_table, source_column, source_record_id, original_value,

--- a/tdf-hq/sql/2026-08-11_pipeline_workflow_cutover_apply.sql
+++ b/tdf-hq/sql/2026-08-11_pipeline_workflow_cutover_apply.sql
@@ -152,6 +152,8 @@ DO UPDATE SET state_id=EXCLUDED.state_id, normalized_value=EXCLUDED.normalized_v
   status='mapped', evidence=EXCLUDED.evidence;
 
 DROP TRIGGER IF EXISTS catalog_pipeline_card_integrity ON pipeline_card;
+ALTER TABLE pipeline_card ALTER COLUMN service_kind DROP NOT NULL;
+ALTER TABLE pipeline_card ALTER COLUMN stage DROP NOT NULL;
 
 DO $batches$
 DECLARE changed_rows integer;

--- a/tdf-hq/sql/2026-08-11_social_event_type_cutover_apply.sql
+++ b/tdf-hq/sql/2026-08-11_social_event_type_cutover_apply.sql
@@ -125,6 +125,9 @@ WHERE source.run_id=:'backfill_run_id'::uuid
 ON CONFLICT (run_id, source_table, source_column, source_record_id, original_value)
 DO UPDATE SET entity_id=EXCLUDED.entity_id, status='mapped', evidence=EXCLUDED.evidence;
 
+DROP TRIGGER IF EXISTS social_event_type_integrity ON social_event;
+DROP TRIGGER IF EXISTS social_event_workflow_state_integrity ON social_event;
+
 UPDATE social_event target SET
   event_type_id=source.target_event_type_id,
   metadata=NULLIF((target.metadata::jsonb - 'eventType')::text, '{}')

--- a/tdf-hq/sql/2026-08-11_social_event_workflow_cutover_apply.sql
+++ b/tdf-hq/sql/2026-08-11_social_event_workflow_cutover_apply.sql
@@ -154,6 +154,8 @@ ON CONFLICT (run_id, source_table, source_column, source_record_id, original_val
 DO UPDATE SET state_id=EXCLUDED.state_id, normalized_value=EXCLUDED.normalized_value,
   status='mapped', evidence=EXCLUDED.evidence;
 
+DROP TRIGGER IF EXISTS social_event_workflow_state_integrity ON social_event;
+
 DO $batches$
 DECLARE changed_rows integer;
 BEGIN

--- a/tdf-hq/sql/2026-08-12_ddex_operational_cutover_apply.sql
+++ b/tdf-hq/sql/2026-08-12_ddex_operational_cutover_apply.sql
@@ -186,6 +186,11 @@ DROP TRIGGER IF EXISTS ddex_operational_state_integrity ON ddex_import_run;
 DROP TRIGGER IF EXISTS ddex_operational_state_integrity ON ddex_job;
 DROP TRIGGER IF EXISTS ddex_import_change_canonical_integrity ON ddex_import_change;
 DROP TRIGGER IF EXISTS ddex_export_canonical_integrity ON ddex_export;
+ALTER TABLE ddex_import_plan ALTER COLUMN status DROP NOT NULL;
+ALTER TABLE ddex_import_run ALTER COLUMN status DROP NOT NULL;
+ALTER TABLE ddex_job ALTER COLUMN job_type DROP NOT NULL;
+ALTER TABLE ddex_job ALTER COLUMN status DROP NOT NULL;
+ALTER TABLE ddex_import_change ALTER COLUMN operation DROP NOT NULL;
 
 DO $batches$ DECLARE changed integer; BEGIN LOOP WITH batch AS (
   SELECT target.id FROM ddex_validation_run target JOIN catalog_ddex_operational_cutover_source source

--- a/tdf-hq/sql/2026-08-16_catalog_locale_preference_resume.sql
+++ b/tdf-hq/sql/2026-08-16_catalog_locale_preference_resume.sql
@@ -36,11 +36,4 @@ BEGIN
 END
 $resume$;
 
--- The interrupted release committed strict canonical triggers before the
--- legacy rows they protect were backfilled. Restore legacy-writer semantics
--- until each later cutover atomically installs its final canonical trigger.
-DROP TRIGGER IF EXISTS catalog_pipeline_card_integrity ON pipeline_card;
-DROP TRIGGER IF EXISTS social_event_type_integrity ON social_event;
-DROP TRIGGER IF EXISTS social_event_workflow_state_integrity ON social_event;
-
 COMMIT;

--- a/tdf-hq/sql/2026-08-16_catalog_locale_preference_resume.sql
+++ b/tdf-hq/sql/2026-08-16_catalog_locale_preference_resume.sql
@@ -1,0 +1,39 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- The canonical cutover clears the copied locale/currency text only after it
+-- has resolved both UUID references. Older installations declared those
+-- evidence columns NOT NULL, so make the expand/contract boundary explicit
+-- before the ledgered backfill runs. This migration changes no row values.
+DO $resume$
+BEGIN
+  IF to_regclass('public.user_locale_preferences') IS NULL THEN
+    RAISE EXCEPTION 'user_locale_preferences is required for catalog cutover resume';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'user_locale_preferences'
+      AND column_name = 'locale_id'
+      AND data_type = 'uuid'
+  ) OR NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'user_locale_preferences'
+      AND column_name = 'currency_id'
+      AND data_type = 'uuid'
+  ) THEN
+    RAISE EXCEPTION 'canonical locale preference UUID columns are missing';
+  END IF;
+
+  ALTER TABLE user_locale_preferences
+    ALTER COLUMN locale DROP NOT NULL,
+    ALTER COLUMN currency DROP NOT NULL;
+END
+$resume$;
+
+COMMIT;

--- a/tdf-hq/sql/2026-08-16_catalog_locale_preference_resume.sql
+++ b/tdf-hq/sql/2026-08-16_catalog_locale_preference_resume.sql
@@ -36,4 +36,11 @@ BEGIN
 END
 $resume$;
 
+-- The interrupted release committed strict canonical triggers before the
+-- legacy rows they protect were backfilled. Restore legacy-writer semantics
+-- until each later cutover atomically installs its final canonical trigger.
+DROP TRIGGER IF EXISTS catalog_pipeline_card_integrity ON pipeline_card;
+DROP TRIGGER IF EXISTS social_event_type_integrity ON social_event;
+DROP TRIGGER IF EXISTS social_event_workflow_state_integrity ON social_event;
+
 COMMIT;

--- a/tdf-hq/sql/2026-08-16_catalog_transitional_writer_resume.sql
+++ b/tdf-hq/sql/2026-08-16_catalog_transitional_writer_resume.sql
@@ -1,0 +1,12 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- The interrupted release committed strict canonical triggers before the
+-- legacy rows they protect were backfilled. Restore legacy-writer semantics
+-- until each later cutover atomically installs its final canonical trigger.
+DROP TRIGGER IF EXISTS catalog_pipeline_card_integrity ON pipeline_card;
+DROP TRIGGER IF EXISTS social_event_type_integrity ON social_event;
+DROP TRIGGER IF EXISTS social_event_workflow_state_integrity ON social_event;
+
+COMMIT;

--- a/tdf-hq/sql/preflight_security_emergency_readiness.sql
+++ b/tdf-hq/sql/preflight_security_emergency_readiness.sql
@@ -45,6 +45,42 @@ SELECT CASE
         ON credential.party_id = assignment.party_id
        AND credential.active
     ),
+    legacy_authenticatable_party AS (
+      SELECT DISTINCT assignment.party_id
+      FROM party_role assignment
+      JOIN user_credential credential
+        ON credential.party_id = assignment.party_id
+       AND credential.active
+      WHERE assignment.active
+        AND assignment.role::text = 'Admin'
+    ),
+    coherent_legacy_target_role AS (
+      SELECT role.id
+      FROM security_role role
+      WHERE role.active
+        AND role.emergency_administrator
+        AND role.code = 'admin'
+        AND NOT EXISTS (
+          SELECT 1
+          FROM required_permission required
+          WHERE NOT EXISTS (
+            SELECT 1
+            FROM role_permission grant_row
+            JOIN security_permission permission
+              ON permission.id = grant_row.permission_id
+             AND permission.active
+            JOIN security_action action
+              ON action.id = permission.action_id
+             AND action.active
+            JOIN security_module module_row
+              ON module_row.id = permission.module_id
+             AND module_row.active
+            WHERE grant_row.role_id = role.id
+              AND grant_row.active
+              AND permission.code = required.code
+          )
+        )
+    ),
     coherent_party AS (
       SELECT DISTINCT candidate.party_id
       FROM authenticatable_party candidate
@@ -74,6 +110,8 @@ SELECT CASE
         (SELECT count(*)::int FROM active_assignment) AS active_assignments,
         (SELECT count(DISTINCT party_id)::int FROM active_assignment) AS assigned_parties,
         (SELECT count(DISTINCT party_id)::int FROM authenticatable_party) AS authenticatable_parties,
+        (SELECT count(*)::int FROM legacy_authenticatable_party) AS legacy_authenticatable_parties,
+        (SELECT count(*)::int FROM coherent_legacy_target_role) AS coherent_legacy_target_roles,
         (SELECT count(*)::int FROM coherent_party) AS database_coherent_paths
     )
     SELECT json_build_object(
@@ -84,8 +122,12 @@ SELECT CASE
       'activeEmergencyAssignments', active_assignments,
       'distinctAssignedParties', assigned_parties,
       'authenticatableParties', authenticatable_parties,
+      'legacyAuthenticatableParties', legacy_authenticatable_parties,
+      'coherentLegacyTargetRoles', coherent_legacy_target_roles,
       'databaseCoherentPaths', database_coherent_paths,
-      'preMigrationReady', database_coherent_paths >= 2,
+      'preMigrationReady', database_coherent_paths >= 2 OR (
+        legacy_authenticatable_parties >= 2 AND coherent_legacy_target_roles = 1
+      ),
       'databaseReady', database_coherent_paths >= 2,
       'manualIndependentLoginVerificationRequired', true,
       'capturedAt', now()


### PR DESCRIPTION
## Summary

Makes the catalog release safely resumable after production stopped between the additive expand migrations and the first backfill.

- Allows the pre-migration security gate to recover from exactly two authenticated legacy `Admin` paths only when one coherent canonical `admin` target role owns every required active capability.
- Keeps the post-migration gate strict: deployment remains blocked until at least two coherent canonical emergency paths exist.
- Adds an immutable locale-preference resume migration before the ledgered backfill.
- Adds a separately ledgered writer-resume migration that removes canonical triggers installed before their legacy rows were converted; each pending cutover reinstalls its final trigger transactionally.
- Locks pipeline writers during the transitional service-offering mapping.
- Relaxes copied pipeline and DDEX evidence columns before clearing them, and removes transitional social-event triggers before canonical updates.
- Extends the production-shaped fixture and release tests to cover locale preferences, two independent administrators, a real pipeline row, migration ordering, and interrupted-resume behavior.

## Production state

The first release attempt failed closed before any API Machine deployment. Six additive catalog migrations committed, the catalog backfill transaction rolled back, and the release lease was released. Both API Machines remain started on `d10e7cdf9429e548aefaa60708610cc8a71e80bd`.

Recovery points:

- Pre-write snapshot: `vs_qqaw6alZAxgh7l13a3M9zlB`
- Exact post-failure partial-state snapshot: `vs_w7RnJReoQxwhaZV7Xnwm`

Read-only preflight on the partial state reports:

- `schemaMode=canonical`
- `legacyAuthenticatableParties=2`
- `coherentLegacyTargetRoles=1`
- `databaseCoherentPaths=0`
- `preMigrationReady=true`
- `databaseReady=false`

## Exact snapshot rehearsal

The current HEAD was applied once to a fresh isolated restore of `vs_w7RnJReoQxwhaZV7Xnwm` using the exact production PostgreSQL 17 image digest and the verified pgvector binary.

- All 37 manifest migrations completed.
- The pipeline cutover mapped 4 production cards and cleared all 4 legacy representations.
- The social-event type and workflow cutovers each mapped 88 production events with zero unresolved rows.
- The full production schema contract passed.
- Post-migration security readiness reported `databaseCoherentPaths=2`, `activeEmergencyAssignments=3`, `authenticatableParties=2`, and `databaseReady=true`.
- The ledger contained 37 rows.
- A second full manifest pass returned `Already applied` for every migration with no checksum mismatch.
- The disposable restore was stopped cleanly and destroyed; both recovery snapshots remain intact.

## Verification

- `npm run test:production-release` — 37/37 passed
- `git diff --check` — passed for the PR changes
- Fresh partial-snapshot restore — full apply, schema verification, security gate, and checksum-stable no-op rerun passed

## Rollout

Keep this PR draft until CI and independent review pass. After merge, build the exact merge revision, take a new production snapshot, rerun the read-only preflight, and resume through the release orchestrator. The original `cc487aca2febe785748c43d8262ae34ba0f259e7` image cannot be used because it does not contain these recovery migrations.

Follow-up to #151.
