### PR TITLE
fix(catalog-audit): refresh social events API decision

### DIFF
--- a/docs/catalog-persistence/catalog-list-decisions.json
+++ b/docs/catalog-persistence/catalog-list-decisions.json
@@ -624,7 +624,7 @@
       "reviewed": true
     },
     {
-      "id": "8aebd2c39e94632d619f",
+      "id": "ac1d43fea60bbc54a939",
       "classification": "genuine-technical-constant",
       "disposition": "retain-in-code",
       "specializedModel": "technical_constant_allowlist",


### PR DESCRIPTION
## Summary

- refresh the reviewed SocialEventsAPI catalog fingerprint after listPublicUpcomingEvents was added
- preserve the existing technical-constant classification and justification

## Validation

- npm run audit:catalog-lists
- npm run test:catalog-list-audit