### PR TITLE
fix(db): make automatic migrations fail closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,18 @@ jobs:
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     container: haskell:9.10.3-bookworm
+    services:
+      postgres:
+        image: pgvector/pgvector:pg17
+        env:
+          POSTGRES_DB: tdf_hq_automatic_migration_test
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+        options: >-
+          --health-cmd "pg_isready -U postgres -d tdf_hq_automatic_migration_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
     env:
       REQUIRE_STACK: '1'
       STACK_ROOT: ${{ github.workspace }}/.stack-root
@@ -142,7 +154,7 @@ jobs:
       - name: Install native build dependencies
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends libpq-dev pkg-config git curl ca-certificates
+          apt-get install -y --no-install-recommends libpq-dev postgresql-client nodejs pkg-config git curl ca-certificates
 
       - name: Restore immutable Stack dependencies
         uses: actions/cache@v4
@@ -160,6 +172,12 @@ jobs:
 
       - name: Build and test backend once
         run: bash scripts/quality-backend.sh
+
+      - name: Verify automatic migrations against the production schema
+        env:
+          TDF_AUTOMIG_TEST_DATABASE_URL: postgresql://postgres:postgres@postgres:5432/tdf_hq_automatic_migration_test
+          TDF_AUTOMIG_SERVER_BIN: ${{ env.BACKEND_BINARY_OUT }}
+        run: bash scripts/test-automatic-migrations-production-schema.sh
 
       - name: Upload tested backend executable
         if: inputs.publish_backend_artifact == true

--- a/docs/automatic-production-migrations.md
+++ b/docs/automatic-production-migrations.md
@@ -1,0 +1,67 @@
+# Automatic production migrations
+
+Production applies database changes automatically from the reviewed SQL
+manifest before the backend starts. It does **not** run schema changes inferred
+from Persistent models.
+
+## Runtime contract
+
+- `AUTO_APPLY_PRODUCTION_MIGRATIONS=true` enables the production entrypoint.
+- `RUN_MIGRATIONS=false` remains mandatory and prevents inferred Persistent
+  DDL from becoming a second source of truth.
+- `EVENT_DISCOVERY_ENABLED` is staged as `false` during a backend rollout and
+  is re-enabled only after the schema, fleet and discovery preflight pass.
+
+The image build renders `scripts/production-migrations.json` and every SQL file
+it references into `/app/production-migrations.sql`. The rendered bundle embeds
+the immutable image commit and the SHA-256 checksum of each migration. It does
+not include repository source, Node.js or database credentials.
+
+At container startup, `tdf-hq/production-entrypoint.sh`:
+
+1. Rejects malformed flags and refuses to combine the reviewed runner with
+   `RUN_MIGRATIONS=true`.
+2. Connects using the same database URL or `DB_*`/`PG*` variables as the app.
+3. Acquires the production migration advisory lock without waiting.
+4. Creates or verifies `tdf_schema_migration`.
+5. Rejects checksum changes to any previously applied migration.
+6. Applies pending migrations in manifest order.
+7. Runs the complete schema verification contract.
+8. Releases the lock and starts the backend with `RUN_MIGRATIONS=false`.
+
+If any migration or verification fails, `psql` exits nonzero and the backend is
+never started. A concurrent runner also exits nonzero instead of executing the
+same batch twice. Fly's rolling strategy and `max_unavailable = 1` preserve one
+serving Machine while the candidate starts.
+
+## Adding a migration
+
+1. Add an idempotent SQL file under `tdf-hq/sql/` with a transaction and
+   explicit safety checks.
+2. Add it to `scripts/production-migrations.json` with an immutable
+   `introducedBy` commit.
+3. Extend the schema verification contract and rollback documentation.
+4. Run:
+
+   ```bash
+   npm run test:production-release
+   npm run test:ci-pipeline
+   npm run audit:catalog-lists
+   bash scripts/test-automatic-migrations-production-schema.sh
+   ```
+
+The PostgreSQL integration test restores the production-shaped fixture, starts
+the real entrypoint, verifies the complete ledger and schema, starts it again,
+and requires an identical schema fingerprint after the second run.
+
+## Rollout and rollback
+
+The guarded release lane still performs backup, dry-run, preflight and explicit
+schema application before the canary. The startup runner is therefore a
+checksum-verified no-op during a normal release, while also protecting restarts
+and deployments that discover an unapplied registered migration.
+
+Rollback remains migration-specific. Never remove ledger rows, aliases,
+catalog data or audit history to roll back. Restore the recorded snapshot when
+the migration's documented reverse procedure cannot safely preserve data. Keep
+automatic publication disabled during migration and rollback.

--- a/docs/catalog-persistence/catalog-list-decisions.json
+++ b/docs/catalog-persistence/catalog-list-decisions.json
@@ -7314,13 +7314,23 @@
       "reviewed": true
     },
     {
-      "id": "c856701bb55914b85aee",
+      "id": "a5fe3d85087e2603bd8e",
       "classification": "genuine-technical-constant",
       "disposition": "retain-in-code",
       "specializedModel": "technical_constant_allowlist",
       "priority": "P3-retain",
       "risk": "Changing the ordered manifest can make a production release non-reproducible or apply schema revisions out of order.",
       "justification": "Migration identifiers and ordered immutable script paths are deployment execution mechanics; every applied revision and checksum is persisted independently in the production migration ledger.",
+      "reviewed": true
+    },
+    {
+      "id": "173ec9d5db984ba8e0e8",
+      "classification": "genuine-technical-constant",
+      "disposition": "retain-in-code",
+      "specializedModel": "technical_constant_allowlist",
+      "priority": "P3-retain",
+      "risk": "Omitting a compiled model group can let an unsafe inferred schema change bypass the global startup preflight.",
+      "justification": "These labels identify the exhaustive compiled Persistent migration groups checked before startup writes; they are execution boundaries, not selectable business data, roles, permissions, labels, or assignments.",
       "reviewed": true
     }
   ]

--- a/fly.toml
+++ b/fly.toml
@@ -10,6 +10,8 @@ primary_region = "gru"
   DEFAULT_LOCALE = "es"
   # Production schema changes are applied once by the guarded release lane.
   RUN_MIGRATIONS = "false"
+  # Apply only checksum-pinned SQL from production-migrations.json at startup.
+  AUTO_APPLY_PRODUCTION_MIGRATIONS = "true"
   # Enable only after the discovery schema and release have been verified.
   EVENT_DISCOVERY_ENABLED = "false"
   # Daily full-platform artist discovery. External research/media is scheduled

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "verify:auto-loop": "node scripts/verify-improvement-loop.mjs",
     "test:auto-loop": "node --test scripts/__tests__/continuous-improvement-loop.test.mjs",
     "test:formal": "node --test scripts/__tests__/formal-methods-audit.test.mjs",
-    "test:production-release": "node --test scripts/__tests__/production-release.test.mjs",
+    "test:production-release": "node --test scripts/__tests__/production-entrypoint.test.mjs scripts/__tests__/production-release.test.mjs",
     "test:ci-pipeline": "node --test scripts/__tests__/ci-change-scope.test.mjs scripts/__tests__/ci-pipeline.test.mjs",
     "artists:enrich": "node scripts/artist-enrichment.mjs",
     "test:artist-enrichment": "node --test scripts/__tests__/artist-enrichment.test.mjs",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "generate:feature-audit-reports": "node scripts/generate-feature-audit-reports.mjs",
     "test:feature-migrations": "sh scripts/test-feature-migrations.sh",
     "test:social-event-optional-end-migration": "sh scripts/test-social-event-optional-end-migration.sh",
+    "test:ddex-partner-legacy-compatibility": "bash scripts/test-ddex-partner-legacy-compatibility.sh",
     "release:backend:plan": "node scripts/production-release.mjs plan",
     "release:backend:preflight": "node scripts/production-release.mjs preflight",
     "release:backend": "node scripts/production-release.mjs release",

--- a/scripts/__tests__/ci-change-scope.test.mjs
+++ b/scripts/__tests__/ci-change-scope.test.mjs
@@ -46,6 +46,17 @@ test('schema model changes run backend and migration checks', () => {
   });
 });
 
+test('production migration runner changes run backend and migration checks', () => {
+  assert.deepEqual(classifyChangedFiles(['tdf-hq/production-entrypoint.sh']), {
+    repo: true,
+    ui: false,
+    mobile: false,
+    backend: true,
+    contracts: false,
+    migrations: true,
+  });
+});
+
 test('root dependency changes cover every JavaScript consumer', () => {
   assert.deepEqual(classifyChangedFiles(['package-lock.json']), {
     repo: true,

--- a/scripts/__tests__/ci-pipeline.test.mjs
+++ b/scripts/__tests__/ci-pipeline.test.mjs
@@ -47,6 +47,10 @@ test('backend image packages the tested artifact instead of recompiling Haskell'
 
   const runtimeDockerfile = await source('tdf-hq/Dockerfile.runtime');
   assert.match(runtimeDockerfile, /COPY tdf-hq\/\.release\/tdf-hq-exe/);
+  assert.match(runtimeDockerfile, /production-migrations\.sql/);
+  assert.match(runtimeDockerfile, /production-entrypoint\.sh/);
+  assert.match(runtimeDockerfile, /ENV AUTO_APPLY_PRODUCTION_MIGRATIONS=true/);
+  assert.match(runtimeDockerfile, /postgresql-client/);
   assert.doesNotMatch(runtimeDockerfile, /stack (?:--[^\n]+ )?build/);
 });
 

--- a/scripts/__tests__/production-entrypoint.test.mjs
+++ b/scripts/__tests__/production-entrypoint.test.mjs
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const entrypoint = path.join(repoRoot, 'tdf-hq', 'production-entrypoint.sh');
+
+function fixture() {
+  const directory = mkdtempSync(path.join(tmpdir(), 'tdf-production-entrypoint-'));
+  const binDirectory = path.join(directory, 'bin');
+  const migrationSql = path.join(directory, 'migrations.sql');
+  const psqlLog = path.join(directory, 'psql.log');
+  const serverLog = path.join(directory, 'server.log');
+  mkdirSync(binDirectory);
+  writeFileSync(migrationSql, 'SELECT 1;\n');
+  writeFileSync(
+    path.join(binDirectory, 'psql'),
+    `#!/bin/sh\nprintf '%s\\n' "$*" > "${psqlLog}"\n`,
+    { mode: 0o755 },
+  );
+  writeFileSync(
+    path.join(binDirectory, 'server'),
+    `#!/bin/sh\nprintf 'RUN_MIGRATIONS=%s\\nAPP_PORT=%s\\n' "$RUN_MIGRATIONS" "$APP_PORT" > "${serverLog}"\n`,
+    { mode: 0o755 },
+  );
+  return {
+    directory,
+    migrationSql,
+    psqlLog,
+    serverBin: path.join(binDirectory, 'server'),
+    serverLog,
+    path: `${binDirectory}:${process.env.PATH}`,
+  };
+}
+
+function run(current, overrides = {}) {
+  return spawnSync(entrypoint, [], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: current.path,
+      DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+      TDF_PRODUCTION_MIGRATIONS_SQL: current.migrationSql,
+      TDF_SERVER_BIN: current.serverBin,
+      AUTO_APPLY_PRODUCTION_MIGRATIONS: 'true',
+      RUN_MIGRATIONS: 'false',
+      PORT: '18881',
+      ...overrides,
+    },
+  });
+}
+
+test('production entrypoint applies reviewed SQL then disables Persistent migrations', (context) => {
+  const current = fixture();
+  context.after(() => rmSync(current.directory, { recursive: true, force: true }));
+
+  const result = run(current);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /schema verification passed/i);
+  assert.match(readFileSync(current.psqlLog, 'utf8'), /-X -v ON_ERROR_STOP=1 -f/);
+  assert.equal(readFileSync(current.serverLog, 'utf8'), 'RUN_MIGRATIONS=false\nAPP_PORT=18881\n');
+});
+
+test('production entrypoint rejects inferred and reviewed migrations together', (context) => {
+  const current = fixture();
+  context.after(() => rmSync(current.directory, { recursive: true, force: true }));
+
+  const result = run(current, { RUN_MIGRATIONS: 'true' });
+
+  assert.equal(result.status, 64);
+  assert.match(result.stderr, /refusing to combine/i);
+});
+
+test('production entrypoint rejects invalid flags and a missing bundle', (context) => {
+  const current = fixture();
+  context.after(() => rmSync(current.directory, { recursive: true, force: true }));
+
+  const invalid = run(current, { AUTO_APPLY_PRODUCTION_MIGRATIONS: 'yes' });
+  assert.equal(invalid.status, 64);
+  assert.match(invalid.stderr, /must be true or false/i);
+
+  const missing = run(current, { TDF_PRODUCTION_MIGRATIONS_SQL: path.join(current.directory, 'missing.sql') });
+  assert.equal(missing.status, 66);
+  assert.match(missing.stderr, /missing or unreadable/i);
+});

--- a/scripts/__tests__/production-release.test.mjs
+++ b/scripts/__tests__/production-release.test.mjs
@@ -34,6 +34,7 @@ primary_region = "gru"
   APP_PORT = "8080"
   DEFAULT_LOCALE = "es"
   RUN_MIGRATIONS = "false"
+  AUTO_APPLY_PRODUCTION_MIGRATIONS = "true"
   EVENT_DISCOVERY_ENABLED = "false"
 
 [deploy]
@@ -442,10 +443,11 @@ test('security emergency readiness parser rejects missing, writable, and malform
   );
 });
 
-test('validateFlyConfig accepts an explicit migration-free staged rolling release', () => {
+test('validateFlyConfig accepts reviewed automatic SQL migrations in a staged rolling release', () => {
   const validation = validateFlyConfig(safeFlyConfig);
 
   assert.equal(validation.runMigrations, false);
+  assert.equal(validation.autoApplyProductionMigrations, true);
   assert.equal(validation.eventDiscoveryEnabled, false);
   assert.equal(validation.healthCheckPath, '/health');
   assert.equal(validation.strategy, 'rolling');
@@ -456,6 +458,18 @@ test('validateFlyConfig fails closed when startup migrations are enabled', () =>
   assert.throws(
     () => validateFlyConfig(safeFlyConfig.replace('RUN_MIGRATIONS = "false"', 'RUN_MIGRATIONS = "true"')),
     /RUN_MIGRATIONS|migration/i,
+  );
+});
+
+test('validateFlyConfig requires the reviewed automatic migration runner', () => {
+  assert.throws(
+    () => validateFlyConfig(
+      safeFlyConfig.replace(
+        'AUTO_APPLY_PRODUCTION_MIGRATIONS = "true"',
+        'AUTO_APPLY_PRODUCTION_MIGRATIONS = "false"',
+      ),
+    ),
+    /AUTO_APPLY_PRODUCTION_MIGRATIONS|reviewed SQL migrations/i,
   );
 });
 
@@ -681,6 +695,7 @@ test('buildReleaseSteps orders schema work before a single-machine canary and fl
   assert.match(canaryCommand, /--only-machines canary-machine(?:\s|$)/);
   assert.match(canaryCommand, new RegExp(`--image ${releaseImage}`));
   assert.match(canaryCommand, /RUN_MIGRATIONS=false/);
+  assert.match(canaryCommand, /AUTO_APPLY_PRODUCTION_MIGRATIONS=true/);
   assert.match(canaryCommand, /EVENT_DISCOVERY_ENABLED=false/);
   assert.doesNotMatch(canaryCommand, /--strategy canary(?:\s|$)/);
 

--- a/scripts/build-catalog-decisions.mjs
+++ b/scripts/build-catalog-decisions.mjs
@@ -74,6 +74,13 @@ function technicalRule(candidate) {
     return 'Migration identifiers and their ordered script paths are deployment execution mechanics; each applied database revision is persisted separately in the migration ledger.';
   }
   if (
+    candidate.file.endsWith('/TDF/App/Boot.hs')
+    && candidate.kind === 'haskell-list'
+    && candidate.name === 'automaticMigrationPlans'
+  ) {
+    return 'These labels identify the exhaustive compiled Persistent migration groups checked before startup writes; they are execution boundaries, not selectable business data, roles, permissions, labels, or assignments.';
+  }
+  if (
     candidate.file.endsWith('/MixingMasteringPage.test.tsx')
     && candidate.kind === 'object-registry'
     && candidate.name === 'packageDto'

--- a/scripts/ci-change-scope.mjs
+++ b/scripts/ci-change-scope.mjs
@@ -27,6 +27,10 @@ function affectsContracts(file) {
 
 function affectsMigrations(file) {
   return isPathOrChild(file, 'tdf-hq/sql')
+    || file === 'tdf-hq/production-entrypoint.sh'
+    || file === 'tdf-hq/Dockerfile'
+    || file === 'tdf-hq/Dockerfile.runtime'
+    || file === 'fly.toml'
     || file === 'scripts/production-migrations.json'
     || file === 'scripts/production-release.mjs'
     || file === 'scripts/lib/production-release.mjs'

--- a/scripts/lib/production-release.mjs
+++ b/scripts/lib/production-release.mjs
@@ -256,6 +256,9 @@ export function validateFlyConfig(toml) {
   const services = tables.get('services') ?? [];
   const healthChecks = tables.get('services.http_checks') ?? [];
   const runMigrations = String(env.get('RUN_MIGRATIONS') ?? '').trim().toLowerCase();
+  const autoApplyProductionMigrations = String(
+    env.get('AUTO_APPLY_PRODUCTION_MIGRATIONS') ?? '',
+  ).trim().toLowerCase();
   const eventDiscovery = String(env.get('EVENT_DISCOVERY_ENABLED') ?? '').trim().toLowerCase();
   const defaultLocale = String(env.get('DEFAULT_LOCALE') ?? '').trim().toLowerCase();
   const hasHealthCheck = services.length === 1 && healthChecks.some((check) => (
@@ -273,6 +276,11 @@ export function validateFlyConfig(toml) {
   if (runMigrations !== 'false') {
     throw new Error('fly.toml must set RUN_MIGRATIONS="false" for production.');
   }
+  if (autoApplyProductionMigrations !== 'true') {
+    throw new Error(
+      'fly.toml must set AUTO_APPLY_PRODUCTION_MIGRATIONS="true" for reviewed SQL migrations.',
+    );
+  }
   if (eventDiscovery !== 'false') {
     throw new Error('fly.toml must stage EVENT_DISCOVERY_ENABLED="false" during rollout.');
   }
@@ -288,6 +296,7 @@ export function validateFlyConfig(toml) {
 
   return {
     runMigrations: false,
+    autoApplyProductionMigrations: true,
     eventDiscoveryEnabled: false,
     defaultLocale: 'es',
     healthCheckPath: '/health',
@@ -1482,6 +1491,7 @@ function deployCommand({ app, image, sha, onlyMachine, excludeMachine }) {
     '--env', `SOURCE_COMMIT=${sha}`,
     '--env', `GIT_SHA=${sha}`,
     '--env', 'RUN_MIGRATIONS=false',
+    '--env', 'AUTO_APPLY_PRODUCTION_MIGRATIONS=true',
     '--env', 'EVENT_DISCOVERY_ENABLED=false',
     '--strategy', 'rolling',
     '--max-unavailable', '1',

--- a/scripts/production-migrations.json
+++ b/scripts/production-migrations.json
@@ -205,6 +205,11 @@
       "id": "2026-08-17_social_event_optional_end",
       "path": "tdf-hq/sql/2026-08-17_social_event_optional_end.sql",
       "introducedBy": "c48f388938eecd92272f377f02c673ac784461be"
+    },
+    {
+      "id": "2026-08-18_ddex_partner_legacy_compatibility",
+      "path": "tdf-hq/sql/2026-08-18_ddex_partner_legacy_compatibility.sql",
+      "introducedBy": "d0f7b80957610014fd436009247be3fc9e0904a0"
     }
   ]
 }

--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -44,13 +44,15 @@ const productionProfile = Object.freeze({
 });
 const stagedRuntimeEnv = Object.freeze({
   RUN_MIGRATIONS: 'false',
+  AUTO_APPLY_PRODUCTION_MIGRATIONS: 'true',
   EVENT_DISCOVERY_ENABLED: 'false',
   DEFAULT_LOCALE: 'es',
 });
 const readRuntimeEnvCommand = [
   "sh -lc '",
-  'printf "RUN_MIGRATIONS=%s\\nEVENT_DISCOVERY_ENABLED=%s\\nDEFAULT_LOCALE=%s\\n" ',
+  'printf "RUN_MIGRATIONS=%s\\nAUTO_APPLY_PRODUCTION_MIGRATIONS=%s\\nEVENT_DISCOVERY_ENABLED=%s\\nDEFAULT_LOCALE=%s\\n" ',
   '"${RUN_MIGRATIONS-__UNSET__}" ',
+  '"${AUTO_APPLY_PRODUCTION_MIGRATIONS-__UNSET__}" ',
   '"${EVENT_DISCOVERY_ENABLED-__UNSET__}" ',
   '"${DEFAULT_LOCALE-__UNSET__}"',
   "'",
@@ -301,8 +303,13 @@ async function readEffectiveRuntimeEnv(app, machines) {
   }));
 }
 
-function runtimeEnvBlockers(rows) {
+function runtimeEnvBlockers(rows, options = {}) {
   return rows.flatMap(({ machineId, values }) => Object.entries(stagedRuntimeEnv)
+    .filter(([name]) => !(
+      options.allowUnavailableAutomaticRunner === true
+      && name === 'AUTO_APPLY_PRODUCTION_MIGRATIONS'
+      && [undefined, '__UNSET__', 'false'].includes(values[name])
+    ))
     .filter(([name, expected]) => values[name] !== expected)
     .map(([name, expected]) => {
       const actual = values[name] === '__UNSET__' || values[name] === undefined
@@ -355,6 +362,9 @@ async function verifyImageExists(image, sha) {
   if (imageEnv.RUN_MIGRATIONS !== 'false') {
     throw new Error(`Image ${image} does not default RUN_MIGRATIONS=false.`);
   }
+  if (imageEnv.AUTO_APPLY_PRODUCTION_MIGRATIONS !== 'true') {
+    throw new Error(`Image ${image} does not enable the reviewed production migration runner.`);
+  }
   const acceptableDigests = new Set([digest]);
   for (const manifest of metadata.manifest?.manifests ?? []) {
     if (manifest.platform?.os === 'linux'
@@ -378,7 +388,7 @@ async function remotePreflight(context) {
   const machines = await readMachines(context.app);
   const runtimeEnv = await readEffectiveRuntimeEnv(context.app, machines);
   const secrets = await readSecretNames(context.app);
-  const blockers = runtimeEnvBlockers(runtimeEnv);
+  const blockers = runtimeEnvBlockers(runtimeEnv, { allowUnavailableAutomaticRunner: true });
   for (const machine of machines) {
     const check = await smokeMachine(context, machine.id, null);
     machine.releaseSnapshot = {
@@ -528,6 +538,7 @@ function deployArgs(context, selector, machineId, image = context.image, sha = c
     '--env', `SOURCE_COMMIT=${sha}`,
     '--env', `GIT_SHA=${sha}`,
     '--env', 'RUN_MIGRATIONS=false',
+    '--env', 'AUTO_APPLY_PRODUCTION_MIGRATIONS=true',
     '--env', 'EVENT_DISCOVERY_ENABLED=false',
     '--strategy', 'rolling',
     '--max-unavailable', '1',
@@ -564,6 +575,7 @@ async function rollbackMachine(context, machine) {
     '--env', `SOURCE_COMMIT=${sha}`,
     '--env', `GIT_SHA=${sha}`,
     '--env', 'RUN_MIGRATIONS=false',
+    '--env', 'AUTO_APPLY_PRODUCTION_MIGRATIONS=true',
     '--env', 'EVENT_DISCOVERY_ENABLED=false',
     '--yes',
   ]);

--- a/scripts/test-automatic-migrations-production-schema.sh
+++ b/scripts/test-automatic-migrations-production-schema.sh
@@ -6,6 +6,7 @@ database_url="${TDF_AUTOMIG_TEST_DATABASE_URL:?Set TDF_AUTOMIG_TEST_DATABASE_URL
 server_bin="${TDF_AUTOMIG_SERVER_BIN:?Set TDF_AUTOMIG_SERVER_BIN to the candidate backend executable}"
 server_port="${TDF_AUTOMIG_SERVER_PORT:-18881}"
 server_log="${TMPDIR:-/tmp}/tdf-automatic-migrations-${$}.log"
+migration_sql="${TMPDIR:-/tmp}/tdf-production-migrations-${$}.sql"
 server_pid=""
 
 stop_server() {
@@ -16,7 +17,11 @@ stop_server() {
   wait "${server_pid}" >/dev/null 2>&1 || true
   server_pid=""
 }
-trap stop_server EXIT INT TERM
+cleanup() {
+  stop_server
+  rm -f "${migration_sql}"
+}
+trap cleanup EXIT INT TERM
 
 if [ ! -x "${server_bin}" ]; then
   echo "Candidate backend executable is missing or not executable: ${server_bin}" >&2
@@ -35,31 +40,20 @@ psql "${database_url}" -X -v ON_ERROR_STOP=1 \
   -f "${repo_root}/scripts/__tests__/fixtures/catalog-production-source-fixture.sql" >/dev/null
 SOURCE_COMMIT="${GITHUB_SHA:-0000000000000000000000000000000000000000}" \
   node "${repo_root}/scripts/render-production-migration-batch.mjs" \
-  | psql "${database_url}" -X -v ON_ERROR_STOP=1 >/dev/null
-
-expected_migrations="$(node -p "require('${repo_root}/scripts/production-migrations.json').migrations.length")"
-applied_migrations="$(psql "${database_url}" -X -qAt -v ON_ERROR_STOP=1 -c 'SELECT count(*) FROM public.tdf_schema_migration;')"
-test "${applied_migrations}" = "${expected_migrations}"
-
-db_host="$(node -e 'const url=new URL(process.argv[1]); process.stdout.write(url.hostname)' "${database_url}")"
-db_port="$(node -e 'const url=new URL(process.argv[1]); process.stdout.write(url.port || "5432")' "${database_url}")"
-db_user="$(node -e 'const url=new URL(process.argv[1]); process.stdout.write(decodeURIComponent(url.username))' "${database_url}")"
-db_pass="$(node -e 'const url=new URL(process.argv[1]); process.stdout.write(decodeURIComponent(url.password))' "${database_url}")"
-db_name="$(node -e 'const url=new URL(process.argv[1]); process.stdout.write(decodeURIComponent(url.pathname.slice(1)))' "${database_url}")"
+  > "${migration_sql}"
 
 start_and_verify() {
   : > "${server_log}"
-  DB_HOST="${db_host}" \
-  DB_PORT="${db_port}" \
-  DB_USER="${db_user}" \
-  DB_PASS="${db_pass}" \
-  DB_NAME="${db_name}" \
+  DATABASE_URL="${database_url}" \
   APP_PORT="${server_port}" \
-  RUN_MIGRATIONS=true \
+  RUN_MIGRATIONS=false \
+  AUTO_APPLY_PRODUCTION_MIGRATIONS=true \
   RESET_DB=false \
   SEED_DB=false \
   EVENT_DISCOVERY_ENABLED=false \
-  "${server_bin}" >"${server_log}" 2>&1 &
+  TDF_SERVER_BIN="${server_bin}" \
+  TDF_PRODUCTION_MIGRATIONS_SQL="${migration_sql}" \
+  "${repo_root}/tdf-hq/production-entrypoint.sh" >"${server_log}" 2>&1 &
   server_pid=$!
 
   for _ in $(seq 1 180); do
@@ -81,6 +75,9 @@ start_and_verify() {
 }
 
 start_and_verify
+expected_migrations="$(node -p "require('${repo_root}/scripts/production-migrations.json').migrations.length")"
+applied_migrations="$(psql "${database_url}" -X -qAt -v ON_ERROR_STOP=1 -c 'SELECT count(*) FROM public.tdf_schema_migration;')"
+test "${applied_migrations}" = "${expected_migrations}"
 node "${repo_root}/scripts/render-production-schema-verification.mjs" \
   | psql "${database_url}" -X -v ON_ERROR_STOP=1 >/dev/null
 

--- a/scripts/test-automatic-migrations-production-schema.sh
+++ b/scripts/test-automatic-migrations-production-schema.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+database_url="${TDF_AUTOMIG_TEST_DATABASE_URL:?Set TDF_AUTOMIG_TEST_DATABASE_URL to an isolated empty PostgreSQL database}"
+server_bin="${TDF_AUTOMIG_SERVER_BIN:?Set TDF_AUTOMIG_SERVER_BIN to the candidate backend executable}"
+server_port="${TDF_AUTOMIG_SERVER_PORT:-18881}"
+server_log="${TMPDIR:-/tmp}/tdf-automatic-migrations-${$}.log"
+server_pid=""
+
+stop_server() {
+  if [ -z "${server_pid}" ]; then
+    return
+  fi
+  kill "${server_pid}" >/dev/null 2>&1 || true
+  wait "${server_pid}" >/dev/null 2>&1 || true
+  server_pid=""
+}
+trap stop_server EXIT INT TERM
+
+if [ ! -x "${server_bin}" ]; then
+  echo "Candidate backend executable is missing or not executable: ${server_bin}" >&2
+  exit 1
+fi
+
+existing_tables="$(psql "${database_url}" -X -qAt -v ON_ERROR_STOP=1 -c "SELECT count(*) FROM pg_class WHERE relnamespace='public'::regnamespace AND relkind IN ('r','p');")"
+if [ "${existing_tables}" != "0" ]; then
+  echo "Automatic migration test requires an empty isolated database; found ${existing_tables} tables" >&2
+  exit 1
+fi
+
+psql "${database_url}" -X -v ON_ERROR_STOP=1 \
+  -f "${repo_root}/scripts/__tests__/fixtures/production-schema-20260814.sql" >/dev/null
+psql "${database_url}" -X -v ON_ERROR_STOP=1 \
+  -f "${repo_root}/scripts/__tests__/fixtures/catalog-production-source-fixture.sql" >/dev/null
+SOURCE_COMMIT="${GITHUB_SHA:-0000000000000000000000000000000000000000}" \
+  node "${repo_root}/scripts/render-production-migration-batch.mjs" \
+  | psql "${database_url}" -X -v ON_ERROR_STOP=1 >/dev/null
+
+expected_migrations="$(node -p "require('${repo_root}/scripts/production-migrations.json').migrations.length")"
+applied_migrations="$(psql "${database_url}" -X -qAt -v ON_ERROR_STOP=1 -c 'SELECT count(*) FROM public.tdf_schema_migration;')"
+test "${applied_migrations}" = "${expected_migrations}"
+
+db_host="$(node -e 'const url=new URL(process.argv[1]); process.stdout.write(url.hostname)' "${database_url}")"
+db_port="$(node -e 'const url=new URL(process.argv[1]); process.stdout.write(url.port || "5432")' "${database_url}")"
+db_user="$(node -e 'const url=new URL(process.argv[1]); process.stdout.write(decodeURIComponent(url.username))' "${database_url}")"
+db_pass="$(node -e 'const url=new URL(process.argv[1]); process.stdout.write(decodeURIComponent(url.password))' "${database_url}")"
+db_name="$(node -e 'const url=new URL(process.argv[1]); process.stdout.write(decodeURIComponent(url.pathname.slice(1)))' "${database_url}")"
+
+start_and_verify() {
+  : > "${server_log}"
+  DB_HOST="${db_host}" \
+  DB_PORT="${db_port}" \
+  DB_USER="${db_user}" \
+  DB_PASS="${db_pass}" \
+  DB_NAME="${db_name}" \
+  APP_PORT="${server_port}" \
+  RUN_MIGRATIONS=true \
+  RESET_DB=false \
+  SEED_DB=false \
+  EVENT_DISCOVERY_ENABLED=false \
+  "${server_bin}" >"${server_log}" 2>&1 &
+  server_pid=$!
+
+  for _ in $(seq 1 180); do
+    if curl -fsS "http://127.0.0.1:${server_port}/health" 2>/dev/null | grep -q '"db":"ok"'; then
+      stop_server
+      return
+    fi
+    if ! kill -0 "${server_pid}" >/dev/null 2>&1; then
+      tail -160 "${server_log}" >&2
+      echo "Backend exited during automatic migration verification" >&2
+      exit 1
+    fi
+    sleep 1
+  done
+
+  tail -160 "${server_log}" >&2
+  echo "Backend did not become healthy after automatic migration preflight" >&2
+  exit 1
+}
+
+start_and_verify
+node "${repo_root}/scripts/render-production-schema-verification.mjs" \
+  | psql "${database_url}" -X -v ON_ERROR_STOP=1 >/dev/null
+
+legacy_rows="$(psql "${database_url}" -X -qAt -v ON_ERROR_STOP=1 -c 'SELECT count(*) FROM ddex_partner WHERE cardinality(allowed_versions) <> 0;')"
+test "${legacy_rows}" = "0"
+
+schema_before="$(psql "${database_url}" -X -qAt -v ON_ERROR_STOP=1 <<'SQL'
+SELECT md5(string_agg(definition, E'\n' ORDER BY definition))
+FROM (
+  SELECT 'column:' || table_schema || '.' || table_name || '.' || column_name || ':' || data_type || ':' || is_nullable || ':' || coalesce(column_default, '') AS definition
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+  UNION ALL
+  SELECT 'constraint:' || conrelid::regclass::text || '.' || conname || ':' || pg_get_constraintdef(oid, true)
+  FROM pg_constraint
+  WHERE connamespace = 'public'::regnamespace
+  UNION ALL
+  SELECT 'index:' || schemaname || '.' || indexname || ':' || indexdef
+  FROM pg_indexes
+  WHERE schemaname = 'public'
+) schema_objects;
+SQL
+)"
+
+start_and_verify
+
+schema_after="$(psql "${database_url}" -X -qAt -v ON_ERROR_STOP=1 <<'SQL'
+SELECT md5(string_agg(definition, E'\n' ORDER BY definition))
+FROM (
+  SELECT 'column:' || table_schema || '.' || table_name || '.' || column_name || ':' || data_type || ':' || is_nullable || ':' || coalesce(column_default, '') AS definition
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+  UNION ALL
+  SELECT 'constraint:' || conrelid::regclass::text || '.' || conname || ':' || pg_get_constraintdef(oid, true)
+  FROM pg_constraint
+  WHERE connamespace = 'public'::regnamespace
+  UNION ALL
+  SELECT 'index:' || schemaname || '.' || indexname || ':' || indexdef
+  FROM pg_indexes
+  WHERE schemaname = 'public'
+) schema_objects;
+SQL
+)"
+
+test -n "${schema_before}"
+test "${schema_after}" = "${schema_before}"
+echo "Automatic migrations passed against the fully cut-over production schema and were idempotent"

--- a/scripts/test-ddex-partner-legacy-compatibility.sh
+++ b/scripts/test-ddex-partner-legacy-compatibility.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+container_name="tdf-ddex-partner-legacy-test-${RANDOM}"
+database_name="tdf_ddex_partner_legacy_test"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+up_migration="${repo_root}/tdf-hq/sql/2026-08-18_ddex_partner_legacy_compatibility.sql"
+rollback_migration="${repo_root}/tdf-hq/sql/2026-08-18_ddex_partner_legacy_compatibility_rollback.sql"
+
+cleanup() {
+  docker rm -f "${container_name}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker run --detach --rm \
+  --name "${container_name}" \
+  --env POSTGRES_PASSWORD=postgres \
+  --env POSTGRES_DB="${database_name}" \
+  postgres:16-alpine >/dev/null
+
+database_ready=0
+for _ in $(seq 1 30); do
+  if docker exec "${container_name}" pg_isready -U postgres -d "${database_name}" >/dev/null 2>&1; then
+    database_ready=1
+    break
+  fi
+  sleep 1
+done
+if [ "${database_ready}" -ne 1 ]; then
+  docker logs "${container_name}" >&2
+  echo "PostgreSQL DDEX compatibility test container did not become ready" >&2
+  exit 1
+fi
+
+psql_test() {
+  docker exec -i "${container_name}" psql -X -v ON_ERROR_STOP=1 -U postgres -d "${database_name}" "$@"
+}
+
+psql_test <<'SQL'
+CREATE TABLE ddex_partner (
+    id serial PRIMARY KEY,
+    name text NOT NULL UNIQUE,
+    dpid text,
+    allowed_versions text[] NOT NULL DEFAULT ARRAY['4.3.2']::text[],
+    rules_json jsonb,
+    naming_convention text,
+    is_active boolean NOT NULL DEFAULT true
+);
+SQL
+
+psql_test < "${up_migration}"
+psql_test < "${up_migration}"
+
+empty_default="$(psql_test -qAt -c "INSERT INTO ddex_partner (name) VALUES ('canonical-default') RETURNING cardinality(allowed_versions);")"
+test "${empty_default//[[:space:]]/}" = "0"
+
+psql_test < "${rollback_migration}"
+legacy_default="$(psql_test -qAt -c "INSERT INTO ddex_partner (name) VALUES ('rollback-default') RETURNING array_to_string(allowed_versions, ',');")"
+test "${legacy_default//[[:space:]]/}" = "4.3.2"
+
+psql_test -c "UPDATE ddex_partner SET allowed_versions=ARRAY[]::text[];" >/dev/null
+psql_test < "${up_migration}"
+psql_test -c "UPDATE ddex_partner SET allowed_versions=ARRAY['legacy-conflict']::text[] WHERE name='canonical-default';" >/dev/null
+if psql_test < "${up_migration}" >/dev/null 2>&1; then
+  echo "expected migration to reject unresolved legacy DDEX values" >&2
+  exit 1
+fi
+
+echo "DDEX partner legacy compatibility migration test passed"

--- a/tdf-hq/Dockerfile
+++ b/tdf-hq/Dockerfile
@@ -85,7 +85,22 @@ RUN set -eu; \
     fi; \
     printf '%s\n' "$BUILD_TS" > /app/BUILD_TIME
 
-# -------- Stage 2: slim runtime ----------
+# -------- Stage 2: render reviewed migration bundle ----------
+FROM node:22-bookworm-slim AS migration-bundle
+ARG SOURCE_COMMIT=dev
+WORKDIR /repo
+COPY scripts/production-migrations.json scripts/production-migrations.json
+COPY scripts/render-production-migration-batch.mjs scripts/render-production-migration-batch.mjs
+COPY scripts/lib/production-release.mjs scripts/lib/production-release.mjs
+COPY tdf-hq/sql tdf-hq/sql
+RUN set -eu; \
+    case "$SOURCE_COMMIT" in \
+      [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) migration_source_commit="$SOURCE_COMMIT" ;; \
+      *) migration_source_commit=0000000000000000000000000000000000000000 ;; \
+    esac; \
+    SOURCE_COMMIT="$migration_source_commit" node scripts/render-production-migration-batch.mjs > /production-migrations.sql
+
+# -------- Stage 3: slim runtime ----------
 FROM debian:bookworm-slim
 ARG DEBIAN_FRONTEND=noninteractive
 WORKDIR /app
@@ -95,7 +110,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get -o Acquire::AllowInsecureRepositories=true -o Acquire::Check-Valid-Until=false update && \
     apt-get -o Acquire::AllowInsecureRepositories=true --allow-unauthenticated install -y --no-install-recommends \
-    libpq5 ca-certificates tzdata libxml2-utils && \
+    libpq5 postgresql-client ca-certificates tzdata libxml2-utils && \
     rm -rf /var/lib/apt/lists/*
 
 ARG SOURCE_COMMIT=dev
@@ -108,14 +123,18 @@ COPY --from=builder /app/docs /app/docs
 COPY --from=builder /app/COMMIT /app/COMMIT
 COPY --from=builder /app/BUILD_TIME /app/BUILD_TIME
 COPY --from=builder /app/assets /app/assets
+COPY --from=migration-bundle /production-migrations.sql /app/production-migrations.sql
+COPY tdf-hq/production-entrypoint.sh /app/production-entrypoint.sh
 
 # Render provides PORT; map it to the app's APP_PORT
 ENV APP_PORT=8080
 # Production Docker/Fly deploys use the pre-initialized schema path.
 ENV RUN_MIGRATIONS=false
+ENV AUTO_APPLY_PRODUCTION_MIGRATIONS=true
 
 # Non-root user for better security
-RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app
+RUN chmod 0755 /app/production-entrypoint.sh && \
+    useradd -m -u 1000 appuser && chown -R appuser:appuser /app
 USER appuser
 
-CMD ["/bin/sh","-c","APP_PORT=${PORT:-8080} /app/tdf-hq-exe"]
+CMD ["/app/production-entrypoint.sh"]

--- a/tdf-hq/Dockerfile.runtime
+++ b/tdf-hq/Dockerfile.runtime
@@ -1,5 +1,18 @@
 # syntax=docker/dockerfile:1
 
+# Render the reviewed, checksum-pinned SQL manifest once at image build time.
+# The runtime image needs only psql, not Node or the repository source tree.
+FROM node:22-bookworm-slim AS migration-bundle
+ARG SOURCE_COMMIT
+WORKDIR /repo
+COPY scripts/production-migrations.json scripts/production-migrations.json
+COPY scripts/render-production-migration-batch.mjs scripts/render-production-migration-batch.mjs
+COPY scripts/lib/production-release.mjs scripts/lib/production-release.mjs
+COPY tdf-hq/sql tdf-hq/sql
+RUN set -eu; \
+    printf '%s' "$SOURCE_COMMIT" | grep -Eq '^[0-9a-f]{40}$'; \
+    SOURCE_COMMIT="$SOURCE_COMMIT" node scripts/render-production-migration-batch.mjs > /production-migrations.sql
+
 # Package the executable already compiled and tested by the backend CI job.
 # This stage deliberately contains no Haskell toolchain.
 FROM debian:bookworm-slim
@@ -10,14 +23,16 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get -o Acquire::AllowInsecureRepositories=true -o Acquire::Check-Valid-Until=false update && \
     apt-get -o Acquire::AllowInsecureRepositories=true --allow-unauthenticated install -y --no-install-recommends \
-    libpq5 ca-certificates tzdata libxml2-utils && \
+    libpq5 postgresql-client ca-certificates tzdata libxml2-utils && \
     rm -rf /var/lib/apt/lists/*
 
 COPY tdf-hq/.release/tdf-hq-exe /app/tdf-hq-exe
 COPY tdf-hq/docs /app/docs
 COPY tdf-hq/assets /app/assets
+COPY tdf-hq/production-entrypoint.sh /app/production-entrypoint.sh
+COPY --from=migration-bundle /production-migrations.sql /app/production-migrations.sql
 
-RUN chmod 0755 /app/tdf-hq-exe && \
+RUN chmod 0755 /app/tdf-hq-exe /app/production-entrypoint.sh && \
     ldd /app/tdf-hq-exe | tee /tmp/tdf-hq-ldd.txt && \
     ! grep -q 'not found' /tmp/tdf-hq-ldd.txt
 
@@ -35,8 +50,9 @@ ENV GIT_SHA=${SOURCE_COMMIT}
 ENV BUILD_TIME=${BUILD_TIME}
 ENV APP_PORT=8080
 ENV RUN_MIGRATIONS=false
+ENV AUTO_APPLY_PRODUCTION_MIGRATIONS=true
 
 RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app
 USER appuser
 
-CMD ["/bin/sh","-c","APP_PORT=${PORT:-8080} /app/tdf-hq-exe"]
+CMD ["/app/production-entrypoint.sh"]

--- a/tdf-hq/MIGRATION_FREE_DEPLOYMENT.md
+++ b/tdf-hq/MIGRATION_FREE_DEPLOYMENT.md
@@ -1,5 +1,12 @@
 # Migration-Free Database Deployment
 
+> Historical development guide. Production now uses the checksum-pinned SQL
+> runner documented in
+> [`docs/automatic-production-migrations.md`](../docs/automatic-production-migrations.md).
+> It keeps `RUN_MIGRATIONS=false` and enables
+> `AUTO_APPLY_PRODUCTION_MIGRATIONS=true`; Persistent-inferred DDL is never the
+> production schema authority.
+
 ## Summary
 
 This guide provides a complete solution for deploying TDF Records without runtime database migrations. The schema is pre-initialized using SQL scripts, avoiding ALTER TABLE operations and deployment failures.

--- a/tdf-hq/production-entrypoint.sh
+++ b/tdf-hq/production-entrypoint.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+set -eu
+
+server_bin="${TDF_SERVER_BIN:-/app/tdf-hq-exe}"
+migration_sql="${TDF_PRODUCTION_MIGRATIONS_SQL:-/app/production-migrations.sql}"
+auto_apply="${AUTO_APPLY_PRODUCTION_MIGRATIONS:-false}"
+persistent_migrations="${RUN_MIGRATIONS:-false}"
+
+case "${auto_apply}" in
+  true|false) ;;
+  *)
+    echo "AUTO_APPLY_PRODUCTION_MIGRATIONS must be true or false" >&2
+    exit 64
+    ;;
+esac
+
+case "${persistent_migrations}" in
+  true|false) ;;
+  *)
+    echo "RUN_MIGRATIONS must be true or false" >&2
+    exit 64
+    ;;
+esac
+
+if [ "${auto_apply}" = "true" ]; then
+  if [ "${persistent_migrations}" = "true" ]; then
+    echo "Refusing to combine reviewed production migrations with inferred Persistent migrations" >&2
+    exit 64
+  fi
+  if [ ! -r "${migration_sql}" ]; then
+    echo "Reviewed production migration bundle is missing or unreadable" >&2
+    exit 66
+  fi
+
+  database_url="${DATABASE_URL:-${DATABASE_PRIVATE_URL:-${POSTGRES_URL:-${POSTGRES_PRISMA_URL:-}}}}"
+  if [ -n "${database_url}" ]; then
+    psql "${database_url}" -X -v ON_ERROR_STOP=1 -f "${migration_sql}"
+  else
+    export PGHOST="${DB_HOST:-${PGHOST:-127.0.0.1}}"
+    export PGPORT="${DB_PORT:-${PGPORT:-5432}}"
+    export PGUSER="${DB_USER:-${PGUSER:-postgres}}"
+    export PGPASSWORD="${DB_PASS:-${PGPASSWORD:-postgres}}"
+    export PGDATABASE="${DB_NAME:-${PGDATABASE:-tdf_hq}}"
+    if [ -n "${DB_SSLMODE:-}" ]; then
+      export PGSSLMODE="${DB_SSLMODE}"
+    fi
+    psql -X -v ON_ERROR_STOP=1 -f "${migration_sql}"
+  fi
+  echo "Reviewed production migrations are applied and schema verification passed"
+fi
+
+# The production image never delegates schema authority to Persistent. Direct
+# development invocations may still opt into that path without this entrypoint.
+export RUN_MIGRATIONS=false
+export APP_PORT="${PORT:-${APP_PORT:-8080}}"
+exec "${server_bin}"

--- a/tdf-hq/sql/2026-08-18_ddex_partner_legacy_compatibility.sql
+++ b/tdf-hq/sql/2026-08-18_ddex_partner_legacy_compatibility.sql
@@ -1,0 +1,42 @@
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+DO $preflight$
+BEGIN
+    IF to_regclass('public.ddex_partner') IS NULL THEN
+        RAISE EXCEPTION 'ddex_partner is required before applying legacy compatibility metadata';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'ddex_partner'
+          AND column_name = 'allowed_versions'
+          AND data_type = 'ARRAY'
+          AND udt_name = '_text'
+          AND is_nullable = 'NO'
+    ) THEN
+        RAISE EXCEPTION 'ddex_partner.allowed_versions must be a non-null text array';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM ddex_partner
+        WHERE cardinality(allowed_versions) <> 0
+    ) THEN
+        RAISE EXCEPTION
+            'ddex_partner.allowed_versions contains legacy values; resolve the governed DDEX cutover before changing its default';
+    END IF;
+END
+$preflight$;
+
+-- The column is retained exclusively as reversible cutover evidence. New
+-- policy is written through ddex_partner_standard_version, so omitted legacy
+-- values must default to an empty array.
+ALTER TABLE ddex_partner
+    ALTER COLUMN allowed_versions SET DEFAULT ARRAY[]::text[];
+
+COMMIT;

--- a/tdf-hq/sql/2026-08-18_ddex_partner_legacy_compatibility_rollback.sql
+++ b/tdf-hq/sql/2026-08-18_ddex_partner_legacy_compatibility_rollback.sql
@@ -1,0 +1,26 @@
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+DO $preflight$
+BEGIN
+    IF to_regclass('public.ddex_partner') IS NULL THEN
+        RAISE EXCEPTION 'ddex_partner is required before rolling back legacy compatibility metadata';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM ddex_partner
+        WHERE cardinality(allowed_versions) <> 0
+    ) THEN
+        RAISE EXCEPTION
+            'ddex_partner.allowed_versions contains post-cutover legacy values; rollback requires manual review';
+    END IF;
+END
+$preflight$;
+
+ALTER TABLE ddex_partner
+    ALTER COLUMN allowed_versions SET DEFAULT ARRAY['4.3.2']::text[];
+
+COMMIT;

--- a/tdf-hq/src/TDF/App/Boot.hs
+++ b/tdf-hq/src/TDF/App/Boot.hs
@@ -9,7 +9,7 @@ module TDF.App.Boot
 
 import Control.Concurrent (forkFinally, newEmptyMVar, putMVar, takeMVar, threadDelay)
 import Control.Exception (SomeException, displayException, handle, throwIO, try)
-import Control.Monad (forM_, unless, when)
+import Control.Monad (forM, forM_, unless, when)
 import Control.Monad.IO.Class (liftIO)
 import qualified Data.ByteString.Char8 as BS
 import Data.IORef (newIORef, readIORef, writeIORef)
@@ -20,8 +20,10 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time.Clock (getCurrentTime)
 import Database.Persist.Sql (
+    Migration,
     Single (..),
     SqlPersistT,
+    parseMigration,
     rawExecute,
     rawSql,
     runMigration,
@@ -214,6 +216,11 @@ resetSchema = do
 
 runAllMigrations :: AppConfig -> SqlPersistT IO ()
 runAllMigrations cfg = do
+  -- Persistent rejects unsafe statements inside each individual migration,
+  -- but by then earlier migration groups may already have run. Parse every
+  -- model plan first so an incompatible retained column aborts startup before
+  -- any schema or seed write is attempted.
+  validateAutomaticMigrationPlans
   ensureExtensionInstalled "pgcrypto"
   vectorAvailable <- hasVectorExtension
   if vectorAvailable
@@ -288,6 +295,35 @@ runAllMigrations cfg = do
   ensureInternationalColumns
   restoreLegacyPartyRoles legacyRoles
   validateSecurityRegistry
+
+automaticMigrationPlans :: [(Text, Migration)]
+automaticMigrationPlans =
+  [ ("core", migrateAll)
+  , ("cms", CMS.migrateCMS)
+  , ("catalog-governance", Catalog.migrateCatalogGovernance)
+  , ("catalog-security", Catalog.migrateCatalogSecurity)
+  , ("catalog-references", Catalog.migrateCatalogReferences)
+  , ("catalog-domains", Catalog.migrateCatalogDomains)
+  , ("ddex", Ddex.migrateDdex)
+  , ("operations", migrateExtra)
+  , ("social-events", migrateSocialEvents)
+  , ("trials", migrateTrials)
+  ]
+
+validateAutomaticMigrationPlans :: SqlPersistT IO ()
+validateAutomaticMigrationPlans = do
+  parsed <- forM automaticMigrationPlans $ \(component, migration) -> do
+    result <- parseMigration migration
+    pure (component, result)
+  let unsafeStatements =
+        [ component <> ": " <> statement
+        | (component, Left statements) <- parsed
+        , statement <- statements
+        ]
+  unless (null unsafeStatements) $
+    liftIO . ioError . userError . T.unpack $
+      "Automatic migration preflight rejected unsafe schema changes before execution:\n"
+        <> T.unlines unsafeStatements
 
 syncRegionalDeploymentEnablement :: AppConfig -> SqlPersistT IO ()
 syncRegionalDeploymentEnablement cfg = do

--- a/tdf-hq/src/TDF/DDEX/DB.hs
+++ b/tdf-hq/src/TDF/DDEX/DB.hs
@@ -174,6 +174,7 @@ insertPartner name dpid allowedVersionIds = do
   partnerId <- insert $ DdexPartner
     { ddexPartnerName = name
     , ddexPartnerDpid = dpid
+    , ddexPartnerAllowedVersionsLegacy = []
     , ddexPartnerRulesJson = Nothing
     , ddexPartnerNamingConvention = Nothing
     , ddexPartnerIsActive = True

--- a/tdf-hq/src/TDF/DDEX/Models.hs
+++ b/tdf-hq/src/TDF/DDEX/Models.hs
@@ -233,6 +233,10 @@ DdexExport
 DdexPartner
   name Text
   dpid Text Maybe
+  -- Rollback evidence retained by the governed DDEX cutover. Current writers
+  -- must keep this empty; canonical version policy lives in
+  -- DdexPartnerStandardVersion.
+  allowedVersionsLegacy [Text] sql=allowed_versions sqltype=text[] default='{}'
   rulesJson Text Maybe  -- JSONB
   namingConvention Text Maybe
   isActive Bool


### PR DESCRIPTION
## Summary

- retain `ddex_partner.allowed_versions` as empty rollback evidence instead of letting Persistent infer a destructive drop
- preflight every Persistent model migration before any schema or seed write and reject the complete unsafe plan
- register an idempotent, fail-closed migration that changes the legacy default to an empty array
- package the checksum-pinned production SQL manifest into the backend image and apply it automatically before startup
- keep `RUN_MIGRATIONS=false` in production so Persistent-inferred DDL cannot become a second schema authority
- run the real production entrypoint twice against the fully cut-over PostgreSQL fixture and require an unchanged schema fingerprint

## Production context

Event discovery is enabled on both Fly Machines with automatic publication disabled. A guarded `RUN_MIGRATIONS=true` canary on revision `591abfacddd8a3acfbe117421efe65382fa73252` first exposed an inferred destructive DDEX column drop. The first CI follow-up then exposed a non-destructive-looking but invalid Persistent constraint/index collision plus extensive unreviewed type/default drift.

This PR therefore separates the authorities:

- `AUTO_APPLY_PRODUCTION_MIGRATIONS=true` runs only reviewed SQL from `scripts/production-migrations.json`, protected by checksums, `tdf_schema_migration`, an advisory lock and the full schema verifier.
- `RUN_MIGRATIONS=false` prevents model-inferred DDL in the production process.
- The backend starts only after all pending reviewed migrations and schema verification succeed.

The currently deployed fleet has not been changed by this PR. Pre-write snapshot: `vs_n2LkNLnjox1SlaxwXnM8o2` (identifier only; no credentials).

## Verification

- `stack build --fast --test --no-run-tests`
- `npm run test:production-release` — 43 passed
- `npm run test:ci-pipeline` — 14 passed
- `npm run audit:catalog-lists` — passed with the reviewed allowlist
- shell syntax and `git diff --check` — passed
- PostgreSQL forward/idempotency/schema-fingerprint test is wired into `backend-quality`
- Docker image construction is validated by the Build Image workflow because the local Docker daemon was unavailable

## Rollout

1. Require all CI checks and exact human review while the PR remains draft.
2. Merge through branch protection and build an immutable image for the merge SHA.
3. Create a fresh production snapshot and run the release dry-run/preflight.
4. Apply migration 42 through the guarded release lane.
5. Deploy one canary with `AUTO_APPLY_PRODUCTION_MIGRATIONS=true`, `RUN_MIGRATIONS=false`, discovery staged off and auto-publication off.
6. Verify checksum ledger, schema, health, image revision and no-op startup migration logs; then roll the second Machine.
7. Re-enable discovery after fleet verification, keep auto-publication off, and verify the next discovery run.
8. Restore the snapshot or use the migration-specific rollback if any schema, health, authorization or discovery gate fails.
