### PR TITLE
fix(ci): align migration startup locale

### DIFF
--- a/scripts/__tests__/ci-pipeline.test.mjs
+++ b/scripts/__tests__/ci-pipeline.test.mjs
@@ -54,6 +54,13 @@ test('backend image packages the tested artifact instead of recompiling Haskell'
   assert.doesNotMatch(runtimeDockerfile, /stack (?:--[^\n]+ )?build/);
 });
 
+test('automatic migration integration matches the persisted production locale', async () => {
+  const integration = await source('scripts/test-automatic-migrations-production-schema.sh');
+  assert.match(integration, /DEFAULT_LOCALE=es/);
+  assert.match(integration, /AUTO_APPLY_PRODUCTION_MIGRATIONS=true/);
+  assert.match(integration, /production-entrypoint\.sh/);
+});
+
 test('backend image receives deterministic, non-empty release metadata', async () => {
   const workflow = await source('.github/workflows/build.yml');
   assert.match(workflow, /id: image-metadata/);

--- a/scripts/test-automatic-migrations-production-schema.sh
+++ b/scripts/test-automatic-migrations-production-schema.sh
@@ -50,6 +50,7 @@ start_and_verify() {
   AUTO_APPLY_PRODUCTION_MIGRATIONS=true \
   RESET_DB=false \
   SEED_DB=false \
+  DEFAULT_LOCALE=es \
   EVENT_DISCOVERY_ENABLED=false \
   TDF_SERVER_BIN="${server_bin}" \
   TDF_PRODUCTION_MIGRATIONS_SQL="${migration_sql}" \


### PR DESCRIPTION
## Summary

- set `DEFAULT_LOCALE=es` in the production-schema startup integration test
- assert that the integration test always invokes the reviewed migration entrypoint with the persisted production locale

## Cause

PR #164's entrypoint successfully applied all 42 checksum-pinned migrations and passed the complete schema verifier. The candidate backend then failed its runtime registry check because the isolated CI process omitted `DEFAULT_LOCALE=es`, while `fly.toml` and production both provide it.

This hotfix changes only the test environment. It does not modify SQL, migration checksums, runtime defaults or production data.

## Verification

- `npm run test:ci-pipeline` — 15 passed
- `npm run test:production-release` — 43 passed
- `bash -n scripts/test-automatic-migrations-production-schema.sh`
- `git diff --check`

The backend PostgreSQL job must prove the complete forward + second-run idempotency path before merge.
