### PR TITLE
fix(ci): dedupe migration locale after merge

### DIFF
--- a/scripts/test-automatic-migrations-production-schema.sh
+++ b/scripts/test-automatic-migrations-production-schema.sh
@@ -52,7 +52,6 @@ start_and_verify() {
   SEED_DB=false \
   DEFAULT_LOCALE=es \
   EVENT_DISCOVERY_ENABLED=false \
-  DEFAULT_LOCALE=es \
   TDF_SERVER_BIN="${server_bin}" \
   TDF_PRODUCTION_MIGRATIONS_SQL="${migration_sql}" \
   "${repo_root}/tdf-hq/production-entrypoint.sh" >"${server_log}" 2>&1 &


### PR DESCRIPTION
## What changed

- Removed the duplicate `DEFAULT_LOCALE=es` entry from the production-schema migration integration harness.

## Why

PR #173's merge reintroduced a second copy of the locale fixture that PR #174 had already deduplicated. The latest `main` Build Image run correctly failed the exact-once CI invariant with `2 !== 1`, blocking Docker publication.

## Impact

This is test-harness-only. Runtime behavior, production configuration, migrations, and application code are unchanged.

## Validation

- `bash -n scripts/test-automatic-migrations-production-schema.sh`
- `npm run test:ci-pipeline` (15/15)
- `npm run quality:repo`
- `git diff --check`

Closes the release-gate failure in Build Image run 32188222944.
