### PR TITLE
fix(ci): require canonical image build metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,18 @@ jobs:
           test -s tdf-hq/.release/tdf-hq-exe
           chmod +x tdf-hq/.release/tdf-hq-exe
 
+      - name: Resolve image build metadata
+        id: image-metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]]
+          commit_epoch="$(git show -s --format=%ct "$GITHUB_SHA")"
+          [[ "$commit_epoch" =~ ^[0-9]+$ ]]
+          build_time="$(node -p "new Date(Number(process.argv[1]) * 1000).toISOString().replace('.000Z', 'Z')" "$commit_epoch")"
+          [[ "$build_time" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
+          printf 'build_time=%s\n' "$build_time" >> "$GITHUB_OUTPUT"
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -77,6 +89,6 @@ jobs:
           cache-to: type=gha,mode=max,scope=tdf-hq-backend
           build-args: |
             SOURCE_COMMIT=${{ github.sha }}
-            BUILD_TIME=${{ github.event.head_commit.timestamp || github.run_started_at }}
+            BUILD_TIME=${{ steps.image-metadata.outputs.build_time }}
           tags: |
             ${{ env.DOCKER_IMAGE_REPO }}:${{ env.DOCKER_IMAGE_TAG }}

--- a/scripts/__tests__/ci-pipeline.test.mjs
+++ b/scripts/__tests__/ci-pipeline.test.mjs
@@ -50,6 +50,21 @@ test('backend image packages the tested artifact instead of recompiling Haskell'
   assert.doesNotMatch(runtimeDockerfile, /stack (?:--[^\n]+ )?build/);
 });
 
+test('backend image receives deterministic, non-empty release metadata', async () => {
+  const workflow = await source('.github/workflows/build.yml');
+  assert.match(workflow, /id: image-metadata/);
+  assert.match(workflow, /git show -s --format=%ct "\$GITHUB_SHA"/);
+  assert.match(workflow, /new Date\(Number\(process\.argv\[1\]\) \* 1000\)\.toISOString\(\)/);
+  assert.match(workflow, /BUILD_TIME=\$\{\{ steps\.image-metadata\.outputs\.build_time \}\}/);
+  assert.doesNotMatch(workflow, /github\.event\.head_commit\.timestamp|github\.run_started_at/);
+
+  const runtimeDockerfile = await source('tdf-hq/Dockerfile.runtime');
+  assert.match(runtimeDockerfile, /ARG SOURCE_COMMIT\nARG BUILD_TIME\n/);
+  assert.match(runtimeDockerfile, /grep -Eq '\^\[0-9a-f\]\{40\}\$'/);
+  assert.match(runtimeDockerfile, /grep -Eq '\^\[0-9\]\{4\}.*T.*Z\$'/);
+  assert.doesNotMatch(runtimeDockerfile, /ARG SOURCE_COMMIT=(?:dev|unknown)|ARG BUILD_TIME=(?:dev|unknown)/);
+});
+
 test('source Dockerfile introduces changing release metadata after compilation', async () => {
   const dockerfile = await source('tdf-hq/Dockerfile');
   const builder = dockerfile.slice(0, dockerfile.indexOf('FROM debian:bookworm-slim'));

--- a/tdf-hq/Dockerfile.runtime
+++ b/tdf-hq/Dockerfile.runtime
@@ -22,9 +22,12 @@ RUN chmod 0755 /app/tdf-hq-exe && \
     ! grep -q 'not found' /tmp/tdf-hq-ldd.txt
 
 # Keep volatile release metadata after the reusable runtime and binary layers.
-ARG SOURCE_COMMIT=dev
-ARG BUILD_TIME=unknown
-RUN printf '%s\n' "$SOURCE_COMMIT" > /app/COMMIT && \
+ARG SOURCE_COMMIT
+ARG BUILD_TIME
+RUN set -eu; \
+    printf '%s' "$SOURCE_COMMIT" | grep -Eq '^[0-9a-f]{40}$'; \
+    printf '%s' "$BUILD_TIME" | grep -Eq '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$'; \
+    printf '%s\n' "$SOURCE_COMMIT" > /app/COMMIT; \
     printf '%s\n' "$BUILD_TIME" > /app/BUILD_TIME
 
 ENV SOURCE_COMMIT=${SOURCE_COMMIT}


### PR DESCRIPTION
## Summary

- derive the image `BUILD_TIME` deterministically from the exact source commit timestamp for push, manual, and reusable workflow runs
- reject empty or malformed source SHA/build-time arguments while constructing the runtime image
- add CI regression coverage so unsupported GitHub contexts cannot silently restore stale `/version` metadata

## Root cause

The manual Build Image run had no `github.event.head_commit`, and `github.run_started_at` did not resolve to a supported context value. Docker therefore received an empty `BUILD_TIME`; the backend correctly rejected it and fell back to its older compiled timestamp.

## Verification

- `npm run test:ci-pipeline` — 13/13 passed
- `npm run test:production-release` — 39/39 passed
- deterministic metadata smoke check — `2026-08-17T09:21:17Z`
- `docker buildx build --check ... -f tdf-hq/Dockerfile.runtime .` — no warnings
- `git diff --check` — passed

## Rollout boundary

This PR changes only image-build metadata. It does not modify database migrations, runtime schema, application contracts, or feature flags. Merging it must not be treated as authorization to deploy unrelated changes already present on `main`.
