### PR TITLE
fix(directory): restore registered image migration

### DIFF
--- a/tdf-hq/sql/2026-08-18_music_directory_profile_images.sql
+++ b/tdf-hq/sql/2026-08-18_music_directory_profile_images.sql
@@ -25,8 +25,7 @@ AS $$
     AND strpos(candidate.image_url, chr(92)) = 0
     AND (
       (
-        candidate.image_url ~* '^https?://[^/?#[:space:][:cntrl:]@:%\[\]]+(:[0-9]+)?([/?#]|$)'
-        OR candidate.image_url ~* '^https?://\[[0-9a-f:.]+\](:[0-9]+)?([/?#]|$)'
+        candidate.image_url ~* '^https{0,1}://[a-z0-9.-]+(:[0-9]+)?(/|$)'
       )
       OR candidate.image_url ~ '^/[^/[:space:][:cntrl:]][^[:space:][:cntrl:]]*$'
     )


### PR DESCRIPTION
## Resumen

- restaura byte por byte la migración registrada `2026-08-18_music_directory_profile_images.sql` al contenido fusionado en #173
- mantiene la compatibilidad IDN/IPv6 únicamente en la nueva migración forward registrada por #178
- evita `Checksum mismatch` en entornos que ya aplicaron la revisión original

## Validación

- comparación sin diferencias contra `8021446264b0691d9af50d94bbfc94fc28483e78`
- `npm run test:production-release` (43/43)
- `git diff --check`

Seguimiento crítico de #173 y #178 después de que #181 reintrodujera accidentalmente el cambio al archivo inmutable.
