### PR TITLE
fix(ci): dedupe migration locale fixture

### DIFF
--- a/scripts/__tests__/ci-pipeline.test.mjs
+++ b/scripts/__tests__/ci-pipeline.test.mjs
@@ -56,7 +56,7 @@ test('backend image packages the tested artifact instead of recompiling Haskell'
 
 test('automatic migration integration matches the persisted production locale', async () => {
   const integration = await source('scripts/test-automatic-migrations-production-schema.sh');
-  assert.match(integration, /DEFAULT_LOCALE=es/);
+  assert.equal(integration.match(/DEFAULT_LOCALE=es/g)?.length, 1);
   assert.match(integration, /AUTO_APPLY_PRODUCTION_MIGRATIONS=true/);
   assert.match(integration, /production-entrypoint\.sh/);
 });

--- a/scripts/test-automatic-migrations-production-schema.sh
+++ b/scripts/test-automatic-migrations-production-schema.sh
@@ -52,7 +52,6 @@ start_and_verify() {
   SEED_DB=false \
   DEFAULT_LOCALE=es \
   EVENT_DISCOVERY_ENABLED=false \
-  DEFAULT_LOCALE=es \
   TDF_SERVER_BIN="${server_bin}" \
   TDF_PRODUCTION_MIGRATIONS_SQL="${migration_sql}" \
   "${repo_root}/tdf-hq/production-entrypoint.sh" >"${server_log}" 2>&1 &


### PR DESCRIPTION
## What changed

- removes the duplicated `DEFAULT_LOCALE=es` assignment created when PR #165 and PR #171 merged the same fix at adjacent positions
- strengthens the CI contract so the production migration harness must contain the locale assignment exactly once

## Why

PR #165 was approved and merged at `e348e7662ce2b04e5b66496fc9765041df01fe29`, but current `main` inherited both parents' equivalent locale lines. The duplicate is runtime-equivalent yet should be corrected before the guarded production release.

## Validation

- `git diff --check`
- `bash -n scripts/test-automatic-migrations-production-schema.sh`
- CI contract tests: 7/7 passed
- production entrypoint/release tests: 43/43 passed
- merged current `main` (`18feaca0fdda1ee1c0c967c10e2f51eb6c340d00`) and reran the focused suites

Exact head: `9adac500e9be64d2c18e7de6432ad1d0d114608c`.