### PR TITLE
fix(events): enable hidden refund moderation

### DIFF
--- a/tdf-hq/src/TDF/Server/SocialEventsHandlers.hs
+++ b/tdf-hq/src/TDF/Server/SocialEventsHandlers.hs
@@ -4735,9 +4735,14 @@ socialEventsServer user =
         eventKey <- parseKeyOr400 "event" eventIdStr
         mEvent <- liftIO $ runSqlPool (get eventKey) envPool
         eventVal <- maybe (throwError err404{errBody = "Event not found"}) pure mEvent
+        hiddenImportedAdmin <-
+            if hasStrictAdminAccess user
+                then liftIO $ runSqlPool (isImportedEventHidden eventKey) envPool
+                else pure False
         let manager = isEventManager currentPartyId eventVal
+            canViewAllRefunds = manager || hiddenImportedAdmin
         candidateOrders <-
-            if manager
+            if canViewAllRefunds
                 then
                     liftIO $
                         runSqlPool
@@ -4760,7 +4765,7 @@ socialEventsServer user =
                     | Entity _ refundRow <- candidateRefunds
                     ]
             orders =
-                if manager
+                if canViewAllRefunds
                     then candidateOrders
                     else
                         filter
@@ -4770,7 +4775,7 @@ socialEventsServer user =
                                         || entityKey orderEntity `Set.member` refundOrderIds
                             )
                             candidateOrders
-        when (not manager && null orders) $
+        when (not canViewAllRefunds && null orders) $
             requireEventVisibleToUser eventKey
         let orderIds = map entityKey orders
             visibleOrderIds = Set.fromList orderIds
@@ -4794,7 +4799,7 @@ socialEventsServer user =
     approveRefund eventIdStr refundIdStr = do
         Env{..} <- ask
         now <- liftIO getCurrentTime
-        (eventKey, _) <- requireManagedEvent eventIdStr
+        (eventKey, _) <- requireRefundManagedEvent eventIdStr
         refundKey <- parseKeyOr400 "refund" refundIdStr
         mRefund <- liftIO $ runSqlPool (get refundKey) envPool
         refund <- maybe (throwError err404{errBody = "Refund request not found"}) pure mRefund
@@ -4852,7 +4857,7 @@ socialEventsServer user =
     rejectRefund eventIdStr refundIdStr RejectionReasonDTO{..} = do
         Env{..} <- ask
         now <- liftIO getCurrentTime
-        (eventKey, _) <- requireManagedEvent eventIdStr
+        (eventKey, _) <- requireRefundManagedEvent eventIdStr
         refundKey <- parseKeyOr400 "refund" refundIdStr
         mRefund <- liftIO $ runSqlPool (get refundKey) envPool
         refund <- maybe (throwError err404{errBody = "Refund request not found"}) pure mRefund
@@ -6142,6 +6147,20 @@ socialEventsServer user =
         eventVal <- maybe (throwError err404{errBody = "Event not found"}) pure mEvent
         claimed <- claimOrRequireEventManager currentPartyId envPool eventKey eventVal
         pure (eventKey, claimed)
+
+    requireRefundManagedEvent :: T.Text -> AppM (SocialEventId, SocialEvent)
+    requireRefundManagedEvent rawEventId = do
+        Env{..} <- ask
+        eventKey <- parseKeyOr400 "event" rawEventId
+        mEvent <- liftIO $ runSqlPool (get eventKey) envPool
+        eventVal <- maybe (throwError err404{errBody = "Event not found"}) pure mEvent
+        hiddenImportedEvent <- liftIO $ runSqlPool (isImportedEventHidden eventKey) envPool
+        if hiddenImportedEvent && hasStrictAdminAccess user
+            then pure (eventKey, eventVal)
+            else do
+                requireEventVisibleToUser eventKey
+                claimed <- claimOrRequireEventManager currentPartyId envPool eventKey eventVal
+                pure (eventKey, claimed)
 
     requireExistingEvent :: ConnectionPool -> SocialEventId -> AppM SocialEvent
     requireExistingEvent pool eventKey = do

--- a/tdf-hq/test/TDF/Social/FollowHandlerSpec.hs
+++ b/tdf-hq/test/TDF/Social/FollowHandlerSpec.hs
@@ -42,6 +42,7 @@ import TDF.DTO.SocialEventsDTO
     , NullableFieldUpdate (..)
     , RefundDTO (..)
     , RefundRequestDTO (..)
+    , RejectionReasonDTO (..)
     , RsvpCreateDTO (..)
     , RsvpDTO
     , StripePaymentIntentDTO
@@ -53,7 +54,7 @@ import TDF.DTO.SocialEventsDTO
 import TDF.Auth (AuthedUser (..), modulesForRoles)
 import qualified TDF.Config as Config
 import TDF.DB (Env (..))
-import TDF.Models (Party (..), RoleEnum (Fan))
+import TDF.Models (Party (..), RoleEnum (Admin, Fan))
 import TDF.Models.SocialEventsModels
 import TDF.Server.SocialEventsHandlers
     ( decodeStoredPromoCodeTierIds
@@ -700,6 +701,7 @@ spec = describe "social event handler helpers" $ do
         let ( stripeHandler
                 , createRefundHandler
                 , listRefundsHandler
+                , rejectRefundHandler
                 , acceptTransferHandler
                 , cancelTransferHandler
                 ) =
@@ -709,13 +711,18 @@ spec = describe "social event handler helpers" $ do
                 runReaderT
                     (createRefundHandler "13" "51" (RefundRequestDTO (Just "Provider cancellation") Nothing))
                     env
-        case refundResult of
+        createdRefundId <- case refundResult of
             Right refund -> do
                 refundOrderId refund `shouldBe` "51"
                 refundStatus refund `shouldBe` "pending"
+                maybe
+                    (expectationFailure "Expected created refund ID" >> pure "")
+                    pure
+                    (refundId refund)
             Left err ->
                 expectationFailure
                     ("Expected the hidden-event buyer to retain refund access, got: " <> show err)
+                    >> pure ""
 
         refundListResult <-
             runHandler $
@@ -731,7 +738,7 @@ spec = describe "social event handler helpers" $ do
                 expectationFailure
                     ("Expected the hidden-event buyer to list refunds, got: " <> show err)
 
-        let (_, otherBuyerCreateRefund, otherBuyerListRefunds, _, _) =
+        let (_, otherBuyerCreateRefund, otherBuyerListRefunds, _, _, _) =
                 socialEventIndirectTicketHandlersFor (socialEventUser 3)
         unauthorizedRefundResult <-
             runHandler $
@@ -817,6 +824,46 @@ spec = describe "social event handler helpers" $ do
                     env
         assertHiddenEventRoute "transfer cancellation" cancelTransferResult
 
+        ownerRejectResult <-
+            runHandler $
+                runReaderT
+                    ( rejectRefundHandler
+                        "13"
+                        createdRefundId
+                        (RejectionReasonDTO "Buyer cannot moderate refunds")
+                    )
+                    env
+        assertHiddenEventRoute "buyer refund rejection" ownerRejectResult
+
+        let (_, _, adminListRefundsHandler, adminRejectRefundHandler, _, _) =
+                socialEventIndirectTicketHandlersFor (strictAdminSocialEventUser 1)
+        adminListResult <-
+            runHandler $
+                runReaderT (adminListRefundsHandler "13") env
+        case adminListResult of
+            Right [refund] -> refundId refund `shouldBe` Just createdRefundId
+            Right refunds ->
+                expectationFailure
+                    ("Expected strict admin to list hidden-event refund, got: " <> show refunds)
+            Left err ->
+                expectationFailure
+                    ("Expected strict admin to list hidden-event refund, got: " <> show err)
+        adminRejectResult <-
+            runHandler $
+                runReaderT
+                    ( adminRejectRefundHandler
+                        "13"
+                        createdRefundId
+                        (RejectionReasonDTO "Imported provider cancellation")
+                    )
+                    env
+        case adminRejectResult of
+            Right refund -> do
+                refundStatus refund `shouldBe` "rejected"
+                refundRejectionReason refund `shouldBe` Just "Imported provider cancellation"
+            Left err ->
+                expectationFailure
+                    ("Expected strict admin to process hidden-event refund, got: " <> show err)
         (transferAfter, ticketAfter) <-
             runSqlPool
                 ((,) <$> get hiddenTransferKey <*> get hiddenTicketKey)
@@ -1203,6 +1250,7 @@ socialEventIndirectTicketHandlersFor
     -> ( TicketPurchaseWithPromoDTO -> ReaderT Env Handler StripePaymentIntentDTO
        , T.Text -> T.Text -> RefundRequestDTO -> ReaderT Env Handler RefundDTO
        , T.Text -> ReaderT Env Handler [RefundDTO]
+       , T.Text -> T.Text -> RejectionReasonDTO -> ReaderT Env Handler RefundDTO
        , T.Text -> ReaderT Env Handler TicketDTO
        , T.Text -> ReaderT Env Handler TicketTransferDTO
        )
@@ -1237,7 +1285,7 @@ socialEventIndirectTicketHandlersFor user =
                     :<|> createRefundRequestHandler
                     :<|> listRefundsHandler
                     :<|> _approveRefund
-                    :<|> _rejectRefund
+                    :<|> rejectRefundHandler
                     :<|> _createTransfer
                     :<|> _listTransfers
                     :<|> acceptTransferHandler
@@ -1246,6 +1294,7 @@ socialEventIndirectTicketHandlersFor user =
                         ( createStripePaymentIntentHandler
                         , createRefundRequestHandler
                         , listRefundsHandler
+                        , rejectRefundHandler
                         , acceptTransferHandler
                         , cancelTransferHandler
                         )
@@ -1317,6 +1366,14 @@ socialEventUser partyId =
         { auPartyId = toSqlKey partyId
         , auRoles = [Fan]
         , auModules = modulesForRoles [Fan]
+        }
+
+strictAdminSocialEventUser :: Int64 -> AuthedUser
+strictAdminSocialEventUser partyId =
+    AuthedUser
+        { auPartyId = toSqlKey partyId
+        , auRoles = [Admin]
+        , auModules = modulesForRoles [Admin]
         }
 
 socialEventStartFixture :: UTCTime


### PR DESCRIPTION
## Summary

- allow strict admins to list, approve, and reject refunds for hidden imported events
- preserve existing organizer-only moderation for visible events
- keep buyers and unrelated callers unable to moderate refunds
- cover strict-admin listing/rejection and buyer rejection denial in the canonical visibility regression

## Context

Post-merge follow-up to #168 for https://github.com/diegueins680/tdf-app/pull/168#discussion_r3804278686. Paid-order owners can now request refunds after an imported event is hidden; this commit ensures an authorized strict admin can complete that refund lifecycle.

## Tests

- `stack test --test-arguments='--match "uses canonical visibility for imported events"'`
- `git diff --check`