### PR TITLE
fix(ci): ignore untracked catalog sources

### DIFF
--- a/.github/workflows/catalog-list-audit.yml
+++ b/.github/workflows/catalog-list-audit.yml
@@ -27,5 +27,8 @@ jobs:
       - name: Install audit dependencies
         run: npm ci --ignore-scripts
 
+      - name: Verify deterministic catalog-list discovery
+        run: npm run test:catalog-list-audit
+
       - name: Reject unreviewed or stale business-list decisions
         run: npm run audit:catalog-lists

--- a/docs/catalog-persistence/catalog-list-decisions.json
+++ b/docs/catalog-persistence/catalog-list-decisions.json
@@ -7444,26 +7444,6 @@
       "reviewed": true
     },
     {
-      "id": "33560ce7abeb955dc314",
-      "classification": "governed-reference-data",
-      "disposition": "migrate-and-remove-authority-from-code",
-      "specializedModel": "governed reference table selected during consumer refactor",
-      "priority": "P2-domain",
-      "risk": "Cross-client divergence, invalid historical labels, ambiguous backfill, or broken filters/reports.",
-      "justification": "Environment configuration values are governed reference data that must be database-authoritative and validated against the exhaustive backend registry.",
-      "reviewed": true
-    },
-    {
-      "id": "2c318ad8f182eb96e2b8",
-      "classification": "governed-reference-data",
-      "disposition": "migrate-and-remove-authority-from-code",
-      "specializedModel": "governed reference table selected during consumer refactor",
-      "priority": "P2-domain",
-      "risk": "Cross-client divergence, invalid historical labels, ambiguous backfill, or broken filters/reports.",
-      "justification": "Environment configuration values are governed reference data that must be database-authoritative and validated against the exhaustive backend registry.",
-      "reviewed": true
-    },
-    {
       "id": "c6e4988f9791b0f4e8d0",
       "classification": "dynamic-business-catalog",
       "disposition": "migrate-and-remove-authority-from-code",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test:formal": "node --test scripts/__tests__/formal-methods-audit.test.mjs",
     "test:production-release": "node --test scripts/__tests__/production-entrypoint.test.mjs scripts/__tests__/production-release.test.mjs",
     "test:ci-pipeline": "node --test scripts/__tests__/ci-change-scope.test.mjs scripts/__tests__/ci-pipeline.test.mjs",
+    "test:catalog-list-audit": "node --test scripts/__tests__/catalog-list-audit.test.mjs",
     "test:music-directory-visual-artifacts": "node --test scripts/__tests__/music-directory-visual-artifacts.test.mjs",
     "artists:enrich": "node scripts/artist-enrichment.mjs",
     "test:artist-enrichment": "node --test scripts/__tests__/artist-enrichment.test.mjs",

--- a/scripts/__tests__/catalog-list-audit.test.mjs
+++ b/scripts/__tests__/catalog-list-audit.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const auditScriptPath = path.resolve(testDir, '..', 'catalog-list-audit.mjs');
+
+async function writeFile(repoDir, filePath, content) {
+  const fullPath = path.join(repoDir, filePath);
+  await fs.mkdir(path.dirname(fullPath), { recursive: true });
+  await fs.writeFile(fullPath, content, 'utf8');
+}
+
+test('catalog audit excludes ignored local source files from candidate fingerprints', async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'catalog-list-audit-test-'));
+  const repoDir = path.join(tempRoot, 'repo');
+  const reportPath = path.join(tempRoot, 'report.json');
+
+  try {
+    await fs.mkdir(repoDir);
+    await execFileAsync('git', ['init', '-b', 'main'], { cwd: repoDir });
+    await writeFile(repoDir, '.gitignore', '*.env\n');
+    await writeFile(
+      repoDir,
+      'scripts/tracked.mjs',
+      "export const STATUS_OPTIONS = ['active', 'inactive'];\n",
+    );
+    await writeFile(repoDir, 'scripts/local.env', 'SUPPORTED_LOCALES=en,es\n');
+    await execFileAsync('git', ['add', '.gitignore', 'scripts/tracked.mjs'], { cwd: repoDir });
+
+    await execFileAsync(
+      process.execPath,
+      [auditScriptPath, '--root', repoDir, '--output', reportPath],
+      { cwd: repoDir },
+    );
+
+    const report = JSON.parse(await fs.readFile(reportPath, 'utf8'));
+    assert.deepEqual(
+      report.candidates.map(({ file, name }) => ({ file, name })),
+      [{ file: 'scripts/tracked.mjs', name: 'STATUS_OPTIONS' }],
+    );
+  } finally {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/scripts/catalog-list-audit.mjs
+++ b/scripts/catalog-list-audit.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 import { createHash } from 'node:crypto';
-import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync, realpathSync, statSync, writeFileSync } from 'node:fs';
 import { extname, relative, resolve, sep } from 'node:path';
 import process from 'node:process';
 import ts from 'typescript';
@@ -90,6 +91,26 @@ function walk(pathname) {
     if (SKIPPED_SEGMENTS.has(entry.name)) return [];
     return walk(resolve(pathname, entry.name));
   });
+}
+
+function repositoryTrackedFiles(root) {
+  const rootResult = spawnSync('git', ['-C', root, 'rev-parse', '--show-toplevel'], {
+    encoding: 'utf8',
+  });
+  if (
+    rootResult.status !== 0 ||
+    realpathSync(resolve(rootResult.stdout.trim())) !== realpathSync(root)
+  ) {
+    return null;
+  }
+
+  const filesResult = spawnSync(
+    'git',
+    ['-C', root, '-c', 'core.quotePath=false', 'ls-files', '--cached', '--recurse-submodules', '-z'],
+    { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 },
+  );
+  if (filesResult.status !== 0) return null;
+  return new Set(filesResult.stdout.split('\0').filter(Boolean));
 }
 
 function sourceKind(file) {
@@ -690,7 +711,14 @@ function loadDecisions(pathname, root) {
 function main() {
   const options = parseArgs(process.argv.slice(2));
   const root = resolve(options.root);
-  const files = SOURCE_ROOTS.flatMap((sourceRoot) => walk(resolve(root, sourceRoot)));
+  const trackedFiles = repositoryTrackedFiles(root);
+  const files = SOURCE_ROOTS
+    .flatMap((sourceRoot) => walk(resolve(root, sourceRoot)))
+    .filter((absolutePath) => {
+      if (!trackedFiles) return true;
+      const file = relative(root, absolutePath).split(sep).join('/');
+      return trackedFiles.has(file);
+    });
   const uniqueFiles = [...new Set(files)].sort();
   const fileTexts = new Map(
     uniqueFiles.map((absolutePath) => [


### PR DESCRIPTION
## Summary
- restrict catalog-list discovery to files tracked by git, including recursive submodules
- remove two stale catalog decisions produced by local environment files
- add deterministic discovery regression coverage to CI

## Validation
- `npm run test:catalog-list-audit`
- `npm run audit:catalog-lists` (clean checkout)

Fixes the catalog-list audit failure reporting stale decisions on clean CI checkouts.