### PR TITLE
fix(release): harden catalog production recovery

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -6,6 +6,8 @@ primary_region = "gru"
 
 [env]
   APP_PORT = "8080"
+  # The persisted deployment default is Spanish; keep runtime validation aligned.
+  DEFAULT_LOCALE = "es"
   # Production schema changes are applied once by the guarded release lane.
   RUN_MIGRATIONS = "false"
   # Enable only after the discovery schema and release have been verified.

--- a/scripts/__tests__/production-release.test.mjs
+++ b/scripts/__tests__/production-release.test.mjs
@@ -5,6 +5,7 @@ import { readFileSync } from 'node:fs';
 import {
   buildDatabaseSqlInvocation,
   buildDeployPlan,
+  buildMachineRollbackImage,
   buildMigrationBatchSql,
   buildReleaseSteps,
   buildSchemaPreflightSql,
@@ -31,6 +32,7 @@ primary_region = "gru"
 
 [env]
   APP_PORT = "8080"
+  DEFAULT_LOCALE = "es"
   RUN_MIGRATIONS = "false"
   EVENT_DISCOVERY_ENABLED = "false"
 
@@ -464,6 +466,31 @@ test('validateFlyConfig fails closed when event discovery would start during the
     ),
     /EVENT_DISCOVERY_ENABLED|discovery/i,
   );
+});
+
+test('validateFlyConfig requires the persisted production default locale', () => {
+  assert.throws(
+    () => validateFlyConfig(safeFlyConfig.replace('DEFAULT_LOCALE = "es"', 'DEFAULT_LOCALE = "en"')),
+    /DEFAULT_LOCALE|persisted production default/i,
+  );
+  assert.throws(
+    () => validateFlyConfig(safeFlyConfig.replace('  DEFAULT_LOCALE = "es"\n', '')),
+    /DEFAULT_LOCALE|persisted production default/i,
+  );
+});
+
+test('buildMachineRollbackImage removes Fly Docker Hub mirror and duplicate digests', () => {
+  const digest = `sha256:${'a'.repeat(64)}`;
+  assert.equal(buildMachineRollbackImage({
+    image_ref: {
+      registry: 'docker-hub-mirror.fly.io',
+      repository: `diegueins680/tdf-hq@${digest}`,
+      digest,
+    },
+  }), `diegueins680/tdf-hq@${digest}`);
+  assert.equal(buildMachineRollbackImage({
+    image_ref: `docker-hub-mirror.fly.io/diegueins680/tdf-hq@${digest}@${digest}`,
+  }), `diegueins680/tdf-hq@${digest}`);
 });
 
 test('validateFlyConfig requires an HTTP readiness check on /health', () => {

--- a/scripts/lib/production-release.mjs
+++ b/scripts/lib/production-release.mjs
@@ -257,6 +257,7 @@ export function validateFlyConfig(toml) {
   const healthChecks = tables.get('services.http_checks') ?? [];
   const runMigrations = String(env.get('RUN_MIGRATIONS') ?? '').trim().toLowerCase();
   const eventDiscovery = String(env.get('EVENT_DISCOVERY_ENABLED') ?? '').trim().toLowerCase();
+  const defaultLocale = String(env.get('DEFAULT_LOCALE') ?? '').trim().toLowerCase();
   const hasHealthCheck = services.length === 1 && healthChecks.some((check) => (
     String(check.get('path') ?? '').trim() === '/health'
       && String(check.get('protocol') ?? '').trim().toLowerCase() === 'http'
@@ -275,6 +276,9 @@ export function validateFlyConfig(toml) {
   if (eventDiscovery !== 'false') {
     throw new Error('fly.toml must stage EVENT_DISCOVERY_ENABLED="false" during rollout.');
   }
+  if (defaultLocale !== 'es') {
+    throw new Error('fly.toml must set DEFAULT_LOCALE="es" to match the persisted production default.');
+  }
   if (!hasHealthCheck) {
     throw new Error('fly.toml must define an HTTP /health readiness check.');
   }
@@ -285,10 +289,38 @@ export function validateFlyConfig(toml) {
   return {
     runMigrations: false,
     eventDiscoveryEnabled: false,
+    defaultLocale: 'es',
     healthCheckPath: '/health',
     strategy: 'rolling',
     maxUnavailable: 1,
   };
+}
+
+export function buildMachineRollbackImage(machine) {
+  const normalize = (value) => {
+    if (typeof value !== 'string' || !value.trim()) return undefined;
+    return value
+      .trim()
+      .replace(/^docker-hub-mirror\.fly\.io\//i, '')
+      .replace(/(@sha256:[0-9a-f]{64})(?:\1)+$/i, '$1');
+  };
+  const imageRef = machine?.image_ref;
+  if (typeof imageRef === 'string') return normalize(imageRef);
+
+  const registry = String(imageRef?.registry ?? '').trim();
+  const repository = String(imageRef?.repository ?? '')
+    .trim()
+    .replace(/@sha256:[0-9a-f]{64}$/i, '');
+  if (registry && repository) {
+    const base = registry.toLowerCase() === 'docker-hub-mirror.fly.io'
+      ? repository
+      : `${registry}/${repository}`;
+    if (/^sha256:[0-9a-f]{64}$/i.test(imageRef?.digest ?? '')) {
+      return `${base}@${imageRef.digest}`;
+    }
+    if (imageRef?.tag) return `${base}:${imageRef.tag}`;
+  }
+  return normalize(machine?.config?.image);
 }
 
 function sqlLiteral(value) {

--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -11,6 +11,7 @@ import { promisify } from 'node:util';
 import {
   buildDatabaseSqlInvocation,
   buildDeployPlan,
+  buildMachineRollbackImage,
   buildMigrationBatchSql,
   buildSchemaPreflightSql,
   buildSchemaVerificationSql,
@@ -44,12 +45,14 @@ const productionProfile = Object.freeze({
 const stagedRuntimeEnv = Object.freeze({
   RUN_MIGRATIONS: 'false',
   EVENT_DISCOVERY_ENABLED: 'false',
+  DEFAULT_LOCALE: 'es',
 });
 const readRuntimeEnvCommand = [
   "sh -lc '",
-  'printf "RUN_MIGRATIONS=%s\\nEVENT_DISCOVERY_ENABLED=%s\\n" ',
+  'printf "RUN_MIGRATIONS=%s\\nEVENT_DISCOVERY_ENABLED=%s\\nDEFAULT_LOCALE=%s\\n" ',
   '"${RUN_MIGRATIONS-__UNSET__}" ',
-  '"${EVENT_DISCOVERY_ENABLED-__UNSET__}"',
+  '"${EVENT_DISCOVERY_ENABLED-__UNSET__}" ',
+  '"${DEFAULT_LOCALE-__UNSET__}"',
   "'",
 ].join('');
 
@@ -536,17 +539,7 @@ function deployArgs(context, selector, machineId, image = context.image, sha = c
 }
 
 function previousImage(machine) {
-  if (typeof machine.image_ref === 'string') return machine.image_ref;
-  const registry = machine.image_ref?.registry;
-  const repository = machine.image_ref?.repository;
-  if (registry && repository) {
-    const base = `${registry}/${repository}`;
-    if (/^sha256:[0-9a-f]{64}$/i.test(machine.image_ref?.digest ?? '')) {
-      return `${base}@${machine.image_ref.digest}`;
-    }
-    if (machine.image_ref?.tag) return `${base}:${machine.image_ref.tag}`;
-  }
-  return machine.config?.image;
+  return buildMachineRollbackImage(machine);
 }
 
 function previousSha(machine) {


### PR DESCRIPTION
## Summary

- pin production `DEFAULT_LOCALE=es` so runtime catalog validation matches the persisted deployment default
- fail preflight when any Machine is missing or drifting from that locale
- normalize Docker Hub mirror rollback references so Fly receives one valid immutable digest

## Why

During the catalog cutover for #154, the canary correctly rejected an unset runtime locale because the persisted default is Spanish. Its automatic rollback then exposed a Fly mirror reference that resolved as `image@digest@digest`. Production was recovered with the minimal locale setting and completed on the exact #154 merge image; this follow-up makes both safeguards durable.

## Validation

- `node --test scripts/__tests__/production-release.test.mjs` — 39/39 passing
- `npm run release:backend:plan -- --sha 188fd170725cc24ee1661e6c666ba1e9969664f8` — dry-run plan generated
- production post-cutover preflight — `databaseReady=true`, both Machines healthy on `5ba55deb5a235872cd55629874aab4f7a8ac8701`
