### PR TITLE
feat(events): add auditable research ingestion pilot

### DIFF
--- a/docs/catalog-persistence/catalog-list-decisions.json
+++ b/docs/catalog-persistence/catalog-list-decisions.json
@@ -494,7 +494,7 @@
       "reviewed": true
     },
     {
-      "id": "6a994b43b0a60d8b3030",
+      "id": "51b43e3c0476c26bf606",
       "classification": "dynamic-business-catalog",
       "disposition": "migrate-and-remove-authority-from-code",
       "specializedModel": "domain-specific catalog table selected during consumer refactor",
@@ -2464,7 +2464,7 @@
       "reviewed": true
     },
     {
-      "id": "acbd8cc20115d7d88c03",
+      "id": "17ba38f46aff91a21784",
       "classification": "dynamic-business-catalog",
       "disposition": "migrate-and-remove-authority-from-code",
       "specializedModel": "domain-specific catalog table selected during consumer refactor",
@@ -5094,7 +5094,7 @@
       "reviewed": true
     },
     {
-      "id": "70d5cbc3cf57ec5ff385",
+      "id": "3f00137f715a55f77dc3",
       "classification": "genuine-technical-constant",
       "disposition": "retain-in-code",
       "specializedModel": "technical_constant_allowlist",
@@ -6494,7 +6494,7 @@
       "reviewed": true
     },
     {
-      "id": "133de626674b6f7f0f25",
+      "id": "f05c06694360cdca11e5",
       "classification": "genuine-technical-constant",
       "disposition": "retain-in-code",
       "specializedModel": "technical_constant_allowlist",
@@ -6581,6 +6581,106 @@
       "priority": "P1-cross-platform",
       "risk": "Mapping review states can diverge between genre/country ingestion, administration, reporting, and remediation jobs.",
       "justification": "Mapped, unresolved, and ambiguous are operational workflow states shown in review queues and reports and must use a persisted governed workflow.",
+      "reviewed": true
+    },
+    {
+      "id": "45ae335358b3aca8ae1b",
+      "classification": "dynamic-business-catalog",
+      "disposition": "migrate-and-remove-authority-from-code",
+      "specializedModel": "event_research_confidence, event_research_candidate.confidence_id",
+      "priority": "P1-cross-platform",
+      "risk": "Confidence labels and publication eligibility can diverge between ingestion, administration, and reporting.",
+      "justification": "Research confidence is persisted, displayed, filtered, and used by the publication gate, so it requires one governed set shared by the API and clients.",
+      "reviewed": true
+    },
+    {
+      "id": "cd20caaccdeb5777d35d",
+      "classification": "dynamic-business-catalog",
+      "disposition": "migrate-and-remove-authority-from-code",
+      "specializedModel": "workflow_definition, workflow_state, workflow_transition",
+      "priority": "P1-cross-platform",
+      "risk": "Candidate review states can diverge between the ingestion API, admin queue, reporting, and pilot cap enforcement.",
+      "justification": "Draft, review, and discarded are persisted operational workflow states and must use the governed workflow model as the authoritative source.",
+      "reviewed": true
+    },
+    {
+      "id": "48faaec5aef65c661663",
+      "classification": "dynamic-business-catalog",
+      "disposition": "migrate-and-remove-authority-from-code",
+      "specializedModel": "workflow_definition, workflow_state, workflow_transition",
+      "priority": "P1-cross-platform",
+      "risk": "Run lifecycle states can diverge between resumable processing, checkpoints, administration, and audit reports.",
+      "justification": "Running, completed, and failed are persisted ingestion-run workflow states and require one governed lifecycle contract across backend and clients.",
+      "reviewed": true
+    },
+    {
+      "id": "ddf50cf95b5f5d545cff",
+      "classification": "genuine-technical-constant",
+      "disposition": "retain-in-code",
+      "specializedModel": "technical_constant_allowlist",
+      "priority": "P3-retain",
+      "risk": "Renaming a typed client operation without its server contract would break request dispatch at compile time or runtime.",
+      "justification": "These names are methods of the typed event-research HTTP client and are implementation mechanics, not selectable or reportable domain values.",
+      "reviewed": true
+    },
+    {
+      "id": "0bd65c3e920d79f4244e",
+      "classification": "dynamic-business-catalog",
+      "disposition": "historical-evidence-replaced-by-forward-migration",
+      "specializedModel": "event_discovery_source, event_discovery_source_type",
+      "priority": "P1-cross-platform",
+      "risk": "Rollback source-type validation can diverge from the persisted source registry and reject otherwise recoverable data.",
+      "justification": "The reversible migration preserves the former discovery-source values while the governed source registry remains the intended authority after cutover.",
+      "reviewed": true
+    },
+    {
+      "id": "dc6c6597683d6ff100b9",
+      "classification": "dynamic-business-catalog",
+      "disposition": "historical-evidence-replaced-by-forward-migration",
+      "specializedModel": "workflow_definition, workflow_state, workflow_transition",
+      "priority": "P1-cross-platform",
+      "risk": "Migration constraints can diverge from the governed ingestion-run lifecycle and reject valid resumable states.",
+      "justification": "The migration bootstraps persisted run workflow values; the governed workflow model is the target authority for lifecycle labels and transitions.",
+      "reviewed": true
+    },
+    {
+      "id": "8de9886e85da6298e67a",
+      "classification": "dynamic-business-catalog",
+      "disposition": "historical-evidence-replaced-by-forward-migration",
+      "specializedModel": "workflow_definition, workflow_state, workflow_transition",
+      "priority": "P1-cross-platform",
+      "risk": "Migration constraints can diverge from candidate review queues and pilot cap enforcement.",
+      "justification": "The migration bootstraps candidate review states; the governed workflow model is the target authority for labels, transitions, and availability.",
+      "reviewed": true
+    },
+    {
+      "id": "dcb9e8ac9a1de3ba1f87",
+      "classification": "dynamic-business-catalog",
+      "disposition": "historical-evidence-replaced-by-forward-migration",
+      "specializedModel": "event_research_confidence, event_research_candidate.confidence_id",
+      "priority": "P1-cross-platform",
+      "risk": "Migration constraints can diverge from publication confidence policy and research reporting.",
+      "justification": "The migration bootstraps persisted confidence codes; a governed confidence model is the target authority for labels and publication eligibility.",
+      "reviewed": true
+    },
+    {
+      "id": "1273bfdd57643fef70ca",
+      "classification": "dynamic-business-catalog",
+      "disposition": "historical-evidence-replaced-by-forward-migration",
+      "specializedModel": "event_research_change_action, event_research_change.action_id",
+      "priority": "P1-cross-platform",
+      "risk": "Audit action codes can diverge between change history, reporting, and replay diagnostics.",
+      "justification": "Research change actions are persisted and reportable audit taxonomy values and require governed identities shared by ingestion and administration.",
+      "reviewed": true
+    },
+    {
+      "id": "cd168824dbabcf3e70ac",
+      "classification": "dynamic-business-catalog",
+      "disposition": "historical-evidence-replaced-by-forward-migration",
+      "specializedModel": "event_discovery_source, event_discovery_source_type",
+      "priority": "P1-cross-platform",
+      "risk": "Discovery-source validation can diverge between persisted registries, API clients, and manual research ingestion.",
+      "justification": "The migration expands persisted discovery-source types for official web research while the source registry remains the intended business authority.",
       "reviewed": true
     }
   ]

--- a/scripts/production-migrations.json
+++ b/scripts/production-migrations.json
@@ -185,6 +185,11 @@
       "id": "2026-08-12_ddex_operational_cutover_apply",
       "path": "tdf-hq/sql/2026-08-12_ddex_operational_cutover_apply.sql",
       "introducedBy": "451bc99e0c96d1922b19f463be4a4c3cc1e1ff39"
+    },
+    {
+      "id": "2026-08-16_event_research_ingestion",
+      "path": "tdf-hq/sql/2026-08-16_event_research_ingestion.sql",
+      "introducedBy": "d36af9ab5521d78de7cfc6eacf5788620c09daad"
     }
   ]
 }

--- a/scripts/production-migrations.json
+++ b/scripts/production-migrations.json
@@ -189,7 +189,7 @@
     {
       "id": "2026-08-16_event_research_ingestion",
       "path": "tdf-hq/sql/2026-08-16_event_research_ingestion.sql",
-      "introducedBy": "d36af9ab5521d78de7cfc6eacf5788620c09daad"
+      "introducedBy": "6198311849a0e12d7e44499051a88188b1ef3fd9"
     }
   ]
 }

--- a/scripts/test-event-research-ingestion-migration.sh
+++ b/scripts/test-event-research-ingestion-migration.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+set -eu
+
+TDF_EVENT_RESEARCH_CONTAINER="tdf-event-research-migration-test-$$"
+TDF_EVENT_RESEARCH_ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+cleanup() {
+  docker rm -f "$TDF_EVENT_RESEARCH_CONTAINER" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+docker run --rm -d \
+  --name "$TDF_EVENT_RESEARCH_CONTAINER" \
+  -e POSTGRES_PASSWORD=event-research-test \
+  -e POSTGRES_DB=tdf_event_research_test \
+  postgres:16-alpine >/dev/null
+
+attempt=0
+until docker exec "$TDF_EVENT_RESEARCH_CONTAINER" psql -v ON_ERROR_STOP=1 -U postgres -d tdf_event_research_test -Atc 'SELECT 1' >/dev/null 2>&1; do
+  attempt=$((attempt + 1))
+  if [ "$attempt" -ge 30 ]; then
+    echo "PostgreSQL migration test database did not become queryable" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+psql_exec() {
+  docker exec "$TDF_EVENT_RESEARCH_CONTAINER" psql -v ON_ERROR_STOP=1 -U postgres -d tdf_event_research_test "$@"
+}
+
+psql_exec -c 'CREATE TABLE social_event (id BIGSERIAL PRIMARY KEY);' >/dev/null
+psql_exec -c 'CREATE TABLE event_discovery_source (id BIGSERIAL PRIMARY KEY, source_key TEXT NOT NULL UNIQUE, name TEXT NOT NULL, source_type TEXT NOT NULL, feed_url TEXT, city_id BIGINT, enabled BOOLEAN NOT NULL DEFAULT TRUE, priority INTEGER NOT NULL DEFAULT 100, configuration TEXT, etag TEXT, last_modified TEXT, consecutive_failures INTEGER NOT NULL DEFAULT 0, last_success_at TIMESTAMPTZ, last_error TEXT, created_at TIMESTAMPTZ NOT NULL DEFAULT now(), updated_at TIMESTAMPTZ NOT NULL DEFAULT now());' >/dev/null
+
+apply_migration() {
+  docker exec -i "$TDF_EVENT_RESEARCH_CONTAINER" psql -v ON_ERROR_STOP=1 -U postgres -d tdf_event_research_test \
+    < "$TDF_EVENT_RESEARCH_ROOT/tdf-hq/sql/2026-08-16_event_research_ingestion.sql" >/dev/null
+}
+
+rollback_migration() {
+  docker exec -i "$TDF_EVENT_RESEARCH_CONTAINER" psql -v ON_ERROR_STOP=1 -U postgres -d tdf_event_research_test \
+    < "$TDF_EVENT_RESEARCH_ROOT/tdf-hq/sql/2026-08-16_event_research_ingestion.down.sql" >/dev/null
+}
+
+apply_migration
+
+source_count=$(psql_exec -Atc "SELECT count(*) FROM event_discovery_source WHERE source_type = 'web' AND NOT enabled;")
+if [ "$source_count" != "7" ]; then
+  echo "Expected seven disabled web research sources, got $source_count" >&2
+  exit 1
+fi
+
+psql_exec -c "INSERT INTO event_research_run (run_key, status, reconciliation, counters, started_at, updated_at, created_by_party_id) VALUES ('test-run', 'running', true, '{}', now(), now(), '1');" >/dev/null
+
+psql_exec -c "INSERT INTO event_research_candidate (provider, external_id, run_id, review_state, title, timezone, country_code, source_url, payload, evidence, confidence, managed_fields, content_hash, verified_at, is_pilot, created_at, updated_at) SELECT 'fixture', 'event-' || value, 1, 'draft', 'Event ' || value, 'America/Guayaquil', 'EC', 'https://official.example/event/' || value, '{}', '[{\"url\":\"https://official.example\"}]', 'medium', '[]', repeat('a', 64), now(), true, now(), now() FROM generate_series(1, 20) AS value;" >/dev/null
+
+if psql_exec -c "INSERT INTO event_research_candidate (provider, external_id, run_id, review_state, title, timezone, country_code, source_url, payload, evidence, confidence, managed_fields, content_hash, verified_at, is_pilot, created_at, updated_at) VALUES ('fixture', 'event-21', 1, 'draft', 'Event 21', 'America/Guayaquil', 'EC', 'https://official.example/event/21', '{}', '[{\"url\":\"https://official.example\"}]', 'medium', '[]', repeat('b', 64), now(), true, now(), now());" >/dev/null 2>&1; then
+  echo "Pilot limit did not reject candidate 21" >&2
+  exit 1
+fi
+
+psql_exec -c "INSERT INTO event_research_candidate (provider, external_id, run_id, review_state, title, timezone, country_code, source_url, payload, evidence, confidence, managed_fields, content_hash, verified_at, is_pilot, created_at, updated_at) VALUES ('fixture', 'event-1', 1, 'draft', 'Event 1 retry', 'America/Guayaquil', 'EC', 'https://official.example/event/1', '{}', '[{\"url\":\"https://official.example\"}]', 'medium', '[]', repeat('c', 64), now(), true, now(), now()) ON CONFLICT (provider, external_id) DO UPDATE SET title = EXCLUDED.title, content_hash = EXCLUDED.content_hash;" >/dev/null
+
+candidate_count=$(psql_exec -Atc 'SELECT count(*) FROM event_research_candidate;')
+if [ "$candidate_count" != "20" ]; then
+  echo "Idempotent retry created a duplicate candidate" >&2
+  exit 1
+fi
+
+psql_exec -c "UPDATE event_research_candidate SET review_state = 'discarded' WHERE provider = 'fixture' AND external_id = 'event-2';" >/dev/null
+psql_exec -c "INSERT INTO event_research_candidate (provider, external_id, run_id, review_state, title, timezone, country_code, source_url, payload, evidence, confidence, managed_fields, content_hash, verified_at, is_pilot, created_at, updated_at) VALUES ('fixture', 'replacement', 1, 'review', 'Replacement', 'America/Guayaquil', 'EC', 'https://official.example/replacement', '{}', '[{\"url\":\"https://official.example\"}]', 'medium', '[]', repeat('d', 64), now(), true, now(), now());" >/dev/null
+
+active_count=$(psql_exec -Atc "SELECT count(*) FROM event_research_candidate WHERE is_pilot AND review_state <> 'discarded';")
+if [ "$active_count" != "20" ]; then
+  echo "Discard-and-replace did not preserve the active pilot limit" >&2
+  exit 1
+fi
+
+rollback_migration
+
+remaining=$(psql_exec -Atc "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name LIKE 'event_research_%';")
+if [ "$remaining" != "0" ]; then
+  echo "Rollback left event research tables behind" >&2
+  exit 1
+fi
+
+apply_migration
+
+echo "Event research migration passed source seed, pilot cap, idempotency, replacement, rollback, and reapply checks."

--- a/tdf-hq-ui/src/api/eventDiscoverySources.ts
+++ b/tdf-hq-ui/src/api/eventDiscoverySources.ts
@@ -1,6 +1,6 @@
 import { get, post, put } from './client';
 
-export type EventDiscoverySourceType = 'ticketmaster' | 'buenplan' | 'ical' | 'json';
+export type EventDiscoverySourceType = 'ticketmaster' | 'buenplan' | 'ical' | 'json' | 'web';
 
 export interface EventDiscoverySource {
   discoverySourceId: string;

--- a/tdf-hq-ui/src/api/eventResearch.ts
+++ b/tdf-hq-ui/src/api/eventResearch.ts
@@ -1,0 +1,125 @@
+import { get, post, put } from './client';
+
+export type EventResearchConfidence = 'high' | 'medium' | 'low';
+export type EventResearchReviewState = 'draft' | 'review' | 'discarded';
+export type EventResearchRunStatus = 'running' | 'completed' | 'failed';
+
+export interface EventResearchEvidence {
+  erEvidenceUrl: string;
+  erEvidenceKind: string;
+  erEvidenceConsultedAt: string;
+  erEvidenceNotes?: string | null;
+}
+
+export interface EventResearchPilot {
+  erPilotApproved: boolean;
+  erPilotApprovedAt?: string | null;
+  erPilotApprovedByPartyId?: string | null;
+  erPilotApprovalReference?: string | null;
+  erPilotMaxActiveCandidates: number;
+  erPilotActiveCandidates: number;
+  erPilotUpdatedAt: string;
+}
+
+export interface EventResearchRun {
+  erRunId: string;
+  erRunKey: string;
+  erRunStatus: EventResearchRunStatus;
+  erRunReconciliation: boolean;
+  erRunCheckpoint?: string | null;
+  erRunCounters: Record<string, unknown>;
+  erRunErrorSummary?: string | null;
+  erRunStartedAt: string;
+  erRunUpdatedAt: string;
+  erRunFinishedAt?: string | null;
+  erRunCreatedByPartyId: string;
+}
+
+export interface EventResearchCandidateWrite {
+  erCandidateProvider: string;
+  erCandidateExternalId: string;
+  erCandidateRunId: string;
+  erCandidateSourceId?: string | null;
+  erCandidateReviewState: EventResearchReviewState;
+  erCandidateTitle: string;
+  erCandidateStartTime?: string | null;
+  erCandidateEndTime?: string | null;
+  erCandidateTimezone: string;
+  erCandidateVenueName?: string | null;
+  erCandidateCity?: string | null;
+  erCandidateProvince?: string | null;
+  erCandidateCountryCode: string;
+  erCandidateSourceUrl: string;
+  erCandidateInfoUrl?: string | null;
+  erCandidatePurchaseUrl?: string | null;
+  erCandidatePayload: Record<string, unknown>;
+  erCandidateEvidence: EventResearchEvidence[];
+  erCandidateConfidence: EventResearchConfidence;
+  erCandidateManagedFields: string[];
+  erCandidateVerifiedAt: string;
+}
+
+export interface EventResearchCandidate extends EventResearchCandidateWrite {
+  erCandidateId: string;
+  erCandidateEventId?: string | null;
+  erCandidateContentHash: string;
+  erCandidateIsPilot: boolean;
+  erCandidateCreatedAt: string;
+  erCandidateUpdatedAt: string;
+}
+
+export interface EventResearchChange {
+  erChangeId: string;
+  erChangeRunId: string;
+  erChangeCandidateId?: string | null;
+  erChangeEventId?: string | null;
+  erChangeAction: string;
+  erChangeBeforeValue?: Record<string, unknown> | null;
+  erChangeAfterValue?: Record<string, unknown> | null;
+  erChangeSourceUrl: string;
+  erChangeConfidence: EventResearchConfidence;
+  erChangeConsultedAt: string;
+  erChangeExternalId: string;
+  erChangeResult: string;
+  erChangeCreatedAt: string;
+}
+
+const queryString = (entries: Record<string, string | number | undefined>) => {
+  const params = new URLSearchParams();
+  Object.entries(entries).forEach(([key, value]) => {
+    if (value !== undefined) params.set(key, String(value));
+  });
+  const encoded = params.toString();
+  return encoded ? `?${encoded}` : '';
+};
+
+export const EventResearchAPI = {
+  getPilot: () => get<EventResearchPilot>('/social-events/event-research/pilot'),
+  approvePilot: (approvalReference: string) =>
+    post<EventResearchPilot>('/social-events/event-research/pilot/approve', {
+      erPilotApprovalReference: approvalReference,
+    }),
+  listRuns: (limit = 100) =>
+    get<EventResearchRun[]>(`/social-events/event-research/runs${queryString({ limit })}`),
+  createRun: (payload: { erRunKey: string; erRunReconciliation: boolean; erRunCheckpoint?: string | null }) =>
+    post<EventResearchRun>('/social-events/event-research/runs', payload),
+  updateRun: (runId: string, payload: {
+    erRunStatus: EventResearchRunStatus;
+    erRunCheckpoint?: string | null;
+    erRunCounters: Record<string, unknown>;
+    erRunErrorSummary?: string | null;
+  }) => put<EventResearchRun>(`/social-events/event-research/runs/${encodeURIComponent(runId)}`, payload),
+  listCandidates: (filters: { provider?: string; reviewState?: EventResearchReviewState; limit?: number } = {}) =>
+    get<EventResearchCandidate[]>(`/social-events/event-research/candidates${queryString({
+      provider: filters.provider,
+      review_state: filters.reviewState,
+      limit: filters.limit,
+    })}`),
+  upsertCandidate: (payload: EventResearchCandidateWrite) =>
+    put<EventResearchCandidate>('/social-events/event-research/candidates', payload),
+  listChanges: (filters: { runId?: string; limit?: number } = {}) =>
+    get<EventResearchChange[]>(`/social-events/event-research/changes${queryString({
+      run_id: filters.runId,
+      limit: filters.limit,
+    })}`),
+};

--- a/tdf-hq-ui/src/api/generated/types.ts
+++ b/tdf-hq-ui/src/api/generated/types.ts
@@ -39,6 +39,113 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/social-events/event-research/pilot": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Read accumulated pilot state */
+        get: operations["getEventResearchPilot"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/social-events/event-research/pilot/approve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Record an explicit, immutable pilot approval */
+        post: operations["approveEventResearchPilot"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/social-events/event-research/runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List research runs and checkpoints */
+        get: operations["listEventResearchRuns"];
+        put?: never;
+        /** Idempotently start a research run by run key */
+        post: operations["createEventResearchRun"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/social-events/event-research/runs/{runId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Commit a run checkpoint or terminal status */
+        put: operations["updateEventResearchRun"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/social-events/event-research/candidates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List accumulated research candidates */
+        get: operations["listEventResearchCandidates"];
+        /**
+         * Idempotently create, update, or reverify a candidate
+         * @description Uses provider plus external identifier as the canonical key. It never publishes a social event.
+         */
+        put: operations["upsertEventResearchCandidate"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/social-events/event-research/changes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List immutable candidate change records */
+        get: operations["listEventResearchChanges"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/version": {
         parameters: {
             query?: never;
@@ -2976,6 +3083,118 @@ export interface components {
             emReactions: components["schemas"]["EventMomentReaction"][];
             emComments: components["schemas"]["EventMomentComment"][];
         };
+        EventResearchPilot: {
+            erPilotApproved: boolean;
+            /** Format: date-time */
+            erPilotApprovedAt?: string | null;
+            erPilotApprovedByPartyId?: string | null;
+            erPilotApprovalReference?: string | null;
+            /** @enum {integer} */
+            erPilotMaxActiveCandidates: 20;
+            erPilotActiveCandidates: number;
+            /** Format: date-time */
+            erPilotUpdatedAt: string;
+        };
+        EventResearchRunCreate: {
+            erRunKey: string;
+            erRunReconciliation: boolean;
+            erRunCheckpoint?: string | null;
+        };
+        EventResearchRunUpdate: {
+            /** @enum {string} */
+            erRunStatus: "running" | "completed" | "failed";
+            erRunCheckpoint?: string | null;
+            erRunCounters: {
+                [key: string]: unknown;
+            };
+            erRunErrorSummary?: string | null;
+        };
+        EventResearchRun: components["schemas"]["EventResearchRunCreate"] & components["schemas"]["EventResearchRunUpdate"] & {
+            erRunId: string;
+            /** Format: date-time */
+            erRunStartedAt: string;
+            /** Format: date-time */
+            erRunUpdatedAt: string;
+            /** Format: date-time */
+            erRunFinishedAt?: string | null;
+            erRunCreatedByPartyId: string;
+        };
+        EventResearchEvidence: {
+            /** Format: uri */
+            erEvidenceUrl: string;
+            erEvidenceKind: string;
+            /** Format: date-time */
+            erEvidenceConsultedAt: string;
+            erEvidenceNotes?: string | null;
+        };
+        EventResearchCandidateWrite: {
+            erCandidateProvider: string;
+            erCandidateExternalId: string;
+            erCandidateRunId: string;
+            erCandidateSourceId?: string | null;
+            /** @enum {string} */
+            erCandidateReviewState: "draft" | "review" | "discarded";
+            erCandidateTitle: string;
+            /** Format: date-time */
+            erCandidateStartTime?: string | null;
+            /** Format: date-time */
+            erCandidateEndTime?: string | null;
+            /** @example America/Guayaquil */
+            erCandidateTimezone: string;
+            erCandidateVenueName?: string | null;
+            erCandidateCity?: string | null;
+            erCandidateProvince?: string | null;
+            erCandidateCountryCode: string;
+            /** Format: uri */
+            erCandidateSourceUrl: string;
+            /** Format: uri */
+            erCandidateInfoUrl?: string | null;
+            /** Format: uri */
+            erCandidatePurchaseUrl?: string | null;
+            erCandidatePayload: {
+                [key: string]: unknown;
+            };
+            erCandidateEvidence: components["schemas"]["EventResearchEvidence"][];
+            /** @enum {string} */
+            erCandidateConfidence: "high" | "medium" | "low";
+            erCandidateManagedFields: string[];
+            /** Format: date-time */
+            erCandidateVerifiedAt: string;
+        };
+        EventResearchCandidate: components["schemas"]["EventResearchCandidateWrite"] & {
+            erCandidateId: string;
+            erCandidateEventId?: string | null;
+            erCandidateContentHash: string;
+            erCandidateIsPilot: boolean;
+            /** Format: date-time */
+            erCandidateCreatedAt: string;
+            /** Format: date-time */
+            erCandidateUpdatedAt: string;
+        };
+        EventResearchChange: {
+            erChangeId: string;
+            erChangeRunId: string;
+            erChangeCandidateId?: string | null;
+            erChangeEventId?: string | null;
+            /** @enum {string} */
+            erChangeAction: "created" | "updated" | "verified" | "discarded" | "materialized";
+            erChangeBeforeValue?: {
+                [key: string]: unknown;
+            } | null;
+            erChangeAfterValue?: {
+                [key: string]: unknown;
+            } | null;
+            /** Format: uri */
+            erChangeSourceUrl: string;
+            /** @enum {string} */
+            erChangeConfidence: "high" | "medium" | "low";
+            /** Format: date-time */
+            erChangeConsultedAt: string;
+            erChangeExternalId: string;
+            erChangeResult: string;
+            /** Format: date-time */
+            erChangeCreatedAt: string;
+        };
         SocialEvent: {
             eventId?: string | null;
             eventOrganizerPartyId?: string | null;
@@ -2985,6 +3204,8 @@ export interface components {
             eventStart: string;
             /** Format: date-time */
             eventEnd: string;
+            /** @example America/Guayaquil */
+            eventTimezone?: string | null;
             eventVenueId?: string | null;
             eventPriceCents?: number | null;
             eventCapacity?: number | null;
@@ -5231,6 +5452,230 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    getEventResearchPilot: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Pilot approval and active-candidate count */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EventResearchPilot"];
+                };
+            };
+            /** @description Strict administrator access is required */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    approveEventResearchPilot: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    erPilotApprovalReference: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Approved pilot state */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EventResearchPilot"];
+                };
+            };
+            /** @description Strict administrator access is required */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description The pilot has a different existing approval reference */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    listEventResearchRuns: {
+        parameters: {
+            query?: {
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Research runs */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EventResearchRun"][];
+                };
+            };
+        };
+    };
+    createEventResearchRun: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EventResearchRunCreate"];
+            };
+        };
+        responses: {
+            /** @description Existing or newly created run */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EventResearchRun"];
+                };
+            };
+        };
+    };
+    updateEventResearchRun: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                runId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EventResearchRunUpdate"];
+            };
+        };
+        responses: {
+            /** @description Updated run */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EventResearchRun"];
+                };
+            };
+            /** @description A completed run cannot be reopened */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    listEventResearchCandidates: {
+        parameters: {
+            query?: {
+                provider?: string;
+                review_state?: "draft" | "review" | "discarded";
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Research candidates */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EventResearchCandidate"][];
+                };
+            };
+        };
+    };
+    upsertEventResearchCandidate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EventResearchCandidateWrite"];
+            };
+        };
+        responses: {
+            /** @description Upserted candidate */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EventResearchCandidate"];
+                };
+            };
+            /** @description Pilot cap reached or a closed run received a material change */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    listEventResearchChanges: {
+        parameters: {
+            query?: {
+                run_id?: string;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Auditable candidate changes */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EventResearchChange"][];
+                };
             };
         };
     };

--- a/tdf-hq-ui/src/api/socialEvents.ts
+++ b/tdf-hq-ui/src/api/socialEvents.ts
@@ -37,6 +37,7 @@ export interface SocialEventDTO {
   eventDescription?: string | null;
   eventStart: string;
   eventEnd: string;
+  eventTimezone?: string | null;
   eventVenueId?: string | null;
   eventPriceCents?: number | null;
   eventCapacity?: number | null;

--- a/tdf-hq-ui/src/pages/EventDiscoverySourcesPage.tsx
+++ b/tdf-hq-ui/src/pages/EventDiscoverySourcesPage.tsx
@@ -37,6 +37,7 @@ const sourceTypes: { value: EventDiscoverySourceType; label: string }[] = [
   { value: 'json', label: 'Venue JSON' },
   { value: 'ticketmaster', label: 'Ticketmaster' },
   { value: 'buenplan', label: 'Buen Plan' },
+  { value: 'web', label: 'Web oficial (investigación manual)' },
 ];
 
 const draftFromSource = (source: EventDiscoverySource): SourceDraft => ({
@@ -61,6 +62,9 @@ const emptyDraft = (): SourceDraft => ({
 
 const isVenueFeed = (sourceType: EventDiscoverySourceType) =>
   sourceType === 'ical' || sourceType === 'json';
+
+const hasSourceUrl = (sourceType: EventDiscoverySourceType) =>
+  isVenueFeed(sourceType) || sourceType === 'web';
 
 const formatTimestamp = (value?: string | null) => {
   if (!value) return 'Nunca';
@@ -221,13 +225,14 @@ export default function EventDiscoverySourcesPage() {
 
 function normalizeDraft(draft: SourceDraft): SourceDraft {
   const venueFeed = isVenueFeed(draft.discoverySourceWriteType);
+  const sourceUrl = hasSourceUrl(draft.discoverySourceWriteType);
   const normalizedFeedUrl = draft.discoverySourceWriteFeedUrl?.trim() ?? null;
   const normalizedCityId = draft.discoverySourceWriteCityId?.trim() ?? null;
   return {
     ...draft,
     discoverySourceWriteKey: draft.discoverySourceWriteKey.trim().toLowerCase(),
     discoverySourceWriteName: draft.discoverySourceWriteName.trim(),
-    discoverySourceWriteFeedUrl: venueFeed
+    discoverySourceWriteFeedUrl: sourceUrl
       ? normalizedFeedUrl
       : null,
     discoverySourceWriteCityId: venueFeed
@@ -249,9 +254,11 @@ function SourceFields({
   onChange: (update: Partial<SourceDraft>) => void;
 }) {
   const venueFeed = isVenueFeed(draft.discoverySourceWriteType);
+  const sourceUrl = hasSourceUrl(draft.discoverySourceWriteType);
+  const manualWeb = draft.discoverySourceWriteType === 'web';
   const availableSourceTypes = lockProviderIdentity
     ? sourceTypes
-    : sourceTypes.filter((sourceType) => isVenueFeed(sourceType.value));
+    : sourceTypes.filter((sourceType) => isVenueFeed(sourceType.value) || sourceType.value === 'web');
   return (
     <Stack spacing={1.25}>
       <Stack direction={{ xs: 'column', md: 'row' }} spacing={1.25}>
@@ -276,9 +283,13 @@ function SourceFields({
           select
           label="Tipo"
           value={draft.discoverySourceWriteType}
-          onChange={(event) =>
-            onChange({ discoverySourceWriteType: event.target.value as EventDiscoverySourceType })
-          }
+          onChange={(event) => {
+            const nextType = event.target.value as EventDiscoverySourceType;
+            onChange({
+              discoverySourceWriteType: nextType,
+              ...(nextType === 'web' ? { discoverySourceWriteEnabled: false } : {}),
+            });
+          }}
           disabled={lockProviderIdentity}
           size="small"
           fullWidth
@@ -290,17 +301,17 @@ function SourceFields({
           ))}
         </TextField>
       </Stack>
-      {venueFeed && (
+      {sourceUrl && (
         <Stack direction={{ xs: 'column', md: 'row' }} spacing={1.25}>
           <TextField
-            label="URL HTTPS del feed"
+            label={manualWeb ? 'URL HTTPS oficial' : 'URL HTTPS del feed'}
             value={draft.discoverySourceWriteFeedUrl ?? ''}
             onChange={(event) => onChange({ discoverySourceWriteFeedUrl: event.target.value })}
             size="small"
             fullWidth
             inputProps={{ maxLength: 2048 }}
           />
-          <TextField
+          {venueFeed && <TextField
             select
             label="Ciudad"
             value={draft.discoverySourceWriteCityId ?? ''}
@@ -313,7 +324,7 @@ function SourceFields({
                 {city.eventCityName} · {city.eventCityCountryCode}
               </MenuItem>
             ))}
-          </TextField>
+          </TextField>}
         </Stack>
       )}
       <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} alignItems={{ sm: 'center' }}>
@@ -331,6 +342,7 @@ function SourceFields({
           control={(
             <Switch
               checked={draft.discoverySourceWriteEnabled}
+              disabled={manualWeb}
               onChange={(event) =>
                 onChange({ discoverySourceWriteEnabled: event.target.checked })
               }

--- a/tdf-hq/docs/Event_Research_Ingestion.md
+++ b/tdf-hq/docs/Event_Research_Ingestion.md
@@ -1,0 +1,37 @@
+# Event research ingestion
+
+This workflow stores evidence-backed web research separately from published social events. It is intended for Ecuador event discovery where many official ticketing sources expose HTML, social posts, queue pages, or other material that the automated structured-feed cron must not scrape.
+
+## Safety boundary
+
+- Every route under `/social-events/event-research` requires strict administrator access.
+- Candidate upserts never create or publish a `social_event`.
+- Before explicit pilot approval, the database permits at most 20 active pilot candidates across all runs. A discarded candidate frees one slot; no record is deleted.
+- Pilot approval is an explicit `POST /social-events/event-research/pilot/approve` with a durable reference. It is append-audited and cannot be silently replaced with a different reference.
+- `web` discovery sources are registry entries for manual research only. They require an HTTPS official URL and must remain disabled, so the structured-feed cron never treats HTML as a feed.
+- A candidate records its IANA timezone, primary source, evidence list, verification time, confidence, source-owned fields, and the complete normalized payload.
+
+## Idempotent batch flow
+
+1. Read `GET /social-events/event-research/pilot` and the latest runs. Do not start a new unapproved pilot if 20 active candidates already exist.
+2. `POST /social-events/event-research/runs` with a stable run key such as `ecuador-events-2026-08-16`. Reusing the key returns the existing run.
+3. Process bounded source batches. `PUT /social-events/event-research/candidates` uses `(provider, externalId)` as its unique key.
+4. Commit the last confirmed source position with `PUT /social-events/event-research/runs/{runId}`. A retry with the same content creates neither a candidate duplicate nor a duplicate change entry.
+5. Close the run as `completed` or `failed`. A completed run cannot be reopened; exact candidate retries remain readable and materially different writes are rejected.
+6. Audit the result through `GET /social-events/event-research/changes?run_id=...`.
+
+The content hash excludes run identity, verification timestamp, and evidence consultation timestamps. A later verification of unchanged source content is recorded as `verified`; a changed normalized payload is recorded as `updated`, with before and after values.
+
+## Confidence
+
+`high` is accepted only when the start time, venue, city, direct purchase URL, and an `official_sale` evidence item are present. End times remain optional unless the official source confirms them. `medium` and `low` candidates may preserve incomplete or contradictory information in review, but still require an official HTTPS source and at least one evidence item containing the primary source URL.
+
+## Schema rollout and rollback
+
+Apply `tdf-hq/sql/2026-08-16_event_research_ingestion.sql` before deploying code that uses these routes. The reverse migration is `tdf-hq/sql/2026-08-16_event_research_ingestion.down.sql`. The isolated regression script is:
+
+```sh
+./scripts/test-event-research-ingestion-migration.sh
+```
+
+It verifies the seven disabled source seeds, the accumulated cap, retry idempotency, discard-and-replace behavior, rollback, and clean reapplication.

--- a/tdf-hq/docs/event-research-runs/2026-08-16-ecuador-pilot.json
+++ b/tdf-hq/docs/event-research-runs/2026-08-16-ecuador-pilot.json
@@ -1,0 +1,189 @@
+{
+  "runKey": "ecuador-events-2026-08-16",
+  "researchedAt": "2026-08-16T10:46:20-05:00",
+  "researchWindow": { "from": "2026-08-16", "through": "2027-08-16" },
+  "defaultTimezone": "America/Guayaquil",
+  "sundayFullReconciliation": true,
+  "checkpoint": "reconciliation-complete:candidates-verified:20:api-write-not-started",
+  "result": "blocked_before_write",
+  "blockers": [
+    "The attached administrative browser redirected to login; no authenticated API session was available.",
+    "The production schema has no research candidate, evidence, pilot-control, or change-audit contract.",
+    "Passline presented a Cloudflare challenge and Feel The Tickets presented a Queue-it waiting room; neither control was bypassed."
+  ],
+  "productionSnapshot": {
+    "environment": "production",
+    "baseUrl": "https://tdf-hq.fly.dev",
+    "health": "ok",
+    "productionCommit": "d10e7cdf",
+    "pilotApprovalFound": false,
+    "eventsWritten": 0,
+    "eventsPublished": 0,
+    "existingEventsInHorizon": 7,
+    "existingEventsWithTimezone": 0,
+    "existingEventsWithSource": 0,
+    "existingExternalReferences": 0,
+    "exactDuplicateReview": ["social_event:88", "social_event:89"]
+  },
+  "sourcesReviewed": [
+    "https://www.instagram.com/meet2go/",
+    "https://www.instagram.com/passline.ec/",
+    "https://www.instagram.com/buenplantickets/",
+    "https://www.instagram.com/feelthetickets.ec/",
+    "https://www.instagram.com/ticketshow/",
+    "https://www.meet2go.com/",
+    "https://www.buenplan.com.ec/",
+    "https://www.ticketshow.com.ec/",
+    "https://www.feelthetickets.com/",
+    "https://www.ontimetickets.com/",
+    "https://conciertos.output.ec/",
+    "https://visitquito.ec/es/grandes-eventos-calendario/"
+  ],
+  "newOfficialSources": [
+    { "name": "On Time Tickets", "kind": "ticket_seller", "url": "https://www.ontimetickets.com/" },
+    { "name": "Output Concerts", "kind": "organizer_promoter", "url": "https://conciertos.output.ec/" },
+    { "name": "Visit Quito", "kind": "municipal_verification", "url": "https://visitquito.ec/es/grandes-eventos-calendario/" }
+  ],
+  "candidates": [
+    {
+      "provider": "buenplan", "externalId": "metal-sinfonico-quito-2026-08-21", "title": "Metal Sinfónico", "slug": "metal-sinfonico-quito-2026",
+      "localDate": "2026-08-21", "startTime": "2026-08-21T19:00:00-05:00", "endTime": null, "timezone": "America/Guayaquil",
+      "venue": "Teatro Nacional de la Casa de la Cultura Ecuatoriana", "address": null, "city": "Quito", "province": "Pichincha", "country": "EC", "coordinates": null,
+      "lineup": ["Fabio Lione", "Edu Falaschi", "Christian Bertoncelli"], "organizer": null, "promoter": null, "ticketSeller": "BuenPlan",
+      "purchaseUrl": null, "sourceUrl": "https://www.buenplan.com.ec/", "prices": [{"category":"Box","amount":75,"currency":"USD"},{"category":"Black","amount":40,"currency":"USD"},{"category":"VIP","amount":25,"currency":"USD"}],
+      "ageRestriction": "Todo público", "eventType": "concert", "genres": ["metal", "symphonic metal"], "candidateState": "review", "plannedTdfStatus": "draft", "confidence": "medium",
+      "reviewReason": "The official seller confirms essentials, but no stable direct event URL was found.", "inferences": [], "description": "Concierto sinfónico de metal con tres vocalistas internacionales y acompañamiento orquestal.",
+      "image": {"url":null,"source":"https://www.buenplan.com.ec/","attribution":"BuenPlan; permission pending"}, "evidence": [{"url":"https://www.buenplan.com.ec/","kind":"official_sale_listing","consultedAt":"2026-08-16T10:46:20-05:00"}]
+    },
+    {
+      "provider": "buenplan", "externalId": "ken-y-2026-quito", "title": "Ken-Y en Quito", "slug": "ken-y-quito-2026",
+      "localDate": "2026-09-11", "startTime": "2026-09-11T19:00:00-05:00", "endTime": null, "timezone": "America/Guayaquil",
+      "venue": "Ágora de la Casa de la Cultura Ecuatoriana", "address": null, "city": "Quito", "province": "Pichincha", "country": "EC", "coordinates": null,
+      "lineup": ["Ken-Y"], "organizer": "Street Show", "promoter": "Street Show", "ticketSeller": "BuenPlan", "purchaseUrl": "https://www.buenplan.com.ec/event/ken-y-2026-quito", "sourceUrl": "https://www.buenplan.com.ec/event/ken-y-2026-quito",
+      "prices": [{"category":"General","amount":20,"currency":"USD","fees":"USD 3 IVA"},{"category":"Preferencia","amount":35,"currency":"USD","fees":"USD 5.25 IVA"}], "ageRestriction": "16+", "eventType": "concert", "genres": ["reggaeton", "latin urban"],
+      "candidateState": "review", "plannedTdfStatus": "draft", "confidence": "high", "reviewReason": "Pilot is not approved.", "inferences": [], "description": "Presentación en Quito del repertorio urbano y romántico de Ken-Y.",
+      "image": {"url":null,"source":"https://www.buenplan.com.ec/event/ken-y-2026-quito","attribution":"BuenPlan; permission pending"}, "evidence": [{"url":"https://www.buenplan.com.ec/event/ken-y-2026-quito","kind":"official_sale","consultedAt":"2026-08-16T10:46:20-05:00"}]
+    },
+    {
+      "provider": "buenplan", "externalId": "trueno-turrazo-quito", "title": "Trueno — Tour Turr4zo", "slug": "trueno-tour-turr4zo-quito-2026",
+      "localDate": "2026-09-19", "startTime": "2026-09-19T19:00:00-05:00", "endTime": null, "timezone": "America/Guayaquil", "venue": "Coliseo General Rumiñahui", "address": null, "city": "Quito", "province": "Pichincha", "country": "EC", "coordinates": null,
+      "lineup": ["Trueno"], "organizer": "Pulso", "promoter": "Pulso", "ticketSeller": "BuenPlan", "purchaseUrl": "https://www.buenplan.com.ec/event/trueno-turrazo-quito", "sourceUrl": "https://www.buenplan.com.ec/event/trueno-turrazo-quito",
+      "prices": [{"category":"Top","amount":120,"currency":"USD","fees":"IVA adicional"},{"category":"Tier 2","amount":70,"currency":"USD","fees":"IVA adicional"},{"category":"Tier 3","amount":50,"currency":"USD","fees":"IVA adicional"},{"category":"Tier 4","amount":35,"currency":"USD","fees":"IVA adicional"}], "ageRestriction": "Todo público", "eventType": "concert", "genres": ["hip hop", "latin urban"],
+      "candidateState": "review", "plannedTdfStatus": "draft", "confidence": "high", "reviewReason": "Pilot is not approved.", "inferences": [], "description": "Fecha quiteña de la gira Turr4zo del rapero argentino Trueno.", "image": {"url":null,"source":"https://www.buenplan.com.ec/event/trueno-turrazo-quito","attribution":"BuenPlan; permission pending"}, "evidence": [{"url":"https://www.buenplan.com.ec/event/trueno-turrazo-quito","kind":"official_sale","consultedAt":"2026-08-16T10:46:20-05:00"}]
+    },
+    {
+      "provider": "buenplan", "externalId": "sonata-arctica-2026-quito", "title": "Sonata Arctica — Rock United", "slug": "sonata-arctica-rock-united-quito-2026",
+      "localDate": "2026-09-23", "startTime": "2026-09-23T20:00:00-05:00", "endTime": null, "timezone": "America/Guayaquil", "venue": "Teatro San Gabriel", "address": null, "city": "Quito", "province": "Pichincha", "country": "EC", "coordinates": null,
+      "lineup": ["Sonata Arctica", "Black Sun", "Kill City"], "organizer": "Alive", "promoter": "Alive", "ticketSeller": "BuenPlan", "purchaseUrl": "https://www.buenplan.com.ec/event/sonata-arctica-2026-quito", "sourceUrl": "https://www.buenplan.com.ec/event/sonata-arctica-2026-quito",
+      "prices": [{"category":"Tier 1","amount":69.99,"currency":"USD"},{"category":"Tier 2","amount":59.99,"currency":"USD"}], "ageRestriction": "16+", "eventType": "concert", "genres": ["power metal"], "candidateState": "review", "plannedTdfStatus": "draft", "confidence": "high", "reviewReason": "Pilot is not approved.", "inferences": [], "description": "Sonata Arctica encabeza una noche de power metal junto a Black Sun y Kill City.",
+      "image": {"url":null,"source":"https://www.buenplan.com.ec/event/sonata-arctica-2026-quito","attribution":"BuenPlan; permission pending"}, "evidence": [{"url":"https://www.buenplan.com.ec/event/sonata-arctica-2026-quito","kind":"official_sale","consultedAt":"2026-08-16T10:46:20-05:00"}]
+    },
+    {
+      "provider": "buenplan", "externalId": "akriila-2026-quito", "title": "Akriila — El Tour de Lucy", "slug": "akriila-tour-de-lucy-quito-2026",
+      "localDate": "2026-10-24", "startTime": "2026-10-24T20:00:00-05:00", "endTime": null, "timezone": "America/Guayaquil", "venue": "Teatro San Gabriel", "address": null, "city": "Quito", "province": "Pichincha", "country": "EC", "coordinates": null,
+      "lineup": ["Akriila"], "organizer": "Pulso", "promoter": "Pulso", "ticketSeller": "BuenPlan", "purchaseUrl": "https://www.buenplan.com.ec/event/akriila-2026-quito", "sourceUrl": "https://www.buenplan.com.ec/event/akriila-2026-quito",
+      "prices": [{"category":"Tier 1","amount":50,"currency":"USD"},{"category":"Tier 2","amount":40,"currency":"USD"},{"category":"Tier 3","amount":30,"currency":"USD"}], "ageRestriction": "Todo público", "eventType": "concert", "genres": ["latin urban", "alternative pop"], "candidateState": "review", "plannedTdfStatus": "draft", "confidence": "high", "reviewReason": "Pilot is not approved; an earlier tier appeared sold out, not the full event.", "inferences": [], "description": "Akriila presenta en Quito su gira El Tour de Lucy.",
+      "image": {"url":null,"source":"https://www.buenplan.com.ec/event/akriila-2026-quito","attribution":"BuenPlan; permission pending"}, "evidence": [{"url":"https://www.buenplan.com.ec/event/akriila-2026-quito","kind":"official_sale","consultedAt":"2026-08-16T10:46:20-05:00"}]
+    },
+    {
+      "provider": "buenplan", "externalId": "iron-maiden-quito-2026", "title": "Iron Maiden — Run For Your Lives", "slug": "iron-maiden-run-for-your-lives-quito-2026",
+      "localDate": "2026-10-14", "startTime": "2026-10-14T21:00:00-05:00", "endTime": null, "timezone": "America/Guayaquil", "venue": "Estadio Olímpico Atahualpa", "address": null, "city": "Quito", "province": "Pichincha", "country": "EC", "coordinates": null,
+      "lineup": ["Iron Maiden", "The Raven Age"], "organizer": "Move Concerts", "promoter": "Move Concerts / Sight Concerts", "ticketSeller": "BuenPlan", "purchaseUrl": "https://www.buenplan.com.ec/ironmaiden/", "sourceUrl": "https://www.buenplan.com.ec/ironmaiden/",
+      "prices": [{"category":"Tier 1","amount":185,"currency":"USD","fees":"27.75 servicio + 31.91 IVA"},{"category":"Tier 2","amount":155,"currency":"USD","fees":"23.25 servicio + 26.74 IVA"},{"category":"Tier 3","amount":125,"currency":"USD","fees":"18.75 servicio + 21.56 IVA"},{"category":"Tier 4","amount":99,"currency":"USD","fees":"14.85 servicio + 17.08 IVA"},{"category":"Tier 5","amount":65,"currency":"USD","fees":"9.75 servicio + 11.21 IVA"},{"category":"Tier 6","amount":55,"currency":"USD","fees":"8.25 servicio + 9.49 IVA"}], "ageRestriction": null, "eventType": "concert", "genres": ["heavy metal"],
+      "candidateState": "review", "plannedTdfStatus": "draft", "confidence": "high", "reviewReason": "Pilot is not approved.", "inferences": [], "description": "Iron Maiden llega a Quito con la gira Run For Your Lives y The Raven Age como invitado.", "image": {"url":null,"source":"https://www.buenplan.com.ec/ironmaiden/","attribution":"BuenPlan / promoter; permission pending"}, "evidence": [{"url":"https://www.buenplan.com.ec/ironmaiden/","kind":"official_sale","consultedAt":"2026-08-16T10:46:20-05:00"}]
+    },
+    {
+      "provider": "ticketshow", "externalId": "ZHAMIRA-QUITO-2026", "title": "Zhamira Zambrano en Quito", "slug": "zhamira-zambrano-quito-2026",
+      "localDate": "2026-08-23", "startTime": "2026-08-23T20:00:00-05:00", "endTime": null, "timezone": "America/Guayaquil", "venue": "Teatro San Gabriel", "address": null, "city": "Quito", "province": "Pichincha", "country": "EC", "coordinates": null,
+      "lineup": ["Zhamira Zambrano"], "organizer": "Output", "promoter": "Output", "ticketSeller": "TicketShow", "purchaseUrl": "https://www.ticketshow.com.ec/evento/ZHAMIRA-QUITO-2026", "sourceUrl": "https://www.ticketshow.com.ec/evento/ZHAMIRA-QUITO-2026", "prices": [], "ageRestriction": null, "eventType": "concert", "genres": ["latin pop"],
+      "candidateState": "review", "plannedTdfStatus": "draft", "confidence": "high", "reviewReason": "Pilot is not approved; seller labels availability as preventa.", "inferences": [], "description": "Concierto de Zhamira Zambrano en el Teatro San Gabriel.", "image": {"url":null,"source":"https://www.ticketshow.com.ec/evento/ZHAMIRA-QUITO-2026","attribution":"TicketShow / Output; permission pending"}, "evidence": [{"url":"https://www.ticketshow.com.ec/evento/ZHAMIRA-QUITO-2026","kind":"official_sale","consultedAt":"2026-08-16T10:46:20-05:00"}]
+    },
+    {
+      "provider": "ticketshow", "externalId": "RAWAYANA-QUITO-2026", "title": "Rawayana en Quito", "slug": "rawayana-quito-2026",
+      "localDate": "2026-08-27", "startTime": "2026-08-27T20:30:00-05:00", "endTime": null, "timezone": "America/Guayaquil", "venue": "Coliseo General Rumiñahui", "address": null, "city": "Quito", "province": "Pichincha", "country": "EC", "coordinates": null,
+      "lineup": ["Rawayana"], "organizer": "Output", "promoter": "Output", "ticketSeller": "TicketShow", "purchaseUrl": "https://www.ticketshow.com.ec/evento/RAWAYANA-QUITO-2026", "sourceUrl": "https://www.ticketshow.com.ec/evento/RAWAYANA-QUITO-2026",
+      "prices": [{"category":"Tier 1","amount":30,"currency":"USD"},{"category":"Tier 2","amount":60,"currency":"USD"},{"category":"Tier 3","amount":90,"currency":"USD"},{"category":"Tier 4","amount":130,"currency":"USD"},{"category":"Tier 5","amount":160,"currency":"USD"}], "ageRestriction": null, "eventType": "concert", "genres": ["latin alternative", "reggae"],
+      "candidateState": "review", "plannedTdfStatus": "draft", "confidence": "high", "reviewReason": "Pilot is not approved; seller time 20:30 overrides organizer page time 20:00 under the source hierarchy.", "inferences": [], "description": "Rawayana presenta su gira en el Coliseo General Rumiñahui.", "image": {"url":null,"source":"https://www.ticketshow.com.ec/evento/RAWAYANA-QUITO-2026","attribution":"TicketShow / Output; permission pending"}, "evidence": [{"url":"https://www.ticketshow.com.ec/evento/RAWAYANA-QUITO-2026","kind":"official_sale","consultedAt":"2026-08-16T10:46:20-05:00"},{"url":"https://conciertos.output.ec/conciertos/rawayana/","kind":"official_organizer","consultedAt":"2026-08-16T10:46:20-05:00","notes":"Conflicting 20:00 show time; official sale page is primary."}]
+    },
+    {
+      "provider": "ticketshow", "externalId": "SEATTLE-SUPERSONICS-QUITO-2026", "title": "Seattle Supersonics en Quito", "slug": "seattle-supersonics-quito-2026",
+      "localDate": "2026-08-29", "startTime": "2026-08-29T20:00:00-05:00", "endTime": null, "timezone": "America/Guayaquil", "venue": "Teatro San Gabriel", "address": null, "city": "Quito", "province": "Pichincha", "country": "EC", "coordinates": null,
+      "lineup": ["Seattle Supersonics"], "organizer": "Sandra Lorena Fernández Alvarado", "promoter": null, "ticketSeller": "TicketShow", "purchaseUrl": "https://www.ticketshow.com.ec/evento/SEATTLE-SUPERSONICS-QUITO-2026", "sourceUrl": "https://www.ticketshow.com.ec/evento/SEATTLE-SUPERSONICS-QUITO-2026", "prices": [], "ageRestriction": null, "eventType": "concert", "genres": ["rock tribute"],
+      "candidateState": "review", "plannedTdfStatus": "draft", "confidence": "high", "reviewReason": "Pilot is not approved; seller marks ticket exchange available.", "inferences": [], "description": "Espectáculo tributo al grunge de Nirvana a cargo de Seattle Supersonics.", "image": {"url":null,"source":"https://www.ticketshow.com.ec/evento/SEATTLE-SUPERSONICS-QUITO-2026","attribution":"TicketShow; permission pending"}, "evidence": [{"url":"https://www.ticketshow.com.ec/evento/SEATTLE-SUPERSONICS-QUITO-2026","kind":"official_sale","consultedAt":"2026-08-16T10:46:20-05:00"}]
+    },
+    {
+      "provider": "ticketshow", "externalId": "CARLOS-VIVES-QUITO-2026", "title": "Carlos Vives en Quito", "slug": "carlos-vives-quito-2026",
+      "localDate": "2026-09-03", "startTime": "2026-09-03T20:00:00-05:00", "endTime": null, "timezone": "America/Guayaquil", "venue": "Coliseo General Rumiñahui", "address": null, "city": "Quito", "province": "Pichincha", "country": "EC", "coordinates": null,
+      "lineup": ["Carlos Vives"], "organizer": "Top Shows", "promoter": "Top Shows", "ticketSeller": "TicketShow", "purchaseUrl": "https://www.ticketshow.com.ec/evento/CARLOS-VIVES-QUITO-2026", "sourceUrl": "https://www.ticketshow.com.ec/evento/CARLOS-VIVES-QUITO-2026", "prices": [], "ageRestriction": null, "eventType": "concert", "genres": ["vallenato", "latin pop"],
+      "candidateState": "review", "plannedTdfStatus": "draft", "confidence": "high", "reviewReason": "Pilot is not approved; seller labels availability as pre-sale.", "inferences": [], "description": "Carlos Vives vuelve a Quito con un repertorio de pop colombiano y vallenato.", "image": {"url":null,"source":"https://www.ticketshow.com.ec/evento/CARLOS-VIVES-QUITO-2026","attribution":"TicketShow / Top Shows; permission pending"}, "evidence": [{"url":"https://www.ticketshow.com.ec/evento/CARLOS-VIVES-QUITO-2026","kind":"official_sale","consultedAt":"2026-08-16T10:46:20-05:00"}]
+    },
+    {
+      "provider": "passline", "externalId": "los-reyes-de-la-cumbia", "title": "Los Reyes de la Cumbia", "slug": "los-reyes-de-la-cumbia-quito-2026",
+      "localDate": "2026-10-02", "startTime": "2026-10-02T18:00:00-05:00", "endTime": null, "timezone": "America/Guayaquil", "venue": "Coliseo General Rumiñahui", "address": "Av. Diego Ladrón de Guevara, Quito", "city": "Quito", "province": "Pichincha", "country": "EC", "coordinates": null,
+      "lineup": [], "organizer": null, "promoter": null, "ticketSeller": "Passline", "purchaseUrl": "https://www.passline.com/eventos/los-reyes-de-la-cumbia", "sourceUrl": "https://www.passline.com/eventos/los-reyes-de-la-cumbia",
+      "prices": [{"category":"Tier 1 total","amount":23,"currency":"USD"},{"category":"Tier 2 total","amount":34.5,"currency":"USD"},{"category":"Tier 3 total","amount":46,"currency":"USD"},{"category":"Tier 4 total","amount":57.5,"currency":"USD"},{"category":"Tier 5 total","amount":80.5,"currency":"USD"}], "ageRestriction": null, "eventType": "concert", "genres": ["cumbia"],
+      "candidateState": "review", "plannedTdfStatus": "draft", "confidence": "medium", "reviewReason": "Official page conflicts on America Box: prose totals USD 920 while the price table shows USD 820; the browser also presented a Cloudflare challenge.", "inferences": [], "description": "Encuentro de referentes de la cumbia en el Coliseo General Rumiñahui.", "image": {"url":null,"source":"https://www.passline.com/eventos/los-reyes-de-la-cumbia","attribution":"Passline; permission pending"}, "evidence": [{"url":"https://www.passline.com/eventos/los-reyes-de-la-cumbia","kind":"official_sale","consultedAt":"2026-08-16T10:46:20-05:00","notes":"Price conflict retained for review."}]
+    },
+    {
+      "provider": "feelthetickets", "externalId": "ftc-live-al-parque-quito-2026-08-29", "title": "FTC Live al Parque", "slug": "ftc-live-al-parque-quito-2026",
+      "localDate": "2026-08-29", "startTime": null, "endTime": null, "timezone": "America/Guayaquil", "venue": "Parque Bicentenario", "address": "Antiguo aeropuerto, Quito", "city": "Quito", "province": "Pichincha", "country": "EC", "coordinates": null,
+      "lineup": ["Maroon 5", "Yandel Sinfónico", "Myke Towers", "Lost Frequencies", "Fruko y sus Tesos"], "organizer": "Feel The Club", "promoter": "Feel The Club", "ticketSeller": "Feel The Tickets", "purchaseUrl": null, "sourceUrl": "https://visitquito.ec/es/grandes-eventos-calendario/ftc-live-al-parque-29-agosto/", "prices": [], "ageRestriction": null, "eventType": "festival", "genres": ["pop", "latin urban", "electronic", "salsa"],
+      "candidateState": "review", "plannedTdfStatus": "draft", "confidence": "medium", "reviewReason": "Municipal and promoter sources confirm date, venue, and lineup; the sale page was inaccessible behind Queue-it and the first published set time is not treated as the gate time.", "inferences": [], "description": "Festival de gran formato con pop, música urbana, electrónica y salsa en el Parque Bicentenario.", "image": {"url":null,"source":"https://www.instagram.com/feelthetickets.ec/","attribution":"Feel The Club; permission pending"}, "evidence": [{"url":"https://visitquito.ec/es/grandes-eventos-calendario/ftc-live-al-parque-29-agosto/","kind":"official_municipal","consultedAt":"2026-08-16T10:46:20-05:00"},{"url":"https://www.instagram.com/feelthetickets.ec/","kind":"official_promoter_social","consultedAt":"2026-08-16T10:46:20-05:00","notes":"Official set-time artwork reviewed."}]
+    },
+    {
+      "provider": "feelthetickets", "externalId": "romeo-prince-royce-quito-2026", "title": "Romeo Santos + Prince Royce", "slug": "romeo-santos-prince-royce-quito-2026",
+      "localDate": "2026-09-26", "startTime": null, "endTime": null, "timezone": "America/Guayaquil", "venue": "Estadio Olímpico Atahualpa", "address": null, "city": "Quito", "province": "Pichincha", "country": "EC", "coordinates": null,
+      "lineup": ["Romeo Santos", "Prince Royce"], "organizer": "Feel The Club", "promoter": "Feel The Club", "ticketSeller": "Feel The Tickets", "purchaseUrl": "https://www.feelthetickets.com/romeoprinceroyce/", "sourceUrl": "https://www.feelthetickets.com/romeoprinceroyce/", "prices": [], "ageRestriction": null, "eventType": "concert", "genres": ["bachata"],
+      "candidateState": "review", "plannedTdfStatus": "draft", "confidence": "medium", "reviewReason": "Date, city, venue, and sale page are official, but no exact start time was confirmed; General, Preferencia, and Tribuna are sold out while other categories remain available.", "inferences": [], "description": "Romeo Santos y Prince Royce comparten escenario en una fecha dedicada a la bachata.", "image": {"url":null,"source":"https://www.feelthetickets.com/romeoprinceroyce/","attribution":"Feel The Club; permission pending"}, "evidence": [{"url":"https://www.feelthetickets.com/romeoprinceroyce/","kind":"official_sale","consultedAt":"2026-08-16T10:46:20-05:00"},{"url":"https://www.instagram.com/feelthetickets.ec/","kind":"official_ticket_seller_social","consultedAt":"2026-08-16T10:46:20-05:00"}]
+    },
+    {
+      "provider": "feelthetickets", "externalId": "the-strokes-quito-2026-11-24", "title": "The Strokes en Quito", "slug": "the-strokes-quito-2026",
+      "localDate": "2026-11-24", "startTime": null, "endTime": null, "timezone": "America/Guayaquil", "venue": "Estadio Olímpico Atahualpa", "address": null, "city": "Quito", "province": "Pichincha", "country": "EC", "coordinates": null,
+      "lineup": ["The Strokes"], "organizer": "Feel The Club", "promoter": "Feel The Club", "ticketSeller": "Feel The Tickets", "purchaseUrl": null, "sourceUrl": "https://www.instagram.com/feelthetickets.ec/", "prices": [], "ageRestriction": null, "eventType": "concert", "genres": ["indie rock"],
+      "candidateState": "review", "plannedTdfStatus": "draft", "confidence": "medium", "reviewReason": "Official promoter communication confirms date and venue, but an accessible direct sale page and exact start time were not confirmed.", "inferences": [], "description": "The Strokes se presenta por primera vez en Quito en el Estadio Olímpico Atahualpa.", "image": {"url":null,"source":"https://www.instagram.com/feelthetickets.ec/","attribution":"Feel The Club; permission pending"}, "evidence": [{"url":"https://www.instagram.com/feelthetickets.ec/","kind":"official_promoter_social","consultedAt":"2026-08-16T10:46:20-05:00"}]
+    },
+    {
+      "provider": "meet2go", "externalId": "funk-tribu-quito-2026-10-08", "title": "Bassick presenta Funk Tribu", "slug": "bassick-funk-tribu-quito-2026",
+      "localDate": "2026-10-08", "startTime": null, "endTime": null, "timezone": "America/Guayaquil", "venue": null, "address": null, "city": "Quito", "province": "Pichincha", "country": "EC", "coordinates": null,
+      "lineup": ["Funk Tribu"], "organizer": "Bassick", "promoter": "Bassick", "ticketSeller": "Meet2Go", "purchaseUrl": null, "sourceUrl": "https://www.meet2go.com/", "prices": [], "ageRestriction": null, "eventType": "dj_set", "genres": ["electronic"],
+      "candidateState": "review", "plannedTdfStatus": "draft", "confidence": "medium", "reviewReason": "Official listings confirm Quito/Puembo and the date, but exact time and the Soundgarden Open Air venue identity/address remain ambiguous.", "inferences": [], "description": "Bassick presenta un set de Funk Tribu en el sector de Puembo.", "image": {"url":null,"source":"https://www.instagram.com/meet2go/","attribution":"Meet2Go / Bassick; permission pending"}, "evidence": [{"url":"https://www.meet2go.com/","kind":"official_sale_listing","consultedAt":"2026-08-16T10:46:20-05:00"},{"url":"https://www.instagram.com/meet2go/","kind":"official_ticket_seller_social","consultedAt":"2026-08-16T10:46:20-05:00"}]
+    },
+    {
+      "provider": "meet2go", "externalId": "jazeuio", "title": "Jaze — Quizá no es para tanto Tour II", "slug": "jaze-quiza-no-es-para-tanto-quito-2026",
+      "localDate": "2026-10-24", "startTime": null, "endTime": null, "timezone": "America/Guayaquil", "venue": "Auditorio del Colegio de Economistas de Pichincha", "address": "Iñaquito y Juan Pablo Sanz, Quito", "city": "Quito", "province": "Pichincha", "country": "EC", "coordinates": null,
+      "lineup": ["Jaze"], "organizer": "Distin Shows", "promoter": "Distin Shows", "ticketSeller": "Meet2Go", "purchaseUrl": "https://www.meet2go.com/ev/jazeuio", "sourceUrl": "https://www.meet2go.com/ev/jazeuio", "prices": [{"category":"Tier 1","amount":78,"currency":"USD"},{"category":"Tier 2","amount":68,"currency":"USD"},{"category":"Tier 3","amount":58,"currency":"USD"},{"category":"Tier 4","amount":48,"currency":"USD"}], "ageRestriction": null, "eventType": "concert", "genres": ["hip hop", "latin alternative"],
+      "candidateState": "review", "plannedTdfStatus": "draft", "confidence": "medium", "reviewReason": "Official sale page confirms date and venue but not an exact start time.", "inferences": [], "description": "Jaze trae a Quito la segunda etapa de su gira Quizá no es para tanto.", "image": {"url":null,"source":"https://www.meet2go.com/ev/jazeuio","attribution":"Meet2Go / Distin Shows; permission pending"}, "evidence": [{"url":"https://www.meet2go.com/ev/jazeuio","kind":"official_sale","consultedAt":"2026-08-16T10:46:20-05:00"}]
+    },
+    {
+      "provider": "meet2go", "externalId": "padreguilhermequito2", "title": "DJ Padre Guilherme en Quito", "slug": "dj-padre-guilherme-quito-2026",
+      "localDate": "2026-11-21", "startTime": null, "endTime": null, "timezone": "America/Guayaquil", "venue": "Centro de Exposiciones Quito", "address": "Av. Río Amazonas 3461, Quito", "city": "Quito", "province": "Pichincha", "country": "EC", "coordinates": null,
+      "lineup": ["Padre Guilherme"], "organizer": "El Zello", "promoter": "El Zello", "ticketSeller": "Meet2Go", "purchaseUrl": "https://www.meet2go.com/ev/padreguilhermequito2", "sourceUrl": "https://www.meet2go.com/ev/padreguilhermequito2", "prices": [], "ageRestriction": "18+", "eventType": "dj_set", "genres": ["electronic"],
+      "candidateState": "review", "plannedTdfStatus": "draft", "confidence": "medium", "reviewReason": "Official sale page confirms date, venue, city, and age restriction but not an exact start time.", "inferences": [], "description": "El DJ portugués Padre Guilherme presenta su propuesta electrónica en Quito.", "image": {"url":null,"source":"https://www.meet2go.com/ev/padreguilhermequito2","attribution":"Meet2Go / El Zello; permission pending"}, "evidence": [{"url":"https://www.meet2go.com/ev/padreguilhermequito2","kind":"official_sale","consultedAt":"2026-08-16T10:46:20-05:00"}]
+    },
+    {
+      "provider": "meet2go", "externalId": "jorgedrexler2027", "title": "Jorge Drexler — Gira Taracá", "slug": "jorge-drexler-gira-taraca-quito-2027",
+      "localDate": "2027-02-17", "startTime": null, "endTime": null, "timezone": "America/Guayaquil", "venue": "Medio Coliseo General Rumiñahui", "address": "Diego Ladrón de Guevara, Quito", "city": "Quito", "province": "Pichincha", "country": "EC", "coordinates": null,
+      "lineup": ["Jorge Drexler"], "organizer": "Star Shows", "promoter": "Star Shows", "ticketSeller": "Meet2Go", "purchaseUrl": "https://www.meet2go.com/ev/jorgedrexler2027", "sourceUrl": "https://www.meet2go.com/ev/jorgedrexler2027", "prices": [{"category":"Tier 1","amount":149.5,"currency":"USD"},{"category":"Tier 2","amount":126.5,"currency":"USD"},{"category":"Tier 3","amount":103.5,"currency":"USD"},{"category":"Tier 4","amount":86.25,"currency":"USD"},{"category":"Tier 5","amount":46,"currency":"USD"}], "ageRestriction": null, "eventType": "concert", "genres": ["singer-songwriter", "latin pop"],
+      "candidateState": "review", "plannedTdfStatus": "draft", "confidence": "medium", "reviewReason": "Official sale page confirms date and venue but not an exact start time.", "inferences": [], "description": "Jorge Drexler presenta en Quito su gira Taracá 2026–2027.", "image": {"url":null,"source":"https://www.meet2go.com/ev/jorgedrexler2027","attribution":"Meet2Go / Star Shows; permission pending"}, "evidence": [{"url":"https://www.meet2go.com/ev/jorgedrexler2027","kind":"official_sale","consultedAt":"2026-08-16T10:46:20-05:00"}]
+    },
+    {
+      "provider": "ontime", "externalId": "rocklatam-2026-quito-1", "title": "RockLatam 2026 Quito", "slug": "rocklatam-2026-quito",
+      "localDate": "2026-10-16", "startTime": "2026-10-16T20:00:00-05:00", "endTime": "2026-10-16T23:50:00-05:00", "timezone": "America/Guayaquil", "venue": "Coliseo General Rumiñahui", "address": null, "city": "Quito", "province": "Pichincha", "country": "EC", "coordinates": null,
+      "lineup": ["Vilma Palma e Vampiros", "Los Auténticos Decadentes", "Los Prisioneros de Miguel Tapia"], "organizer": null, "promoter": null, "ticketSeller": "On Time Tickets", "purchaseUrl": "https://www.ontimetickets.com/event-details/rocklatam-2026-quito-1", "sourceUrl": "https://www.ontimetickets.com/event-details/rocklatam-2026-quito-1", "prices": [], "ageRestriction": null, "eventType": "concert", "genres": ["latin rock"],
+      "candidateState": "review", "plannedTdfStatus": "draft", "confidence": "high", "reviewReason": "Pilot is not approved; the official ticket listing says sales have not opened yet.", "inferences": [], "description": "Tres bandas emblemáticas del rock latino se reúnen en una fecha conjunta en Quito.", "image": {"url":null,"source":"https://www.ontimetickets.com/event-details/rocklatam-2026-quito-1","attribution":"On Time Tickets; permission pending"}, "evidence": [{"url":"https://www.ontimetickets.com/event-details/rocklatam-2026-quito-1","kind":"official_sale_listing","consultedAt":"2026-08-16T10:46:20-05:00","notes":"Tickets not yet on sale."}]
+    },
+    {
+      "provider": "output", "externalId": "grupo-frontera-quito-2026-10-09", "title": "Grupo Frontera — Tour Ecuador", "slug": "grupo-frontera-quito-2026",
+      "localDate": "2026-10-09", "startTime": "2026-10-09T20:30:00-05:00", "endTime": null, "timezone": "America/Guayaquil", "venue": "Coliseo General Rumiñahui", "address": null, "city": "Quito", "province": "Pichincha", "country": "EC", "coordinates": null,
+      "lineup": ["Grupo Frontera"], "organizer": "Output", "promoter": "Output", "ticketSeller": null, "purchaseUrl": null, "sourceUrl": "https://conciertos.output.ec/conciertos/grupo-frontera/", "prices": [{"category":"VIP","amount":40,"currency":"USD"},{"category":"Fan","amount":80,"currency":"USD"},{"category":"Butaca","amount":100,"currency":"USD"},{"category":"Output Box","amount":120,"currency":"USD"},{"category":"Frontera Box","amount":160,"currency":"USD"}], "ageRestriction": null, "eventType": "concert", "genres": ["regional Mexican"],
+      "candidateState": "review", "plannedTdfStatus": "draft", "confidence": "medium", "reviewReason": "Official organizer confirms doors 18:00 and show 20:30; the direct seller behind its purchase button was not independently verified.", "inferences": [], "description": "Grupo Frontera lleva su Tour Ecuador al Coliseo General Rumiñahui.", "image": {"url":null,"source":"https://conciertos.output.ec/conciertos/grupo-frontera/","attribution":"Output; permission pending"}, "evidence": [{"url":"https://conciertos.output.ec/conciertos/grupo-frontera/","kind":"official_organizer","consultedAt":"2026-08-16T10:46:20-05:00"}]
+    }
+  ],
+  "excludedOrQueued": [
+    {"title":"Vadhir — Fantasy Tour Quito","reason":"Official sale page has a date but no confirmed venue."},
+    {"title":"Opera IX Quito","reason":"Official listing lacks a confirmed venue and start time."},
+    {"title":"Amazonika / Hugel","reason":"Official communication confirms date but no exact start time; excluded to keep the accumulated pilot at 20."},
+    {"title":"WWE Live Quito","reason":"Public but outside the music and music-industry scope."},
+    {"title":"Existing Domo events 83–89","reason":"No sufficient primary corroboration found; events 88 and 89 are an exact duplicate pair and require manual review, never automatic deletion."}
+  ]
+}

--- a/tdf-hq/docs/openapi/api.yaml
+++ b/tdf-hq/docs/openapi/api.yaml
@@ -94,6 +94,142 @@ paths:
                 $ref: '#/components/schemas/EventMoment'
         '422':
           description: Reaction type UUID is unknown, inactive, deprecated, or unpublished
+  /social-events/event-research/pilot:
+    get:
+      tags: [Event research]
+      summary: Read accumulated pilot state
+      operationId: getEventResearchPilot
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200':
+          description: Pilot approval and active-candidate count
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/EventResearchPilot' }
+        '403': { description: Strict administrator access is required }
+  /social-events/event-research/pilot/approve:
+    post:
+      tags: [Event research]
+      summary: Record an explicit, immutable pilot approval
+      operationId: approveEventResearchPilot
+      security: [{ bearerAuth: [] }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required: [erPilotApprovalReference]
+              properties:
+                erPilotApprovalReference: { type: string, minLength: 1, maxLength: 500 }
+      responses:
+        '200':
+          description: Approved pilot state
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/EventResearchPilot' }
+        '403': { description: Strict administrator access is required }
+        '409': { description: The pilot has a different existing approval reference }
+  /social-events/event-research/runs:
+    get:
+      tags: [Event research]
+      summary: List research runs and checkpoints
+      operationId: listEventResearchRuns
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - { name: limit, in: query, schema: { type: integer, minimum: 1, maximum: 500, default: 100 } }
+      responses:
+        '200':
+          description: Research runs
+          content:
+            application/json:
+              schema: { type: array, items: { $ref: '#/components/schemas/EventResearchRun' } }
+    post:
+      tags: [Event research]
+      summary: Idempotently start a research run by run key
+      operationId: createEventResearchRun
+      security: [{ bearerAuth: [] }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/EventResearchRunCreate' }
+      responses:
+        '200':
+          description: Existing or newly created run
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/EventResearchRun' }
+  /social-events/event-research/runs/{runId}:
+    put:
+      tags: [Event research]
+      summary: Commit a run checkpoint or terminal status
+      operationId: updateEventResearchRun
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - { name: runId, in: path, required: true, schema: { type: string, pattern: '^[1-9][0-9]*$' } }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/EventResearchRunUpdate' }
+      responses:
+        '200':
+          description: Updated run
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/EventResearchRun' }
+        '409': { description: A completed run cannot be reopened }
+  /social-events/event-research/candidates:
+    get:
+      tags: [Event research]
+      summary: List accumulated research candidates
+      operationId: listEventResearchCandidates
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - { name: provider, in: query, schema: { type: string } }
+        - { name: review_state, in: query, schema: { type: string, enum: [draft, review, discarded] } }
+        - { name: limit, in: query, schema: { type: integer, minimum: 1, maximum: 500, default: 100 } }
+      responses:
+        '200':
+          description: Research candidates
+          content:
+            application/json:
+              schema: { type: array, items: { $ref: '#/components/schemas/EventResearchCandidate' } }
+    put:
+      tags: [Event research]
+      summary: Idempotently create, update, or reverify a candidate
+      description: Uses provider plus external identifier as the canonical key. It never publishes a social event.
+      operationId: upsertEventResearchCandidate
+      security: [{ bearerAuth: [] }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/EventResearchCandidateWrite' }
+      responses:
+        '200':
+          description: Upserted candidate
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/EventResearchCandidate' }
+        '409': { description: Pilot cap reached or a closed run received a material change }
+  /social-events/event-research/changes:
+    get:
+      tags: [Event research]
+      summary: List immutable candidate change records
+      operationId: listEventResearchChanges
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - { name: run_id, in: query, schema: { type: string, pattern: '^[1-9][0-9]*$' } }
+        - { name: limit, in: query, schema: { type: integer, minimum: 1, maximum: 500, default: 100 } }
+      responses:
+        '200':
+          description: Auditable candidate changes
+          content:
+            application/json:
+              schema: { type: array, items: { $ref: '#/components/schemas/EventResearchChange' } }
   /version:
     get:
       summary: Get API Version
@@ -4202,6 +4338,126 @@ components:
         emComments:
           type: array
           items: { $ref: '#/components/schemas/EventMomentComment' }
+    EventResearchPilot:
+      type: object
+      required: [erPilotApproved, erPilotMaxActiveCandidates, erPilotActiveCandidates, erPilotUpdatedAt]
+      properties:
+        erPilotApproved: { type: boolean }
+        erPilotApprovedAt: { type: string, format: date-time, nullable: true }
+        erPilotApprovedByPartyId: { type: string, nullable: true }
+        erPilotApprovalReference: { type: string, nullable: true }
+        erPilotMaxActiveCandidates: { type: integer, enum: [20] }
+        erPilotActiveCandidates: { type: integer, minimum: 0, maximum: 20 }
+        erPilotUpdatedAt: { type: string, format: date-time }
+    EventResearchRunCreate:
+      type: object
+      additionalProperties: false
+      required: [erRunKey, erRunReconciliation]
+      properties:
+        erRunKey: { type: string, minLength: 1, maxLength: 160 }
+        erRunReconciliation: { type: boolean }
+        erRunCheckpoint: { type: string, maxLength: 2000, nullable: true }
+    EventResearchRunUpdate:
+      type: object
+      additionalProperties: false
+      required: [erRunStatus, erRunCounters]
+      properties:
+        erRunStatus: { type: string, enum: [running, completed, failed] }
+        erRunCheckpoint: { type: string, maxLength: 2000, nullable: true }
+        erRunCounters: { type: object, additionalProperties: true }
+        erRunErrorSummary: { type: string, maxLength: 4000, nullable: true }
+    EventResearchRun:
+      allOf:
+        - { $ref: '#/components/schemas/EventResearchRunCreate' }
+        - { $ref: '#/components/schemas/EventResearchRunUpdate' }
+        - type: object
+          required: [erRunId, erRunStartedAt, erRunUpdatedAt, erRunCreatedByPartyId]
+          properties:
+            erRunId: { type: string }
+            erRunStartedAt: { type: string, format: date-time }
+            erRunUpdatedAt: { type: string, format: date-time }
+            erRunFinishedAt: { type: string, format: date-time, nullable: true }
+            erRunCreatedByPartyId: { type: string }
+    EventResearchEvidence:
+      type: object
+      additionalProperties: false
+      required: [erEvidenceUrl, erEvidenceKind, erEvidenceConsultedAt]
+      properties:
+        erEvidenceUrl: { type: string, format: uri, pattern: '^https://' }
+        erEvidenceKind: { type: string, maxLength: 80 }
+        erEvidenceConsultedAt: { type: string, format: date-time }
+        erEvidenceNotes: { type: string, maxLength: 1000, nullable: true }
+    EventResearchCandidateWrite:
+      type: object
+      additionalProperties: false
+      required:
+        - erCandidateProvider
+        - erCandidateExternalId
+        - erCandidateRunId
+        - erCandidateReviewState
+        - erCandidateTitle
+        - erCandidateTimezone
+        - erCandidateCountryCode
+        - erCandidateSourceUrl
+        - erCandidatePayload
+        - erCandidateEvidence
+        - erCandidateConfidence
+        - erCandidateManagedFields
+        - erCandidateVerifiedAt
+      properties:
+        erCandidateProvider: { type: string, maxLength: 80 }
+        erCandidateExternalId: { type: string, maxLength: 512 }
+        erCandidateRunId: { type: string, pattern: '^[1-9][0-9]*$' }
+        erCandidateSourceId: { type: string, pattern: '^[1-9][0-9]*$', nullable: true }
+        erCandidateReviewState: { type: string, enum: [draft, review, discarded] }
+        erCandidateTitle: { type: string, maxLength: 240 }
+        erCandidateStartTime: { type: string, format: date-time, nullable: true }
+        erCandidateEndTime: { type: string, format: date-time, nullable: true }
+        erCandidateTimezone: { type: string, example: America/Guayaquil }
+        erCandidateVenueName: { type: string, maxLength: 240, nullable: true }
+        erCandidateCity: { type: string, maxLength: 160, nullable: true }
+        erCandidateProvince: { type: string, maxLength: 160, nullable: true }
+        erCandidateCountryCode: { type: string, pattern: '^[A-Z]{2}$' }
+        erCandidateSourceUrl: { type: string, format: uri, pattern: '^https://' }
+        erCandidateInfoUrl: { type: string, format: uri, pattern: '^https://', nullable: true }
+        erCandidatePurchaseUrl: { type: string, format: uri, pattern: '^https://', nullable: true }
+        erCandidatePayload: { type: object, additionalProperties: true }
+        erCandidateEvidence:
+          type: array
+          minItems: 1
+          items: { $ref: '#/components/schemas/EventResearchEvidence' }
+        erCandidateConfidence: { type: string, enum: [high, medium, low] }
+        erCandidateManagedFields: { type: array, items: { type: string } }
+        erCandidateVerifiedAt: { type: string, format: date-time }
+    EventResearchCandidate:
+      allOf:
+        - { $ref: '#/components/schemas/EventResearchCandidateWrite' }
+        - type: object
+          required: [erCandidateId, erCandidateContentHash, erCandidateIsPilot, erCandidateCreatedAt, erCandidateUpdatedAt]
+          properties:
+            erCandidateId: { type: string }
+            erCandidateEventId: { type: string, nullable: true }
+            erCandidateContentHash: { type: string, pattern: '^[0-9a-f]{64}$' }
+            erCandidateIsPilot: { type: boolean }
+            erCandidateCreatedAt: { type: string, format: date-time }
+            erCandidateUpdatedAt: { type: string, format: date-time }
+    EventResearchChange:
+      type: object
+      required: [erChangeId, erChangeRunId, erChangeAction, erChangeSourceUrl, erChangeConfidence, erChangeConsultedAt, erChangeExternalId, erChangeResult, erChangeCreatedAt]
+      properties:
+        erChangeId: { type: string }
+        erChangeRunId: { type: string }
+        erChangeCandidateId: { type: string, nullable: true }
+        erChangeEventId: { type: string, nullable: true }
+        erChangeAction: { type: string, enum: [created, updated, verified, discarded, materialized] }
+        erChangeBeforeValue: { type: object, additionalProperties: true, nullable: true }
+        erChangeAfterValue: { type: object, additionalProperties: true, nullable: true }
+        erChangeSourceUrl: { type: string, format: uri }
+        erChangeConfidence: { type: string, enum: [high, medium, low] }
+        erChangeConsultedAt: { type: string, format: date-time }
+        erChangeExternalId: { type: string }
+        erChangeResult: { type: string }
+        erChangeCreatedAt: { type: string, format: date-time }
     SocialEvent:
       type: object
       additionalProperties: false
@@ -4224,6 +4480,10 @@ components:
         eventEnd:
           type: string
           format: date-time
+        eventTimezone:
+          type: string
+          nullable: true
+          example: America/Guayaquil
         eventVenueId:
           type: string
           nullable: true

--- a/tdf-hq/sql/2026-08-16_event_research_ingestion.down.sql
+++ b/tdf-hq/sql/2026-08-16_event_research_ingestion.down.sql
@@ -1,0 +1,24 @@
+BEGIN;
+
+DROP TRIGGER IF EXISTS event_research_pilot_limit_trigger ON event_research_candidate;
+DROP FUNCTION IF EXISTS enforce_event_research_pilot_limit();
+DROP TABLE IF EXISTS event_research_change;
+DROP TABLE IF EXISTS event_research_candidate;
+DROP TABLE IF EXISTS event_research_run;
+DROP TABLE IF EXISTS event_research_pilot_audit;
+DROP TABLE IF EXISTS event_research_pilot_control;
+
+DELETE FROM event_discovery_source
+WHERE source_key IN (
+  'meet2go-web',
+  'passline-ec-web',
+  'buenplan-social-web',
+  'feelthetickets-web',
+  'ticketshow-web',
+  'ontime-tickets-web',
+  'output-concerts-web'
+)
+AND source_type = 'web'
+AND last_success_at IS NULL;
+
+COMMIT;

--- a/tdf-hq/sql/2026-08-16_event_research_ingestion.down.sql
+++ b/tdf-hq/sql/2026-08-16_event_research_ingestion.down.sql
@@ -21,4 +21,10 @@ WHERE source_key IN (
 AND source_type = 'web'
 AND last_success_at IS NULL;
 
+ALTER TABLE event_discovery_source
+  DROP CONSTRAINT IF EXISTS event_discovery_source_type_check;
+ALTER TABLE event_discovery_source
+  ADD CONSTRAINT event_discovery_source_type_check
+  CHECK (source_type IN ('ticketmaster', 'buenplan', 'ical', 'json'));
+
 COMMIT;

--- a/tdf-hq/sql/2026-08-16_event_research_ingestion.sql
+++ b/tdf-hq/sql/2026-08-16_event_research_ingestion.sql
@@ -160,6 +160,12 @@ CREATE TRIGGER event_research_pilot_limit_trigger
 BEFORE INSERT OR UPDATE OF review_state, is_pilot ON event_research_candidate
 FOR EACH ROW EXECUTE FUNCTION enforce_event_research_pilot_limit();
 
+ALTER TABLE event_discovery_source
+  DROP CONSTRAINT IF EXISTS event_discovery_source_type_check;
+ALTER TABLE event_discovery_source
+  ADD CONSTRAINT event_discovery_source_type_check
+  CHECK (source_type IN ('ticketmaster', 'buenplan', 'ical', 'json', 'web'));
+
 -- Web sources are maintained for manual research only. The API and database keep
 -- them disabled so the structured-feed cron never attempts to scrape HTML.
 INSERT INTO event_discovery_source

--- a/tdf-hq/sql/2026-08-16_event_research_ingestion.sql
+++ b/tdf-hq/sql/2026-08-16_event_research_ingestion.sql
@@ -1,0 +1,178 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS event_research_pilot_control (
+  id BIGSERIAL PRIMARY KEY,
+  control_key TEXT NOT NULL UNIQUE,
+  approved BOOLEAN NOT NULL DEFAULT FALSE,
+  approved_at TIMESTAMPTZ,
+  approved_by_party_id TEXT,
+  approval_reference TEXT,
+  max_active_candidates INTEGER NOT NULL DEFAULT 20 CHECK (max_active_candidates = 20),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CHECK (NOT approved OR (approved_at IS NOT NULL AND approved_by_party_id IS NOT NULL AND approval_reference IS NOT NULL))
+);
+
+INSERT INTO event_research_pilot_control (control_key, approved, max_active_candidates)
+VALUES ('default', FALSE, 20)
+ON CONFLICT (control_key) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS event_research_pilot_audit (
+  id BIGSERIAL PRIMARY KEY,
+  control_id BIGINT NOT NULL REFERENCES event_research_pilot_control(id),
+  approved BOOLEAN NOT NULL,
+  approved_by_party_id TEXT NOT NULL,
+  approval_reference TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS event_research_run (
+  id BIGSERIAL PRIMARY KEY,
+  run_key TEXT NOT NULL UNIQUE,
+  status TEXT NOT NULL CHECK (status IN ('running', 'completed', 'failed')),
+  reconciliation BOOLEAN NOT NULL DEFAULT FALSE,
+  checkpoint TEXT,
+  counters TEXT NOT NULL DEFAULT '{}',
+  error_summary TEXT,
+  started_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL,
+  finished_at TIMESTAMPTZ,
+  created_by_party_id TEXT NOT NULL,
+  CHECK ((status = 'running' AND finished_at IS NULL) OR (status IN ('completed', 'failed') AND finished_at IS NOT NULL)),
+  CHECK (counters::jsonb IS NOT NULL)
+);
+
+CREATE TABLE IF NOT EXISTS event_research_candidate (
+  id BIGSERIAL PRIMARY KEY,
+  provider TEXT NOT NULL,
+  external_id TEXT NOT NULL,
+  run_id BIGINT NOT NULL REFERENCES event_research_run(id),
+  source_id BIGINT REFERENCES event_discovery_source(id),
+  event_id BIGINT REFERENCES social_event(id),
+  review_state TEXT NOT NULL CHECK (review_state IN ('draft', 'review', 'discarded')),
+  title TEXT NOT NULL,
+  start_time TIMESTAMPTZ,
+  end_time TIMESTAMPTZ,
+  timezone TEXT NOT NULL,
+  venue_name TEXT,
+  city TEXT,
+  province TEXT,
+  country_code TEXT NOT NULL CHECK (country_code ~ '^[A-Z]{2}$'),
+  source_url TEXT NOT NULL,
+  info_url TEXT,
+  purchase_url TEXT,
+  payload TEXT NOT NULL,
+  evidence TEXT NOT NULL,
+  confidence TEXT NOT NULL CHECK (confidence IN ('high', 'medium', 'low')),
+  managed_fields TEXT NOT NULL DEFAULT '[]',
+  content_hash TEXT NOT NULL CHECK (content_hash ~ '^[0-9a-f]{64}$'),
+  verified_at TIMESTAMPTZ NOT NULL,
+  is_pilot BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL,
+  UNIQUE (provider, external_id),
+  CHECK (start_time IS NULL OR end_time IS NULL OR start_time < end_time),
+  CHECK (payload::jsonb IS NOT NULL),
+  CHECK (jsonb_typeof(evidence::jsonb) = 'array'),
+  CHECK (jsonb_array_length(evidence::jsonb) > 0),
+  CHECK (jsonb_typeof(managed_fields::jsonb) = 'array')
+);
+
+CREATE INDEX IF NOT EXISTS event_research_candidate_run_idx
+  ON event_research_candidate(run_id, verified_at DESC);
+CREATE INDEX IF NOT EXISTS event_research_candidate_review_idx
+  ON event_research_candidate(review_state, verified_at DESC);
+CREATE INDEX IF NOT EXISTS event_research_candidate_event_idx
+  ON event_research_candidate(event_id) WHERE event_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS event_research_change (
+  id BIGSERIAL PRIMARY KEY,
+  run_id BIGINT NOT NULL REFERENCES event_research_run(id),
+  candidate_id BIGINT REFERENCES event_research_candidate(id),
+  event_id BIGINT REFERENCES social_event(id),
+  action TEXT NOT NULL CHECK (action IN ('created', 'updated', 'verified', 'discarded', 'materialized')),
+  before_value TEXT,
+  after_value TEXT,
+  source_url TEXT NOT NULL,
+  confidence TEXT NOT NULL CHECK (confidence IN ('high', 'medium', 'low')),
+  consulted_at TIMESTAMPTZ NOT NULL,
+  external_id TEXT NOT NULL,
+  result TEXT NOT NULL,
+  dedupe_key TEXT NOT NULL UNIQUE,
+  created_at TIMESTAMPTZ NOT NULL,
+  CHECK (before_value IS NULL OR before_value::jsonb IS NOT NULL),
+  CHECK (after_value IS NULL OR after_value::jsonb IS NOT NULL)
+);
+
+CREATE INDEX IF NOT EXISTS event_research_change_run_idx
+  ON event_research_change(run_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS event_research_change_candidate_idx
+  ON event_research_change(candidate_id, created_at DESC);
+
+CREATE OR REPLACE FUNCTION enforce_event_research_pilot_limit()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  pilot_approved BOOLEAN;
+  pilot_limit INTEGER;
+  active_candidates INTEGER;
+BEGIN
+  -- Let an INSERT ... ON CONFLICT retry reach the unique key. Any transition
+  -- from discarded back to active is checked again by the UPDATE trigger.
+  IF TG_OP = 'INSERT' AND EXISTS (
+    SELECT 1
+      FROM event_research_candidate
+     WHERE provider = NEW.provider
+       AND external_id = NEW.external_id
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT approved, max_active_candidates
+    INTO pilot_approved, pilot_limit
+    FROM event_research_pilot_control
+   WHERE control_key = 'default'
+   FOR UPDATE;
+
+  IF pilot_approved IS NULL THEN
+    RAISE EXCEPTION 'event research pilot control is not initialized';
+  END IF;
+
+  IF NOT pilot_approved AND NEW.is_pilot AND NEW.review_state <> 'discarded' THEN
+    SELECT count(*)
+      INTO active_candidates
+      FROM event_research_candidate
+     WHERE is_pilot
+       AND review_state <> 'discarded'
+       AND id <> COALESCE(NEW.id, -1);
+
+    IF active_candidates >= pilot_limit THEN
+      RAISE EXCEPTION 'event research pilot candidate limit reached';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS event_research_pilot_limit_trigger ON event_research_candidate;
+CREATE TRIGGER event_research_pilot_limit_trigger
+BEFORE INSERT OR UPDATE OF review_state, is_pilot ON event_research_candidate
+FOR EACH ROW EXECUTE FUNCTION enforce_event_research_pilot_limit();
+
+-- Web sources are maintained for manual research only. The API and database keep
+-- them disabled so the structured-feed cron never attempts to scrape HTML.
+INSERT INTO event_discovery_source
+  (source_key, name, source_type, feed_url, city_id, enabled, priority, configuration,
+   etag, last_modified, consecutive_failures, last_success_at, last_error, created_at, updated_at)
+VALUES
+  ('meet2go-web', 'Meet2Go', 'web', 'https://meet2go.com/', NULL, FALSE, 250, NULL, NULL, NULL, 0, NULL, NULL, now(), now()),
+  ('passline-ec-web', 'Passline Ecuador', 'web', 'https://www.instagram.com/passline.ec/', NULL, FALSE, 240, NULL, NULL, NULL, 0, NULL, NULL, now(), now()),
+  ('buenplan-social-web', 'BuenPlan Tickets (social)', 'web', 'https://www.instagram.com/buenplantickets/', NULL, FALSE, 230, NULL, NULL, NULL, 0, NULL, NULL, now(), now()),
+  ('feelthetickets-web', 'Feel The Tickets', 'web', 'https://www.feelthetickets.com/', NULL, FALSE, 220, NULL, NULL, NULL, 0, NULL, NULL, now(), now()),
+  ('ticketshow-web', 'TicketShow', 'web', 'https://www.ticketshow.com.ec/', NULL, FALSE, 210, NULL, NULL, NULL, 0, NULL, NULL, now(), now()),
+  ('ontime-tickets-web', 'On Time Tickets', 'web', 'https://www.ontimetickets.com/', NULL, FALSE, 205, NULL, NULL, NULL, 0, NULL, NULL, now(), now()),
+  ('output-concerts-web', 'Output Concerts', 'web', 'https://conciertos.output.ec/', NULL, FALSE, 190, NULL, NULL, NULL, 0, NULL, NULL, now(), now())
+ON CONFLICT (source_key) DO NOTHING;
+
+COMMIT;

--- a/tdf-hq/src/TDF/API/EventResearchAPI.hs
+++ b/tdf-hq/src/TDF/API/EventResearchAPI.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+
+module TDF.API.EventResearchAPI (EventResearchRoutes) where
+
+import Data.Text (Text)
+import Servant
+import TDF.DTO.EventResearchDTO
+
+type EventResearchRoutes =
+    "event-research" :> "pilot" :> Get '[JSON] EventResearchPilotDTO
+        :<|> "event-research"
+            :> "pilot"
+            :> "approve"
+            :> ReqBody '[JSON] EventResearchPilotApprovalDTO
+            :> Post '[JSON] EventResearchPilotDTO
+        :<|> "event-research"
+            :> "runs"
+            :> QueryParam "limit" Int
+            :> Get '[JSON] [EventResearchRunDTO]
+        :<|> "event-research"
+            :> "runs"
+            :> ReqBody '[JSON] EventResearchRunCreateDTO
+            :> Post '[JSON] EventResearchRunDTO
+        :<|> "event-research"
+            :> "runs"
+            :> Capture "runId" Text
+            :> ReqBody '[JSON] EventResearchRunUpdateDTO
+            :> Put '[JSON] EventResearchRunDTO
+        :<|> "event-research"
+            :> "candidates"
+            :> QueryParam "provider" Text
+            :> QueryParam "review_state" Text
+            :> QueryParam "limit" Int
+            :> Get '[JSON] [EventResearchCandidateDTO]
+        :<|> "event-research"
+            :> "candidates"
+            :> ReqBody '[JSON] EventResearchCandidateWriteDTO
+            :> Put '[JSON] EventResearchCandidateDTO
+        :<|> "event-research"
+            :> "changes"
+            :> QueryParam "run_id" Text
+            :> QueryParam "limit" Int
+            :> Get '[JSON] [EventResearchChangeDTO]

--- a/tdf-hq/src/TDF/API/SocialEventsAPI.hs
+++ b/tdf-hq/src/TDF/API/SocialEventsAPI.hs
@@ -9,6 +9,7 @@ module TDF.API.SocialEventsAPI (
     EventsRoutes,
     EventCitiesRoutes,
     EventDiscoverySourcesRoutes,
+    EventResearchRoutes,
     VenuesRoutes,
     ArtistsRoutes,
     RsvpRoutes,
@@ -50,6 +51,8 @@ import Servant.Multipart (
     fdInputName,
  )
 import System.FilePath (takeExtension)
+
+import TDF.API.EventResearchAPI (EventResearchRoutes)
 
 import TDF.DTO.SocialEventsDTO (
     ArtistDTO,
@@ -554,6 +557,7 @@ type SocialEventsAPI =
     EventsRoutes
         :<|> EventCitiesRoutes
         :<|> EventDiscoverySourcesRoutes
+        :<|> EventResearchRoutes
         :<|> VenuesRoutes
         :<|> ArtistsRoutes
         :<|> RsvpRoutes

--- a/tdf-hq/src/TDF/DTO/EventResearchDTO.hs
+++ b/tdf-hq/src/TDF/DTO/EventResearchDTO.hs
@@ -1,0 +1,178 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+
+module TDF.DTO.EventResearchDTO
+    ( EventResearchPilotDTO (..)
+    , EventResearchPilotApprovalDTO (..)
+    , EventResearchRunCreateDTO (..)
+    , EventResearchRunUpdateDTO (..)
+    , EventResearchRunDTO (..)
+    , EventResearchEvidenceDTO (..)
+    , EventResearchCandidateWriteDTO (..)
+    , EventResearchCandidateDTO (..)
+    , EventResearchChangeDTO (..)
+    ) where
+
+import Data.Aeson (FromJSON (parseJSON), ToJSON, Value, defaultOptions, genericParseJSON, rejectUnknownFields)
+import Data.Text (Text)
+import Data.Time (UTCTime)
+import GHC.Generics (Generic)
+
+data EventResearchPilotDTO = EventResearchPilotDTO
+    { erPilotApproved :: Bool
+    , erPilotApprovedAt :: Maybe UTCTime
+    , erPilotApprovedByPartyId :: Maybe Text
+    , erPilotApprovalReference :: Maybe Text
+    , erPilotMaxActiveCandidates :: Int
+    , erPilotActiveCandidates :: Int
+    , erPilotUpdatedAt :: UTCTime
+    }
+    deriving (Show, Eq, Generic)
+
+instance ToJSON EventResearchPilotDTO
+instance FromJSON EventResearchPilotDTO
+
+data EventResearchPilotApprovalDTO = EventResearchPilotApprovalDTO
+    { erPilotApprovalReference :: Text
+    }
+    deriving (Show, Eq, Generic)
+
+instance ToJSON EventResearchPilotApprovalDTO
+instance FromJSON EventResearchPilotApprovalDTO where
+    parseJSON = genericParseJSON defaultOptions{rejectUnknownFields = True}
+
+data EventResearchRunCreateDTO = EventResearchRunCreateDTO
+    { erRunKey :: Text
+    , erRunReconciliation :: Bool
+    , erRunCheckpoint :: Maybe Text
+    }
+    deriving (Show, Eq, Generic)
+
+instance ToJSON EventResearchRunCreateDTO
+instance FromJSON EventResearchRunCreateDTO where
+    parseJSON = genericParseJSON defaultOptions{rejectUnknownFields = True}
+
+data EventResearchRunUpdateDTO = EventResearchRunUpdateDTO
+    { erRunStatus :: Text
+    , erRunCheckpoint :: Maybe Text
+    , erRunCounters :: Value
+    , erRunErrorSummary :: Maybe Text
+    }
+    deriving (Show, Eq, Generic)
+
+instance ToJSON EventResearchRunUpdateDTO
+instance FromJSON EventResearchRunUpdateDTO where
+    parseJSON = genericParseJSON defaultOptions{rejectUnknownFields = True}
+
+data EventResearchRunDTO = EventResearchRunDTO
+    { erRunId :: Text
+    , erRunKey :: Text
+    , erRunStatus :: Text
+    , erRunReconciliation :: Bool
+    , erRunCheckpoint :: Maybe Text
+    , erRunCounters :: Value
+    , erRunErrorSummary :: Maybe Text
+    , erRunStartedAt :: UTCTime
+    , erRunUpdatedAt :: UTCTime
+    , erRunFinishedAt :: Maybe UTCTime
+    , erRunCreatedByPartyId :: Text
+    }
+    deriving (Show, Eq, Generic)
+
+instance ToJSON EventResearchRunDTO
+instance FromJSON EventResearchRunDTO
+
+data EventResearchEvidenceDTO = EventResearchEvidenceDTO
+    { erEvidenceUrl :: Text
+    , erEvidenceKind :: Text
+    , erEvidenceConsultedAt :: UTCTime
+    , erEvidenceNotes :: Maybe Text
+    }
+    deriving (Show, Eq, Generic)
+
+instance ToJSON EventResearchEvidenceDTO
+instance FromJSON EventResearchEvidenceDTO where
+    parseJSON = genericParseJSON defaultOptions{rejectUnknownFields = True}
+
+data EventResearchCandidateWriteDTO = EventResearchCandidateWriteDTO
+    { erCandidateProvider :: Text
+    , erCandidateExternalId :: Text
+    , erCandidateRunId :: Text
+    , erCandidateSourceId :: Maybe Text
+    , erCandidateReviewState :: Text
+    , erCandidateTitle :: Text
+    , erCandidateStartTime :: Maybe UTCTime
+    , erCandidateEndTime :: Maybe UTCTime
+    , erCandidateTimezone :: Text
+    , erCandidateVenueName :: Maybe Text
+    , erCandidateCity :: Maybe Text
+    , erCandidateProvince :: Maybe Text
+    , erCandidateCountryCode :: Text
+    , erCandidateSourceUrl :: Text
+    , erCandidateInfoUrl :: Maybe Text
+    , erCandidatePurchaseUrl :: Maybe Text
+    , erCandidatePayload :: Value
+    , erCandidateEvidence :: [EventResearchEvidenceDTO]
+    , erCandidateConfidence :: Text
+    , erCandidateManagedFields :: [Text]
+    , erCandidateVerifiedAt :: UTCTime
+    }
+    deriving (Show, Eq, Generic)
+
+instance ToJSON EventResearchCandidateWriteDTO
+instance FromJSON EventResearchCandidateWriteDTO where
+    parseJSON = genericParseJSON defaultOptions{rejectUnknownFields = True}
+
+data EventResearchCandidateDTO = EventResearchCandidateDTO
+    { erCandidateId :: Text
+    , erCandidateProvider :: Text
+    , erCandidateExternalId :: Text
+    , erCandidateRunId :: Text
+    , erCandidateSourceId :: Maybe Text
+    , erCandidateEventId :: Maybe Text
+    , erCandidateReviewState :: Text
+    , erCandidateTitle :: Text
+    , erCandidateStartTime :: Maybe UTCTime
+    , erCandidateEndTime :: Maybe UTCTime
+    , erCandidateTimezone :: Text
+    , erCandidateVenueName :: Maybe Text
+    , erCandidateCity :: Maybe Text
+    , erCandidateProvince :: Maybe Text
+    , erCandidateCountryCode :: Text
+    , erCandidateSourceUrl :: Text
+    , erCandidateInfoUrl :: Maybe Text
+    , erCandidatePurchaseUrl :: Maybe Text
+    , erCandidatePayload :: Value
+    , erCandidateEvidence :: [EventResearchEvidenceDTO]
+    , erCandidateConfidence :: Text
+    , erCandidateManagedFields :: [Text]
+    , erCandidateContentHash :: Text
+    , erCandidateVerifiedAt :: UTCTime
+    , erCandidateIsPilot :: Bool
+    , erCandidateCreatedAt :: UTCTime
+    , erCandidateUpdatedAt :: UTCTime
+    }
+    deriving (Show, Eq, Generic)
+
+instance ToJSON EventResearchCandidateDTO
+instance FromJSON EventResearchCandidateDTO
+
+data EventResearchChangeDTO = EventResearchChangeDTO
+    { erChangeId :: Text
+    , erChangeRunId :: Text
+    , erChangeCandidateId :: Maybe Text
+    , erChangeEventId :: Maybe Text
+    , erChangeAction :: Text
+    , erChangeBeforeValue :: Maybe Value
+    , erChangeAfterValue :: Maybe Value
+    , erChangeSourceUrl :: Text
+    , erChangeConfidence :: Text
+    , erChangeConsultedAt :: UTCTime
+    , erChangeExternalId :: Text
+    , erChangeResult :: Text
+    , erChangeCreatedAt :: UTCTime
+    }
+    deriving (Show, Eq, Generic)
+
+instance ToJSON EventResearchChangeDTO
+instance FromJSON EventResearchChangeDTO

--- a/tdf-hq/src/TDF/DTO/SocialEventsDTO.hs
+++ b/tdf-hq/src/TDF/DTO/SocialEventsDTO.hs
@@ -460,6 +460,7 @@ data EventDTO = EventDTO
     , eventDescription :: Maybe Text
     , eventStart :: UTCTime
     , eventEnd :: UTCTime
+    , eventTimezone :: Maybe Text
     , eventVenueId :: Maybe Text
     , eventPriceCents :: Maybe Int
     , eventCapacity :: Maybe Int
@@ -528,6 +529,7 @@ eventUpdateAllowedKeys =
     , "eventDescription"
     , "eventStart"
     , "eventEnd"
+    , "eventTimezone"
     , "eventVenueId"
     , "eventPriceCents"
     , "eventCapacity"

--- a/tdf-hq/src/TDF/Models/SocialEventsModels.hs
+++ b/tdf-hq/src/TDF/Models/SocialEventsModels.hs
@@ -157,6 +157,86 @@ EventDiscoverySource sql=event_discovery_source
     UniqueEventDiscoverySource sourceKey
     deriving Show Generic
 
+EventResearchPilotControl sql=event_research_pilot_control
+    controlKey Text
+    approved Bool default=FALSE
+    approvedAt UTCTime Maybe
+    approvedByPartyId Text Maybe
+    approvalReference Text Maybe
+    maxActiveCandidates Int default=20
+    updatedAt UTCTime default=now()
+    UniqueEventResearchPilotControl controlKey
+    deriving Show Generic
+
+EventResearchPilotAudit sql=event_research_pilot_audit
+    controlId EventResearchPilotControlId
+    approved Bool
+    approvedByPartyId Text
+    approvalReference Text
+    createdAt UTCTime default=now()
+    deriving Show Generic
+
+EventResearchRun sql=event_research_run
+    runKey Text
+    status Text
+    reconciliation Bool default=FALSE
+    checkpoint Text Maybe
+    counters Text default='{}'
+    errorSummary Text Maybe
+    startedAt UTCTime
+    updatedAt UTCTime
+    finishedAt UTCTime Maybe
+    createdByPartyId Text
+    UniqueEventResearchRun runKey
+    deriving Show Generic
+
+EventResearchCandidate sql=event_research_candidate
+    provider Text
+    externalId Text
+    runId EventResearchRunId
+    sourceId EventDiscoverySourceId Maybe
+    eventId SocialEventId Maybe
+    reviewState Text
+    title Text
+    startTime UTCTime Maybe
+    endTime UTCTime Maybe
+    timezone Text
+    venueName Text Maybe
+    city Text Maybe
+    province Text Maybe
+    countryCode Text
+    sourceUrl Text
+    infoUrl Text Maybe
+    purchaseUrl Text Maybe
+    payload Text
+    evidence Text
+    confidence Text
+    managedFields Text default='[]'
+    contentHash Text
+    verifiedAt UTCTime
+    isPilot Bool default=TRUE
+    createdAt UTCTime
+    updatedAt UTCTime
+    UniqueEventResearchCandidate provider externalId
+    deriving Show Generic
+
+EventResearchChange sql=event_research_change
+    runId EventResearchRunId
+    candidateId EventResearchCandidateId Maybe
+    eventId SocialEventId Maybe
+    action Text
+    beforeValue Text Maybe
+    afterValue Text Maybe
+    sourceUrl Text
+    confidence Text
+    consultedAt UTCTime
+    externalId Text
+    result Text
+    dedupeKey Text
+    createdAt UTCTime
+    UniqueEventResearchChange dedupeKey
+    deriving Show Generic
+
 EventArtist
     eventId SocialEventId
     artistId ArtistProfileId

--- a/tdf-hq/src/TDF/Server/EventResearch.hs
+++ b/tdf-hq/src/TDF/Server/EventResearch.hs
@@ -1,0 +1,569 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module TDF.Server.EventResearch
+    ( eventResearchServer
+    , validateEventResearchCandidate
+    , eventResearchCandidateContentHash
+    ) where
+
+import Control.Exception (SomeException, displayException, try)
+import Control.Monad (unless, when)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Reader (ReaderT, ask)
+import Crypto.Hash (Digest, SHA256, hash)
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteArray.Encoding as BAE
+import qualified Data.ByteString.Lazy as BL
+import Data.Char (isAlphaNum, isAscii, isControl)
+import Data.Int (Int64)
+import Data.Maybe (isJust)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import Data.Time (UTCTime, getCurrentTime)
+import Database.Persist
+import Database.Persist.Sql (SqlBackend, SqlPersistT, fromSqlKey, runSqlPool, toSqlKey)
+import Servant
+import Text.Read (readMaybe)
+
+import TDF.API.EventResearchAPI
+import TDF.Auth (AuthedUser (..), hasStrictAdminAccess)
+import TDF.DB (Env (..))
+import TDF.DTO.EventResearchDTO
+import TDF.Models.SocialEventsModels hiding (eventResearchCandidateContentHash)
+import qualified TDF.Models.SocialEventsModels as SM
+import qualified TDF.Trials.Server as TrialsServer
+
+type AppM = ReaderT Env Handler
+
+eventResearchServer :: AuthedUser -> ServerT EventResearchRoutes AppM
+eventResearchServer user =
+    getPilot
+        :<|> approvePilot
+        :<|> listRuns
+        :<|> createRun
+        :<|> updateRun
+        :<|> listCandidates
+        :<|> upsertCandidate
+        :<|> listChanges
+  where
+    requireAdmin =
+        unless (hasStrictAdminAccess user) $
+            throwError err403{errBody = "Strict admin access required"}
+
+    partyIdText = renderKey (auPartyId user)
+
+    getPilot = do
+        requireAdmin
+        Env{..} <- ask
+        result <- liftIO $ runSqlPool loadPilotDTO envPool
+        either throwError pure result
+
+    approvePilot EventResearchPilotApprovalDTO{..} = do
+        requireAdmin
+        approvalReference <-
+            either (throwError . badRequest) pure $
+                normalizeRequired "approval reference" 500 erPilotApprovalReference
+        Env{..} <- ask
+        now <- liftIO getCurrentTime
+        result <- liftIO $ runSqlPool (approvePilotDb partyIdText approvalReference now) envPool
+        either throwError pure result
+
+    listRuns mLimit = do
+        requireAdmin
+        Env{..} <- ask
+        limit <- either throwError pure (boundedLimit mLimit)
+        rows <- liftIO $ runSqlPool (selectList [] [Desc EventResearchRunStartedAt, LimitTo limit]) envPool
+        traverse (either (throwError . storedDataError) pure . runEntityToDTO) rows
+
+    createRun EventResearchRunCreateDTO{..} = do
+        requireAdmin
+        runKey <- either (throwError . badRequest) pure (normalizeRunKey erRunKey)
+        checkpoint <- traverse (either (throwError . badRequest) pure . normalizeRequired "checkpoint" 2000) erRunCheckpoint
+        Env{..} <- ask
+        now <- liftIO getCurrentTime
+        row <- liftIO $ runSqlPool (createRunDb partyIdText runKey erRunReconciliation checkpoint now) envPool
+        either (throwError . storedDataError) pure (runEntityToDTO row)
+
+    updateRun rawRunId EventResearchRunUpdateDTO{..} = do
+        requireAdmin
+        runId <- either (throwError . badRequest) pure (parseKey "run" rawRunId)
+        status <- either (throwError . badRequest) pure (normalizeRunStatus erRunStatus)
+        checkpoint <- traverse (either (throwError . badRequest) pure . normalizeRequired "checkpoint" 2000) erRunCheckpoint
+        errorSummary <- traverse (either (throwError . badRequest) pure . normalizeRequired "error summary" 4000) erRunErrorSummary
+        Env{..} <- ask
+        now <- liftIO getCurrentTime
+        result <- liftIO $ runSqlPool (updateRunDb runId status checkpoint erRunCounters errorSummary now) envPool
+        either throwError (either (throwError . storedDataError) pure . runEntityToDTO) result
+
+    listCandidates mProvider mState mLimit = do
+        requireAdmin
+        provider <- traverse (either (throwError . badRequest) pure . normalizeProvider) mProvider
+        state <- traverse (either (throwError . badRequest) pure . normalizeReviewState) mState
+        limit <- either throwError pure (boundedLimit mLimit)
+        Env{..} <- ask
+        let filters =
+                maybe [] (\value -> [EventResearchCandidateProvider ==. value]) provider
+                    <> maybe [] (\value -> [EventResearchCandidateReviewState ==. value]) state
+        rows <- liftIO $ runSqlPool (selectList filters [Desc EventResearchCandidateVerifiedAt, LimitTo limit]) envPool
+        traverse (either (throwError . storedDataError) pure . candidateEntityToDTO) rows
+
+    upsertCandidate rawCandidate = do
+        requireAdmin
+        candidate <- either (throwError . badRequest) pure (validateEventResearchCandidate rawCandidate)
+        Env{..} <- ask
+        now <- liftIO getCurrentTime
+        attempted <- liftIO (try (runSqlPool (upsertCandidateDb candidate now) envPool) :: IO (Either SomeException (Either ServerError (Entity EventResearchCandidate))))
+        row <- case attempted of
+            Left exc
+                | "event research pilot candidate limit reached" `T.isInfixOf` T.toLower (T.pack (displayException exc)) ->
+                    throwError err409{errBody = "The unapproved pilot already contains its maximum of 20 active candidates"}
+                | otherwise -> throwError err500{errBody = "Event research candidate transaction failed"}
+            Right result -> either throwError pure result
+        either (throwError . storedDataError) pure (candidateEntityToDTO row)
+
+    listChanges mRunId mLimit = do
+        requireAdmin
+        runId <- traverse (either (throwError . badRequest) pure . parseKey "run") mRunId
+        limit <- either throwError pure (boundedLimit mLimit)
+        Env{..} <- ask
+        let filters = maybe [] (\value -> [EventResearchChangeRunId ==. value]) runId
+        rows <- liftIO $ runSqlPool (selectList filters [Desc EventResearchChangeCreatedAt, LimitTo limit]) envPool
+        traverse (either (throwError . storedDataError) pure . changeEntityToDTO) rows
+
+loadPilotDTO :: SqlPersistT IO (Either ServerError EventResearchPilotDTO)
+loadPilotDTO = do
+    control <- getBy (UniqueEventResearchPilotControl "default")
+    case control of
+        Nothing -> pure (Left err500{errBody = "Event research pilot control is not initialized"})
+        Just (Entity _ row) -> do
+            activeCount <- count [EventResearchCandidateIsPilot ==. True, EventResearchCandidateReviewState !=. "discarded"]
+            pure . Right $
+                EventResearchPilotDTO
+                    { erPilotApproved = eventResearchPilotControlApproved row
+                    , erPilotApprovedAt = eventResearchPilotControlApprovedAt row
+                    , erPilotApprovedByPartyId = eventResearchPilotControlApprovedByPartyId row
+                    , erPilotApprovalReference = eventResearchPilotControlApprovalReference row
+                    , erPilotMaxActiveCandidates = eventResearchPilotControlMaxActiveCandidates row
+                    , erPilotActiveCandidates = activeCount
+                    , erPilotUpdatedAt = eventResearchPilotControlUpdatedAt row
+                    }
+
+approvePilotDb :: T.Text -> T.Text -> UTCTime -> SqlPersistT IO (Either ServerError EventResearchPilotDTO)
+approvePilotDb partyId approvalReference now = do
+    control <- getBy (UniqueEventResearchPilotControl "default")
+    case control of
+        Nothing -> pure (Left err500{errBody = "Event research pilot control is not initialized"})
+        Just (Entity controlId row)
+            | eventResearchPilotControlApproved row
+                && eventResearchPilotControlApprovalReference row /= Just approvalReference ->
+                    pure (Left err409{errBody = "The pilot was already approved with a different reference"})
+            | eventResearchPilotControlApproved row -> loadPilotDTO
+            | otherwise -> do
+                update
+                    controlId
+                    [ EventResearchPilotControlApproved =. True
+                    , EventResearchPilotControlApprovedAt =. Just (maybe now id (eventResearchPilotControlApprovedAt row))
+                    , EventResearchPilotControlApprovedByPartyId =. Just (maybe partyId id (eventResearchPilotControlApprovedByPartyId row))
+                    , EventResearchPilotControlApprovalReference =. Just approvalReference
+                    , EventResearchPilotControlUpdatedAt =. now
+                    ]
+                when (not (eventResearchPilotControlApproved row)) $
+                    insert_ (EventResearchPilotAudit controlId True partyId approvalReference now)
+                loadPilotDTO
+
+createRunDb :: T.Text -> T.Text -> Bool -> Maybe T.Text -> UTCTime -> SqlPersistT IO (Entity EventResearchRun)
+createRunDb partyId runKey reconciliation checkpoint now = do
+    existing <- getBy (UniqueEventResearchRun runKey)
+    case existing of
+        Just row -> pure row
+        Nothing -> do
+            let row = EventResearchRun runKey "running" reconciliation checkpoint "{}" Nothing now now Nothing partyId
+            key <- insert row
+            pure (Entity key row)
+
+updateRunDb :: EventResearchRunId -> T.Text -> Maybe T.Text -> Aeson.Value -> Maybe T.Text -> UTCTime -> SqlPersistT IO (Either ServerError (Entity EventResearchRun))
+updateRunDb runId status checkpoint counters errorSummary now = do
+    existing <- get runId
+    case existing of
+        Nothing -> pure (Left err404{errBody = "Event research run not found"})
+        Just row
+            | eventResearchRunStatus row == status
+                && eventResearchRunCheckpoint row == checkpoint
+                && eventResearchRunCounters row == encodeJson counters
+                && eventResearchRunErrorSummary row == errorSummary ->
+                    pure (Right (Entity runId row))
+            | eventResearchRunStatus row == "completed" && status /= "completed" ->
+                pure (Left err409{errBody = "A completed research run cannot be reopened"})
+            | otherwise -> do
+                let finishedAt =
+                        if status `elem` ["completed", "failed"]
+                            then Just (maybe now id (eventResearchRunFinishedAt row))
+                            else Nothing
+                update
+                    runId
+                    [ EventResearchRunStatus =. status
+                    , EventResearchRunCheckpoint =. checkpoint
+                    , EventResearchRunCounters =. encodeJson counters
+                    , EventResearchRunErrorSummary =. errorSummary
+                    , EventResearchRunUpdatedAt =. now
+                    , EventResearchRunFinishedAt =. finishedAt
+                    ]
+                updated <- getJust runId
+                pure (Right (Entity runId updated))
+
+upsertCandidateDb :: EventResearchCandidateWriteDTO -> UTCTime -> SqlPersistT IO (Either ServerError (Entity EventResearchCandidate))
+upsertCandidateDb candidate now = do
+    runId <- pure (parseKeyUnsafe (candidate.erCandidateRunId))
+    run <- get runId
+    case run of
+        Nothing -> pure (Left err404{errBody = "Event research run not found"})
+        Just runRow -> do
+            sourceId <- traverse (pure . parseKeyUnsafe) (candidate.erCandidateSourceId)
+            sourceExists <- maybe (pure True) (fmap isJust . get) sourceId
+            if not sourceExists
+                then pure (Left err400{errBody = "Configured event source does not exist"})
+                else do
+                    let provider = candidate.erCandidateProvider
+                        externalId = candidate.erCandidateExternalId
+                        contentHash = eventResearchCandidateContentHash candidate
+                    existing <- getBy (UniqueEventResearchCandidate provider externalId)
+                    case existing of
+                        Just entity@(Entity candidateId row)
+                            | eventResearchRunStatus runRow /= "running"
+                                && SM.eventResearchCandidateContentHash row /= contentHash ->
+                                    pure (Left err409{errBody = "Only idempotent candidate retries are accepted after a run is closed"})
+                            | SM.eventResearchCandidateContentHash row == contentHash
+                                && ( eventResearchRunStatus runRow /= "running"
+                                        || candidate.erCandidateVerifiedAt <= eventResearchCandidateVerifiedAt row
+                                   ) ->
+                                    pure (Right entity)
+                            | otherwise -> do
+                                let action = if SM.eventResearchCandidateContentHash row == contentHash then "verified" else "updated"
+                                    beforeValue = encodeJson <$> either (const Nothing) Just (candidateEntityToDTO entity)
+                                updateCandidate candidate runId sourceId contentHash now candidateId
+                                updated <- getJust candidateId
+                                let updatedEntity = Entity candidateId updated
+                                    afterValue = encodeJson <$> either (const Nothing) Just (candidateEntityToDTO updatedEntity)
+                                insertChange candidate runId (Just candidateId) (eventResearchCandidateEventId updated) action beforeValue afterValue contentHash now
+                                pure (Right updatedEntity)
+                        Nothing
+                            | eventResearchRunStatus runRow /= "running" ->
+                                pure (Left err409{errBody = "New candidates require a running research run"})
+                            | otherwise -> do
+                                pilot <- getBy (UniqueEventResearchPilotControl "default")
+                                case pilot of
+                                    Nothing -> pure (Left err500{errBody = "Event research pilot control is not initialized"})
+                                    Just (Entity _ pilotRow) -> do
+                                        let row = candidateRow candidate runId sourceId contentHash (not (eventResearchPilotControlApproved pilotRow)) now
+                                        candidateId <- insert row
+                                        let entity = Entity candidateId row
+                                            afterValue = encodeJson <$> either (const Nothing) Just (candidateEntityToDTO entity)
+                                        insertChange candidate runId (Just candidateId) Nothing "created" Nothing afterValue contentHash now
+                                        pure (Right entity)
+
+candidateRow :: EventResearchCandidateWriteDTO -> EventResearchRunId -> Maybe EventDiscoverySourceId -> T.Text -> Bool -> UTCTime -> EventResearchCandidate
+candidateRow EventResearchCandidateWriteDTO{..} runId sourceId contentHash isPilot now =
+    EventResearchCandidate
+        erCandidateProvider erCandidateExternalId runId sourceId Nothing erCandidateReviewState
+        erCandidateTitle erCandidateStartTime erCandidateEndTime erCandidateTimezone erCandidateVenueName
+        erCandidateCity erCandidateProvince erCandidateCountryCode erCandidateSourceUrl erCandidateInfoUrl
+        erCandidatePurchaseUrl (encodeJson erCandidatePayload) (encodeJson erCandidateEvidence)
+        erCandidateConfidence (encodeJson erCandidateManagedFields) contentHash erCandidateVerifiedAt isPilot now now
+
+updateCandidate :: EventResearchCandidateWriteDTO -> EventResearchRunId -> Maybe EventDiscoverySourceId -> T.Text -> UTCTime -> EventResearchCandidateId -> SqlPersistT IO ()
+updateCandidate EventResearchCandidateWriteDTO{..} runId sourceId contentHash now candidateId =
+    update
+        candidateId
+        [ EventResearchCandidateRunId =. runId
+        , EventResearchCandidateSourceId =. sourceId
+        , EventResearchCandidateReviewState =. erCandidateReviewState
+        , EventResearchCandidateTitle =. erCandidateTitle
+        , EventResearchCandidateStartTime =. erCandidateStartTime
+        , EventResearchCandidateEndTime =. erCandidateEndTime
+        , EventResearchCandidateTimezone =. erCandidateTimezone
+        , EventResearchCandidateVenueName =. erCandidateVenueName
+        , EventResearchCandidateCity =. erCandidateCity
+        , EventResearchCandidateProvince =. erCandidateProvince
+        , EventResearchCandidateCountryCode =. erCandidateCountryCode
+        , EventResearchCandidateSourceUrl =. erCandidateSourceUrl
+        , EventResearchCandidateInfoUrl =. erCandidateInfoUrl
+        , EventResearchCandidatePurchaseUrl =. erCandidatePurchaseUrl
+        , EventResearchCandidatePayload =. encodeJson erCandidatePayload
+        , EventResearchCandidateEvidence =. encodeJson erCandidateEvidence
+        , EventResearchCandidateConfidence =. erCandidateConfidence
+        , EventResearchCandidateManagedFields =. encodeJson erCandidateManagedFields
+        , EventResearchCandidateContentHash =. contentHash
+        , EventResearchCandidateVerifiedAt =. erCandidateVerifiedAt
+        , EventResearchCandidateUpdatedAt =. now
+        ]
+
+insertChange :: EventResearchCandidateWriteDTO -> EventResearchRunId -> Maybe EventResearchCandidateId -> Maybe SocialEventId -> T.Text -> Maybe T.Text -> Maybe T.Text -> T.Text -> UTCTime -> SqlPersistT IO ()
+insertChange candidate runId candidateId eventId action beforeValue afterValue contentHash now = do
+    let dedupeKey = sha256Text . BL.fromStrict . TE.encodeUtf8 $
+            T.intercalate ":" [renderKey runId, candidate.erCandidateProvider, candidate.erCandidateExternalId, action, contentHash, T.pack (show (candidate.erCandidateVerifiedAt))]
+        row = EventResearchChange runId candidateId eventId action beforeValue afterValue
+                (candidate.erCandidateSourceUrl) (candidate.erCandidateConfidence) (candidate.erCandidateVerifiedAt)
+                (candidate.erCandidateExternalId) "confirmed" dedupeKey now
+    _ <- insertUnique row
+    pure ()
+
+validateEventResearchCandidate :: EventResearchCandidateWriteDTO -> Either T.Text EventResearchCandidateWriteDTO
+validateEventResearchCandidate candidate = do
+    provider <- normalizeProvider (candidate.erCandidateProvider)
+    externalId <- normalizeIdentifier "external identifier" 512 (candidate.erCandidateExternalId)
+    _ <- parsePositiveId "run" candidate.erCandidateRunId
+    _ <- traverse (parsePositiveId "event source") candidate.erCandidateSourceId
+    reviewState <- normalizeReviewState (candidate.erCandidateReviewState)
+    title <- normalizeRequired "title" 240 (candidate.erCandidateTitle)
+    timezone <- normalizeTimeZone (candidate.erCandidateTimezone)
+    countryCode <- normalizeCountryCode (candidate.erCandidateCountryCode)
+    sourceUrl <- normalizeHttpsUrl "source URL" (candidate.erCandidateSourceUrl)
+    infoUrl <- traverse (normalizeHttpsUrl "information URL") (candidate.erCandidateInfoUrl)
+    purchaseUrl <- traverse (normalizeHttpsUrl "purchase URL") (candidate.erCandidatePurchaseUrl)
+    venueName <- traverse (normalizeRequired "venue name" 240) (candidate.erCandidateVenueName)
+    city <- traverse (normalizeRequired "city" 160) (candidate.erCandidateCity)
+    province <- traverse (normalizeRequired "province" 160) (candidate.erCandidateProvince)
+    confidence <- normalizeConfidence (candidate.erCandidateConfidence)
+    unless (not (null (candidate.erCandidateEvidence))) (Left "at least one evidence URL is required")
+    evidence <- traverse validateEvidence (candidate.erCandidateEvidence)
+    unless (any ((== sourceUrl) . erEvidenceUrl) evidence) (Left "evidence must include the primary source URL")
+    case (candidate.erCandidateStartTime, candidate.erCandidateEndTime) of
+        (Just startTime, Just endTime) -> unless (startTime < endTime) (Left "start time must be before end time")
+        _ -> pure ()
+    when (confidence == "high") $ do
+        unless (isJust (candidate.erCandidateStartTime)) (Left "high confidence requires a confirmed start time")
+        unless (isJust venueName && isJust city) (Left "high confidence requires confirmed venue and city")
+        unless (isJust purchaseUrl && any ((== "official_sale") . erEvidenceKind) evidence) (Left "high confidence requires an official sale page and direct purchase URL")
+    managedFields <- traverse (normalizeIdentifier "managed field" 120) (candidate.erCandidateManagedFields)
+    pure
+        EventResearchCandidateWriteDTO
+        { erCandidateProvider = provider
+        , erCandidateExternalId = externalId
+        , erCandidateRunId = candidate.erCandidateRunId
+        , erCandidateSourceId = candidate.erCandidateSourceId
+        , erCandidateReviewState = reviewState
+        , erCandidateTitle = title
+        , erCandidateStartTime = candidate.erCandidateStartTime
+        , erCandidateEndTime = candidate.erCandidateEndTime
+        , erCandidateTimezone = timezone
+        , erCandidateVenueName = venueName
+        , erCandidateCity = city
+        , erCandidateProvince = province
+        , erCandidateCountryCode = countryCode
+        , erCandidateSourceUrl = sourceUrl
+        , erCandidateInfoUrl = infoUrl
+        , erCandidatePurchaseUrl = purchaseUrl
+        , erCandidatePayload = candidate.erCandidatePayload
+        , erCandidateEvidence = evidence
+        , erCandidateConfidence = confidence
+        , erCandidateManagedFields = managedFields
+        , erCandidateVerifiedAt = candidate.erCandidateVerifiedAt
+        }
+
+validateEvidence :: EventResearchEvidenceDTO -> Either T.Text EventResearchEvidenceDTO
+validateEvidence evidence = do
+    url <- normalizeHttpsUrl "evidence URL" (erEvidenceUrl evidence)
+    kind <- normalizeIdentifier "evidence kind" 80 (erEvidenceKind evidence)
+    notes <- traverse (normalizeRequired "evidence notes" 1000) (erEvidenceNotes evidence)
+    pure evidence{erEvidenceUrl = url, erEvidenceKind = kind, erEvidenceNotes = notes}
+
+eventResearchCandidateContentHash :: EventResearchCandidateWriteDTO -> T.Text
+eventResearchCandidateContentHash candidate =
+    sha256Text . Aeson.encode $
+        Aeson.object
+            [ "provider" Aeson..= candidate.erCandidateProvider
+            , "externalId" Aeson..= candidate.erCandidateExternalId
+            , "sourceId" Aeson..= candidate.erCandidateSourceId
+            , "reviewState" Aeson..= candidate.erCandidateReviewState
+            , "title" Aeson..= candidate.erCandidateTitle
+            , "startTime" Aeson..= candidate.erCandidateStartTime
+            , "endTime" Aeson..= candidate.erCandidateEndTime
+            , "timezone" Aeson..= candidate.erCandidateTimezone
+            , "venueName" Aeson..= candidate.erCandidateVenueName
+            , "city" Aeson..= candidate.erCandidateCity
+            , "province" Aeson..= candidate.erCandidateProvince
+            , "countryCode" Aeson..= candidate.erCandidateCountryCode
+            , "sourceUrl" Aeson..= candidate.erCandidateSourceUrl
+            , "infoUrl" Aeson..= candidate.erCandidateInfoUrl
+            , "purchaseUrl" Aeson..= candidate.erCandidatePurchaseUrl
+            , "payload" Aeson..= candidate.erCandidatePayload
+            , "evidence" Aeson..= map evidenceContent (candidate.erCandidateEvidence)
+            , "confidence" Aeson..= candidate.erCandidateConfidence
+            , "managedFields" Aeson..= candidate.erCandidateManagedFields
+            ]
+  where
+    evidenceContent evidence =
+        Aeson.object
+            [ "url" Aeson..= erEvidenceUrl evidence
+            , "kind" Aeson..= erEvidenceKind evidence
+            , "notes" Aeson..= erEvidenceNotes evidence
+            ]
+
+runEntityToDTO :: Entity EventResearchRun -> Either T.Text EventResearchRunDTO
+runEntityToDTO (Entity key row) = do
+    counters <- decodeJson "run counters" (eventResearchRunCounters row)
+    pure EventResearchRunDTO
+        { erRunId = renderKey key
+        , erRunKey = eventResearchRunRunKey row
+        , erRunStatus = eventResearchRunStatus row
+        , erRunReconciliation = eventResearchRunReconciliation row
+        , erRunCheckpoint = eventResearchRunCheckpoint row
+        , erRunCounters = counters
+        , erRunErrorSummary = eventResearchRunErrorSummary row
+        , erRunStartedAt = eventResearchRunStartedAt row
+        , erRunUpdatedAt = eventResearchRunUpdatedAt row
+        , erRunFinishedAt = eventResearchRunFinishedAt row
+        , erRunCreatedByPartyId = eventResearchRunCreatedByPartyId row
+        }
+
+candidateEntityToDTO :: Entity EventResearchCandidate -> Either T.Text EventResearchCandidateDTO
+candidateEntityToDTO (Entity key row) = do
+    payload <- decodeJson "candidate payload" (eventResearchCandidatePayload row)
+    evidence <- decodeJson "candidate evidence" (eventResearchCandidateEvidence row)
+    managedFields <- decodeJson "candidate managed fields" (eventResearchCandidateManagedFields row)
+    pure EventResearchCandidateDTO
+        { erCandidateId = renderKey key
+        , erCandidateProvider = eventResearchCandidateProvider row
+        , erCandidateExternalId = eventResearchCandidateExternalId row
+        , erCandidateRunId = renderKey (eventResearchCandidateRunId row)
+        , erCandidateSourceId = renderKey <$> eventResearchCandidateSourceId row
+        , erCandidateEventId = renderKey <$> eventResearchCandidateEventId row
+        , erCandidateReviewState = eventResearchCandidateReviewState row
+        , erCandidateTitle = eventResearchCandidateTitle row
+        , erCandidateStartTime = eventResearchCandidateStartTime row
+        , erCandidateEndTime = eventResearchCandidateEndTime row
+        , erCandidateTimezone = eventResearchCandidateTimezone row
+        , erCandidateVenueName = eventResearchCandidateVenueName row
+        , erCandidateCity = eventResearchCandidateCity row
+        , erCandidateProvince = eventResearchCandidateProvince row
+        , erCandidateCountryCode = eventResearchCandidateCountryCode row
+        , erCandidateSourceUrl = eventResearchCandidateSourceUrl row
+        , erCandidateInfoUrl = eventResearchCandidateInfoUrl row
+        , erCandidatePurchaseUrl = eventResearchCandidatePurchaseUrl row
+        , erCandidatePayload = payload
+        , erCandidateEvidence = evidence
+        , erCandidateConfidence = eventResearchCandidateConfidence row
+        , erCandidateManagedFields = managedFields
+        , erCandidateContentHash = SM.eventResearchCandidateContentHash row
+        , erCandidateVerifiedAt = eventResearchCandidateVerifiedAt row
+        , erCandidateIsPilot = eventResearchCandidateIsPilot row
+        , erCandidateCreatedAt = eventResearchCandidateCreatedAt row
+        , erCandidateUpdatedAt = eventResearchCandidateUpdatedAt row
+        }
+
+changeEntityToDTO :: Entity EventResearchChange -> Either T.Text EventResearchChangeDTO
+changeEntityToDTO (Entity key row) = do
+    beforeValue <- traverse (decodeJson "change before value") (eventResearchChangeBeforeValue row)
+    afterValue <- traverse (decodeJson "change after value") (eventResearchChangeAfterValue row)
+    pure EventResearchChangeDTO
+        { erChangeId = renderKey key
+        , erChangeRunId = renderKey (eventResearchChangeRunId row)
+        , erChangeCandidateId = renderKey <$> eventResearchChangeCandidateId row
+        , erChangeEventId = renderKey <$> eventResearchChangeEventId row
+        , erChangeAction = eventResearchChangeAction row
+        , erChangeBeforeValue = beforeValue
+        , erChangeAfterValue = afterValue
+        , erChangeSourceUrl = eventResearchChangeSourceUrl row
+        , erChangeConfidence = eventResearchChangeConfidence row
+        , erChangeConsultedAt = eventResearchChangeConsultedAt row
+        , erChangeExternalId = eventResearchChangeExternalId row
+        , erChangeResult = eventResearchChangeResult row
+        , erChangeCreatedAt = eventResearchChangeCreatedAt row
+        }
+
+normalizeRunKey :: T.Text -> Either T.Text T.Text
+normalizeRunKey raw = do
+    value <- normalizeIdentifier "run key" 160 raw
+    unless (T.all (\ch -> isAscii ch && (isAlphaNum ch || ch `elem` ("._:-" :: String))) value) (Left "run key contains unsupported characters")
+    pure value
+
+normalizeRunStatus :: T.Text -> Either T.Text T.Text
+normalizeRunStatus raw =
+    let value = T.toLower (T.strip raw)
+     in if value `elem` ["running", "completed", "failed"] then Right value else Left "run status must be running, completed, or failed"
+
+normalizeReviewState :: T.Text -> Either T.Text T.Text
+normalizeReviewState raw =
+    let value = T.toLower (T.strip raw)
+     in if value `elem` ["draft", "review", "discarded"] then Right value else Left "review state must be draft, review, or discarded"
+
+normalizeConfidence :: T.Text -> Either T.Text T.Text
+normalizeConfidence raw =
+    let value = T.toLower (T.strip raw)
+     in if value `elem` ["high", "medium", "low"] then Right value else Left "confidence must be high, medium, or low"
+
+normalizeProvider :: T.Text -> Either T.Text T.Text
+normalizeProvider = fmap T.toLower . normalizeIdentifier "provider" 80
+
+normalizeIdentifier :: T.Text -> Int -> T.Text -> Either T.Text T.Text
+normalizeIdentifier label maxLength raw = do
+    value <- normalizeRequired label maxLength raw
+    unless (T.all (\ch -> isAscii ch && not (isControl ch)) value) (Left (label <> " must contain safe ASCII characters"))
+    pure value
+
+normalizeRequired :: T.Text -> Int -> T.Text -> Either T.Text T.Text
+normalizeRequired label maxLength raw =
+    let value = T.unwords (T.words (T.strip raw))
+     in if T.null value || T.length value > maxLength || T.any isControl raw
+            then Left (label <> " must be nonblank, safe, and at most " <> T.pack (show maxLength) <> " characters")
+            else Right value
+
+normalizeTimeZone :: T.Text -> Either T.Text T.Text
+normalizeTimeZone raw = do
+    value <- normalizeRequired "timezone" 64 raw
+    unless (T.all (\ch -> isAlphaNum ch || ch `elem` ("_+-/" :: String)) value && "/" `T.isInfixOf` value) (Left "timezone must be an explicit IANA-style identifier")
+    pure value
+
+normalizeCountryCode :: T.Text -> Either T.Text T.Text
+normalizeCountryCode raw =
+    let value = T.toUpper (T.strip raw)
+     in if T.length value == 2 && T.all (\ch -> isAscii ch && ch >= 'A' && ch <= 'Z') value then Right value else Left "country code must be two ASCII letters"
+
+normalizeHttpsUrl :: T.Text -> T.Text -> Either T.Text T.Text
+normalizeHttpsUrl label raw = do
+    value <- normalizeRequired label 2048 raw
+    unless ("https://" `T.isPrefixOf` T.toLower value && TrialsServer.isValidHttpUrl value) (Left (label <> " must be a valid HTTPS URL"))
+    pure value
+
+boundedLimit :: Maybe Int -> Either ServerError Int
+boundedLimit raw =
+    let value = maybe 100 id raw
+     in if value >= 1 && value <= 500 then Right value else Left err400{errBody = "limit must be between 1 and 500"}
+
+parseKey :: (ToBackendKey SqlBackend record) => T.Text -> T.Text -> Either T.Text (Key record)
+parseKey label raw = toSqlKey <$> parsePositiveId label raw
+
+parsePositiveId :: T.Text -> T.Text -> Either T.Text Int64
+parsePositiveId label raw =
+    case readMaybe (T.unpack (T.strip raw)) :: Maybe Int64 of
+        Just value | value > 0 -> Right value
+        _ -> Left (label <> " id must be a positive integer")
+
+parseKeyUnsafe :: (ToBackendKey SqlBackend record) => T.Text -> Key record
+parseKeyUnsafe raw = toSqlKey (maybe 0 id (readMaybe (T.unpack raw)))
+
+renderKey :: (ToBackendKey SqlBackend record) => Key record -> T.Text
+renderKey = T.pack . show . fromSqlKey
+
+encodeJson :: Aeson.ToJSON value => value -> T.Text
+encodeJson = TE.decodeUtf8 . BL.toStrict . Aeson.encode
+
+decodeJson :: Aeson.FromJSON value => T.Text -> T.Text -> Either T.Text value
+decodeJson label raw =
+    case Aeson.eitherDecodeStrict' (TE.encodeUtf8 raw) of
+        Left message -> Left (label <> " is invalid JSON: " <> T.pack message)
+        Right value -> Right value
+
+sha256Text :: BL.ByteString -> T.Text
+sha256Text bytes =
+    TE.decodeUtf8 (BAE.convertToBase BAE.Base16 (hash (BL.toStrict bytes) :: Digest SHA256))
+
+badRequest :: T.Text -> ServerError
+badRequest message = err400{errBody = BL.fromStrict (TE.encodeUtf8 message)}
+
+storedDataError :: T.Text -> ServerError
+storedDataError message = err500{errBody = BL.fromStrict (TE.encodeUtf8 message)}

--- a/tdf-hq/src/TDF/Server/SocialEventsHandlers.hs
+++ b/tdf-hq/src/TDF/Server/SocialEventsHandlers.hs
@@ -51,6 +51,7 @@ module TDF.Server.SocialEventsHandlers (
     validateEventCreateUpdateDimensions,
     validateSocialEventsListOffset,
     validateSocialEventsListFilter,
+    validateDiscoverySourceWrite,
     validateVenueCreateUpdateFields,
     validateEventCurrencyInput,
     TicketCheckInLookup (..),
@@ -156,6 +157,7 @@ import Crypto.MAC.HMAC (HMAC, hmac, hmacGetDigest)
 import Data.Time.Clock (addUTCTime)
 import qualified System.Random as Random
 import TDF.API.SocialEventsAPI
+import qualified TDF.Server.EventResearch as EventResearch
 import TDF.Auth (AuthedUser (..), hasStrictAdminAccess, moduleName)
 import qualified TDF.Catalog.Models as Catalog
 import TDF.Config (AppConfig (..), EmailConfig, assetsRootDir, resolveConfiguredAssetsBase)
@@ -1622,8 +1624,8 @@ validateDiscoverySourceWrite DiscoverySourceWriteDTO{..} = do
         )
         "source name must be a safe value between 1 and 160 characters"
     unlessEither
-        (sourceType `elem` ["ticketmaster", "buenplan", "ical", "json"])
-        "source type must be one of: ticketmaster, buenplan, ical, json"
+        (sourceType `elem` ["ticketmaster", "buenplan", "ical", "json", "web"])
+        "source type must be one of: ticketmaster, buenplan, ical, json, web"
     unlessEither
         (discoverySourceWritePriority >= 0 && discoverySourceWritePriority <= 10000)
         "source priority must be between 0 and 10000"
@@ -1638,6 +1640,20 @@ validateDiscoverySourceWrite DiscoverySourceWriteDTO{..} = do
         "buenplan" -> do
             unlessEither (sourceKey == "buenplan") "Buen Plan must use the buenplan source key"
             unlessEither (isNothing feedUrl && isNothing cityKey) "Buen Plan does not accept a feed URL or city"
+        "web" -> do
+            url <-
+                maybe
+                    (Left err400{errBody = "Web research sources require an HTTPS homepage URL"})
+                    Right
+                    feedUrl
+            unlessEither
+                ( T.length url <= 2048
+                    && "https://" `T.isPrefixOf` T.toLower url
+                    && TrialsServer.isValidHttpUrl url
+                )
+                "Web research source URL must be a valid HTTPS URL"
+            unlessEither (isNothing cityKey) "Web research sources are not tied to one event city"
+            unlessEither (not discoverySourceWriteEnabled) "Web research sources must remain disabled for automated cron ingestion"
         _ -> do
             url <-
                 maybe
@@ -1721,6 +1737,7 @@ socialEventsServer user =
     eventsServer
         :<|> eventCitiesServer
         :<|> eventDiscoverySourcesServer
+        :<|> EventResearch.eventResearchServer user
         :<|> venuesServer
         :<|> artistsServer
         :<|> rsvpsServer
@@ -2150,6 +2167,7 @@ socialEventsServer user =
         now <- liftIO getCurrentTime
         titleVal <- either throwError pure (validateEventTitleInput (eventTitle dto))
         when (eventStart dto >= eventEnd dto) $ throwError err400{errBody = "start time must be before end time"}
+        timezoneVal <- traverse (either throwError pure . validateEventTimeZone) (eventTimezone dto)
         either throwError pure $
             validateEventCreateUpdateDimensions
                 (eventPriceCents dto)
@@ -2201,7 +2219,7 @@ socialEventsServer user =
                             , socialEventTitle = titleVal
                             , socialEventDescription = eventDescription dto
                             , socialEventVenueId = mVenueKey
-                            , socialEventTimezone = Nothing
+                            , socialEventTimezone = timezoneVal
                             , socialEventEventTypeId = Just eventTypeUuid
                             , socialEventWorkflowStateId = Just workflowStateId
                             , socialEventStartTime = eventStart dto
@@ -2227,7 +2245,7 @@ socialEventsServer user =
                     , socialEventTitle = titleVal
                     , socialEventDescription = eventDescription dto
                     , socialEventVenueId = mVenueKey
-                    , socialEventTimezone = Nothing
+                    , socialEventTimezone = timezoneVal
                     , socialEventEventTypeId = Just eventTypeUuid
                     , socialEventWorkflowStateId = Just workflowStateId
                     , socialEventStartTime = eventStart dto
@@ -2272,6 +2290,7 @@ socialEventsServer user =
                 >>= either throwError pure
         titleVal <- either throwError pure (validateEventTitleInput (eventTitle dto))
         when (eventStart dto >= eventEnd dto) $ throwError err400{errBody = "start time must be before end time"}
+        timezoneVal <- traverse (either throwError pure . validateEventTimeZone) (eventTimezone dto)
         either throwError pure $
             validateEventCreateUpdateDimensions
                 (eventPriceCents dto)
@@ -2307,6 +2326,7 @@ socialEventsServer user =
                     [ SocialEventTitle =. titleVal
                     , SocialEventDescription =. eventDescription dto
                     , SocialEventVenueId =. mVenueKey
+                    , SocialEventTimezone =. timezoneVal
                     , SocialEventStartTime =. eventStart dto
                     , SocialEventEndTime =. eventEnd dto
                     , SocialEventPriceCents =. eventPriceCents dto
@@ -2330,6 +2350,7 @@ socialEventsServer user =
                     { socialEventTitle = titleVal
                     , socialEventDescription = eventDescription dto
                     , socialEventVenueId = mVenueKey
+                    , socialEventTimezone = timezoneVal
                     , socialEventStartTime = eventStart dto
                     , socialEventEndTime = eventEnd dto
                     , socialEventPriceCents = eventPriceCents dto
@@ -8171,6 +8192,7 @@ eventEntityToDTO configuredDefault eid eventRow artists = do
                   , eventDescription = socialEventDescription eventRow
                   , eventStart = socialEventStartTime eventRow
                   , eventEnd = socialEventEndTime eventRow
+                  , eventTimezone = socialEventTimezone eventRow
                   , eventVenueId = fmap renderKeyText (socialEventVenueId eventRow)
                   , eventPriceCents = socialEventPriceCents eventRow
                   , eventCapacity = socialEventCapacity eventRow

--- a/tdf-hq/tdf-hq.cabal
+++ b/tdf-hq/tdf-hq.cabal
@@ -41,6 +41,7 @@ executable tdf-hq-exe
     TDF.Contracts.Types
     TDF.Courses.Production
     TDF.API.SocialEventsAPI
+    TDF.API.EventResearchAPI
     TDF.API.Types
     TDF.API.WhatsApp
     TDF.API.DDEX
@@ -57,6 +58,7 @@ executable tdf-hq-exe
     TDF.DB
     TDF.DTO
     TDF.DTO.SocialEventsDTO
+    TDF.DTO.EventResearchDTO
     TDF.DTO.SocialDiscoveryDTO
     TDF.DTO.SocialSyncDTO
     TDF.Email
@@ -99,6 +101,7 @@ executable tdf-hq-exe
     TDF.ServerProposals
     TDF.ServerInternships
     TDF.Server.SocialEventsHandlers
+    TDF.Server.EventResearch
     TDF.Server.DDEX
     TDF.Server.Catalog
     TDF.Server.ServiceStorefront
@@ -239,6 +242,7 @@ test-suite tdf-hq-test
     TDF.API.Rooms
     TDF.API.Sessions
     TDF.API.SocialEventsAPI
+    TDF.API.EventResearchAPI
     TDF.API.Types
     TDF.API.WhatsApp
     TDF.APITypesSpec
@@ -255,6 +259,7 @@ test-suite tdf-hq-test
     TDF.DB
     TDF.DTO
     TDF.DTO.SocialEventsDTO
+    TDF.DTO.EventResearchDTO
     TDF.DTO.SocialDiscoveryDTO
     TDF.DTO.SocialSyncDTO
     TDF.Email
@@ -298,6 +303,7 @@ test-suite tdf-hq-test
     TDF.Server.SocialDiscovery
     TDF.Server.SocialSync
     TDF.Server.SocialEventsHandlers
+    TDF.Server.EventResearch
     TDF.SocialEventLifecycle
     TDF.ServerFuture
     TDF.ServerLiveSessions
@@ -316,6 +322,7 @@ test-suite tdf-hq-test
     TDF.Services.EventDiscovery
     TDF.Services.EventLogisticsRoutes
     TDF.Services.EventDiscoverySpec
+    TDF.Server.EventResearchSpec
     TDF.Services.InstagramSync
     TDF.Services.Stripe
     TDF.Trials.API

--- a/tdf-hq/test/Spec.hs
+++ b/tdf-hq/test/Spec.hs
@@ -107,6 +107,7 @@ import qualified TDF.Catalog.PipelineSpec as CatalogPipelineSpec
 import TDF.Email (resolveRefundTimelineMessage)
 import TDF.Services.InstagramSync (buildUserMediaRequestUrl)
 import qualified TDF.Services.EventDiscoverySpec as EventDiscoverySpec
+import qualified TDF.Server.EventResearchSpec as EventResearchSpec
 import TDF.Services.EventLogisticsRoutes (RouteEstimateResult (..), parseGoogleDurationSeconds, parseGoogleRouteResponse)
 import TDF.DB (Env (..))
 import qualified TDF.DTO as DTO
@@ -14711,6 +14712,7 @@ main = hspec $ do
     CatalogSecuritySpec.spec
     CatalogPipelineSpec.spec
     EventDiscoverySpec.spec
+    EventResearchSpec.spec
     ArtistSpec.spec
     ServerAuthSpec.spec
     ServerSpec.spec

--- a/tdf-hq/test/TDF/Server/EventResearchSpec.hs
+++ b/tdf-hq/test/TDF/Server/EventResearchSpec.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+
+module TDF.Server.EventResearchSpec (spec) where
+
+import Data.Aeson (object)
+import Data.Either (isLeft, isRight)
+import Data.Time (UTCTime (..), fromGregorian, secondsToDiffTime)
+import Test.Hspec
+
+import TDF.DTO.EventResearchDTO
+    ( EventResearchCandidateWriteDTO (..)
+    , EventResearchEvidenceDTO (..)
+    )
+import TDF.DTO.SocialEventsDTO (DiscoverySourceWriteDTO (..))
+import TDF.Server.EventResearch
+import TDF.Server.SocialEventsHandlers (validateDiscoverySourceWrite)
+
+spec :: Spec
+spec = do
+    describe "event research candidate validation" $ do
+        it "accepts a complete official-sale candidate with an explicit timezone" $ do
+            validateEventResearchCandidate completeCandidate `shouldSatisfy` isRight
+
+        it "keeps high confidence stricter than draft review" $ do
+            validateEventResearchCandidate completeCandidate{erCandidatePurchaseUrl = Nothing}
+                `shouldSatisfy` isLeft
+            validateEventResearchCandidate
+                completeCandidate
+                    { erCandidatePurchaseUrl = Nothing
+                    , erCandidateConfidence = "medium"
+                    }
+                `shouldSatisfy` isRight
+
+        it "rejects a missing IANA timezone and evidence not containing the primary source" $ do
+            validateEventResearchCandidate completeCandidate{erCandidateTimezone = "UTC"}
+                `shouldSatisfy` isLeft
+            validateEventResearchCandidate
+                completeCandidate
+                    { erCandidateEvidence =
+                        [ (head completeCandidate.erCandidateEvidence)
+                            { erEvidenceUrl = "https://other.example/event"
+                            }
+                        ]
+                    }
+                `shouldSatisfy` isLeft
+
+        it "keeps material hashes stable across a later verification timestamp" $ do
+            eventResearchCandidateContentHash completeCandidate
+                `shouldBe` eventResearchCandidateContentHash
+                    completeCandidate
+                        { erCandidateVerifiedAt = fixtureTime 13
+                        , erCandidateEvidence =
+                            [ (head completeCandidate.erCandidateEvidence)
+                                { erEvidenceConsultedAt = fixtureTime 13
+                                }
+                            ]
+                        }
+
+    describe "manual web discovery source validation" $ do
+        it "accepts only disabled HTTPS web sources without a city" $ do
+            validateDiscoverySourceWrite webSource `shouldSatisfy` isRight
+            validateDiscoverySourceWrite webSource{discoverySourceWriteEnabled = True}
+                `shouldSatisfy` isLeft
+            validateDiscoverySourceWrite webSource{discoverySourceWriteCityId = Just "1"}
+                `shouldSatisfy` isLeft
+
+completeCandidate :: EventResearchCandidateWriteDTO
+completeCandidate =
+    EventResearchCandidateWriteDTO
+        { erCandidateProvider = "fixture"
+        , erCandidateExternalId = "official-event-1"
+        , erCandidateRunId = "1"
+        , erCandidateSourceId = Nothing
+        , erCandidateReviewState = "draft"
+        , erCandidateTitle = "Festival confirmado"
+        , erCandidateStartTime = Just (fixtureTime 10)
+        , erCandidateEndTime = Just (fixtureTime 12)
+        , erCandidateTimezone = "America/Guayaquil"
+        , erCandidateVenueName = Just "Venue oficial"
+        , erCandidateCity = Just "Quito"
+        , erCandidateProvince = Just "Pichincha"
+        , erCandidateCountryCode = "EC"
+        , erCandidateSourceUrl = "https://official.example/event"
+        , erCandidateInfoUrl = Just "https://official.example/event"
+        , erCandidatePurchaseUrl = Just "https://official.example/event/buy"
+        , erCandidatePayload = object []
+        , erCandidateEvidence =
+            [ EventResearchEvidenceDTO
+                { erEvidenceUrl = "https://official.example/event"
+                , erEvidenceKind = "official_sale"
+                , erEvidenceConsultedAt = fixtureTime 9
+                , erEvidenceNotes = Nothing
+                }
+            ]
+        , erCandidateConfidence = "high"
+        , erCandidateManagedFields = ["title", "startTime", "timezone"]
+        , erCandidateVerifiedAt = fixtureTime 9
+        }
+
+webSource :: DiscoverySourceWriteDTO
+webSource =
+    DiscoverySourceWriteDTO
+        { discoverySourceWriteKey = "official-web"
+        , discoverySourceWriteName = "Official web"
+        , discoverySourceWriteType = "web"
+        , discoverySourceWriteFeedUrl = Just "https://official.example/"
+        , discoverySourceWriteCityId = Nothing
+        , discoverySourceWriteEnabled = False
+        , discoverySourceWritePriority = 200
+        }
+
+fixtureTime :: Integer -> UTCTime
+fixtureTime hour = UTCTime (fromGregorian 2026 8 16) (secondsToDiffTime (hour * 3600))

--- a/tdf-hq/test/TDF/Social/FollowHandlerSpec.hs
+++ b/tdf-hq/test/TDF/Social/FollowHandlerSpec.hs
@@ -579,6 +579,7 @@ socialEventUpdateHandlerFor user =
         eventsServer
             :<|> _cities
             :<|> _sources
+            :<|> _research
             :<|> _venues
             :<|> _artists
             :<|> _rsvps
@@ -605,6 +606,7 @@ socialEventGetHandlerFor user =
         eventsServer
             :<|> _cities
             :<|> _sources
+            :<|> _research
             :<|> _venues
             :<|> _artists
             :<|> _rsvps
@@ -631,6 +633,7 @@ artistGetHandlerFor user =
         _events
             :<|> _cities
             :<|> _sources
+            :<|> _research
             :<|> _venues
             :<|> artistsServer
             :<|> _rsvps
@@ -659,6 +662,7 @@ socialEventInvitationCreateHandlerFor user eventIdText =
         _events
             :<|> _cities
             :<|> _sources
+            :<|> _research
             :<|> _venues
             :<|> _artists
             :<|> _rsvps
@@ -718,6 +722,7 @@ socialEventUpdatePayload title =
                 , eventDescription = Nothing
                 , eventStart = socialEventStartFixture
                 , eventEnd = socialEventEndFixture
+                , eventTimezone = Just "America/Guayaquil"
                 , eventVenueId = Nothing
                 , eventPriceCents = Nothing
                 , eventCapacity = Nothing


### PR DESCRIPTION
## Summary

- add a strict-admin, evidence-backed event research queue with idempotent runs, checkpoints, candidate upserts, and append-only change audit
- enforce the unapproved pilot limit of 20 active candidates in PostgreSQL, including safe retry and discard/replace behavior
- persist explicit event timezones and expose official manual web sources without allowing the structured-feed cron to scrape them
- document the workflow, add OpenAPI/generated client support, and include the 2026-08-16 Sunday reconciliation checkpoint with exactly 20 unique Ecuador candidates

## Operational result

- production was inspected read-only; health is OK and the deployed commit is `d10e7cdf`
- no pilot approval indicator exists, the attached admin browser redirected to login, and the deployed schema lacks the required audit contract
- no production event, entity, source, checkpoint, or approval was written; nothing was published or deployed
- Passline presented Cloudflare and Feel The Tickets presented Queue-it; neither control was bypassed

## Safety and idempotency

- every new route requires strict admin access
- candidate upsert key is `(provider, external_id)` and the server computes the content hash
- exact retries create neither duplicate candidates nor duplicate change entries
- closed runs reject material changes; checkpoints and terminal timestamps are durable
- database locking enforces an accumulated maximum of 20 active pilot candidates until an explicit append-audited approval
- candidates never create or publish `social_event` records
- imported/source-managed fields are recorded so later materialization can preserve manual edits
- all official HTML/web source registry entries are forced disabled for cron ingestion

## Verification

- `./scripts/test-event-research-ingestion-migration.sh` — source seeds, pilot cap, retry idempotency, discard/replace, rollback, and reapply passed
- focused Hspec — 5 examples passed for candidate validation, material hash stability, timezone/evidence requirements, and disabled HTTPS web sources
- UI Jest — 147 suites / 1,593 tests passed
- UI TypeScript typecheck passed
- ESLint passed for every modified UI source file
- OpenAPI client generation passed
- production release manifest tests — 37 passed
- catalog-list governance audit passed with the mobile submodule initialized
- the new backend module compiled successfully

The repository's current `main` full backend build is independently blocked by pre-existing missing `Data.List.foldl'` imports in `ServerRadio`, `ServerProposals`, `SocialEventsHandlers`, `Server`, and `Cron`. Temporary local imports were used only to execute the focused Hspec suite and were reverted; this PR does not mix those unrelated fixes.

## Risks and rollout

- apply `tdf-hq/sql/2026-08-16_event_research_ingestion.sql` before deploying code that serves the new routes
- review the 20-candidate checkpoint before any authenticated replay
- do not call the approval endpoint until Diego explicitly approves the accumulated pilot
- event materialization/publication and first-class promoter/organizer/ticket-seller entities remain follow-up work; evidence is retained in the candidate payload meanwhile
- the reverse migration is provided, but it removes research queue data; capture a backup before rollback after real ingestion

This PR is intentionally draft. It does not authorize a migration, deployment, production write, pilot approval, or publication.
