### PR TITLE
feat: add verified review system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,6 +311,9 @@ jobs:
       - name: Rehearse marketplace customer operations and deposit settlement migration
         run: ./scripts/test-marketplace-operations-migration.sh
 
+      - name: Rehearse verified experience review migration
+        run: sh ./scripts/test-verified-experience-reviews-migration.sh
+
       - name: Create production baseline fixture
         run: |
           psql "$PGURL" -v ON_ERROR_STOP=1 -f scripts/__tests__/fixtures/production-schema-20260814.sql

--- a/docs/catalog-persistence/catalog-list-decisions.json
+++ b/docs/catalog-persistence/catalog-list-decisions.json
@@ -7014,16 +7014,6 @@
       "reviewed": true
     },
     {
-      "id": "9541c8b51b5a0ba2a5c0",
-      "classification": "security-system-registry",
-      "disposition": "retain-in-code",
-      "specializedModel": "technical_constant_allowlist",
-      "priority": "P3-retain",
-      "risk": "Changing the migration list could break deployment execution or skip required schema changes.",
-      "justification": "Migration identifiers and their ordered script paths are deployment execution mechanics; each applied database revision is persisted separately in the migration ledger.",
-      "reviewed": true
-    },
-    {
       "id": "86d102f7ab4e7888140b",
       "classification": "dynamic-business-catalog",
       "disposition": "retain-in-code",
@@ -8611,6 +8601,86 @@
       "priority": "P3-retain",
       "risk": "Changing the constant could break parsing, transport, or implementation dispatch.",
       "justification": "This closed union controls rendering, local view state, or serialization mechanics and is not a governed business catalog.",
+      "reviewed": true
+    },
+    {
+      "id": "9fa6b8a8aff3c73f0707",
+      "classification": "security-system-registry",
+      "disposition": "retain-in-code",
+      "specializedModel": "technical_constant_allowlist",
+      "priority": "P3-retain",
+      "risk": "Changing the migration list could break deployment execution or skip required schema changes.",
+      "justification": "Migration identifiers and their ordered script paths are deployment execution mechanics; each applied database revision is persisted separately in the migration ledger.",
+      "reviewed": true
+    },
+    {
+      "id": "6e9a4e9296cdc51a7fa3",
+      "classification": "dynamic-business-catalog",
+      "disposition": "migrate-and-remove-authority-from-code",
+      "specializedModel": "domain-specific catalog table selected during consumer refactor",
+      "priority": "P1-cross-platform",
+      "risk": "Cross-client divergence, invalid historical labels, ambiguous backfill, or broken filters/reports.",
+      "justification": "Review target kinds are cross-client business data and require one governed source shared by API validation, persistence, and both clients.",
+      "reviewed": true
+    },
+    {
+      "id": "1607a77029a8b28c4e7f",
+      "classification": "dynamic-business-catalog",
+      "disposition": "migrate-and-remove-authority-from-code",
+      "specializedModel": "domain-specific catalog table selected during consumer refactor",
+      "priority": "P1-cross-platform",
+      "risk": "Cross-client divergence, invalid historical labels, ambiguous backfill, or broken filters/reports.",
+      "justification": "Verified interaction source kinds are shared business data whose eligibility mapping must remain consistent across the API, persistence, and both clients.",
+      "reviewed": true
+    },
+    {
+      "id": "076e28494a6b4db501b5",
+      "classification": "genuine-technical-constant",
+      "disposition": "retain-in-code",
+      "specializedModel": "technical_constant_allowlist",
+      "priority": "P3-retain",
+      "risk": "Changing the constant could break abuse-control accounting or permit an unknown rate-limit scope.",
+      "justification": "Rate-limit scopes are closed security mechanics validated by the database rather than selectable or displayable business data.",
+      "reviewed": true
+    },
+    {
+      "id": "9debece52815e02a07a9",
+      "classification": "dynamic-business-catalog",
+      "disposition": "migrate-and-remove-authority-from-code",
+      "specializedModel": "domain-specific catalog table selected during consumer refactor",
+      "priority": "P2-domain",
+      "risk": "Cross-client divergence, invalid historical labels, ambiguous backfill, or broken filters/reports.",
+      "justification": "The persistence constraint mirrors cross-client review target kinds and must converge on their governed domain model.",
+      "reviewed": true
+    },
+    {
+      "id": "0ad29b3306e823682bf8",
+      "classification": "dynamic-business-catalog",
+      "disposition": "migrate-and-remove-authority-from-code",
+      "specializedModel": "domain-specific catalog table selected during consumer refactor",
+      "priority": "P2-domain",
+      "risk": "Cross-client divergence, invalid historical labels, ambiguous backfill, or broken filters/reports.",
+      "justification": "The persistence constraint mirrors verified interaction source kinds and must converge on their governed eligibility model.",
+      "reviewed": true
+    },
+    {
+      "id": "f99ba8fe6f37a8606d3d",
+      "classification": "dynamic-business-catalog",
+      "disposition": "migrate-and-remove-authority-from-code",
+      "specializedModel": "workflow_definition, workflow_state, workflow_transition",
+      "priority": "P2-domain",
+      "risk": "Invalid moderation transitions could expose removed content or hide published reviews without an auditable state model.",
+      "justification": "Review publication and moderation statuses are governed workflow states and should converge on the canonical workflow model.",
+      "reviewed": true
+    },
+    {
+      "id": "ce63e73628f073165d01",
+      "classification": "governed-reference-data",
+      "disposition": "retain-in-code",
+      "specializedModel": "technical_constant_allowlist",
+      "priority": "P3-retain",
+      "risk": "Changing identifier parsing modes could accept malformed evidence identifiers or reject valid persisted identifiers.",
+      "justification": "DecimalId and UuidId are closed parser dispatch constructors, not selectable or reportable domain values.",
       "reviewed": true
     }
   ]

--- a/scripts/production-migrations.json
+++ b/scripts/production-migrations.json
@@ -300,6 +300,11 @@
       "id": "2026-08-18_music_directory_profile_image_host_compatibility",
       "path": "tdf-hq/sql/2026-08-18_music_directory_profile_image_host_compatibility.sql",
       "introducedBy": "bc594785274f9f1b692c6da3b69ce439e060b27a"
+    },
+    {
+      "id": "2026-08-20_verified_experience_reviews",
+      "path": "tdf-hq/sql/2026-08-20_verified_experience_reviews.sql",
+      "introducedBy": "dad0ca237b737bdeee5ec87970c2bbfe846e1450"
     }
   ]
 }

--- a/scripts/test-verified-experience-reviews-migration.sh
+++ b/scripts/test-verified-experience-reviews-migration.sh
@@ -1,0 +1,260 @@
+#!/bin/sh
+set -eu
+
+TDF_REVIEW_ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+TDF_REVIEW_CONTAINER="tdf-experience-review-migration-$$"
+TDF_REVIEW_DATABASE="tdf_experience_review_test"
+TDF_REVIEW_USE_DOCKER="false"
+
+cleanup() {
+  if [ "$TDF_REVIEW_USE_DOCKER" = "true" ]; then
+    docker rm -f "$TDF_REVIEW_CONTAINER" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+if [ -n "${TDF_REVIEW_DATABASE_URL:-}" ]; then
+  psql_exec() {
+    PGOPTIONS='-c statement_timeout=10000' \
+      psql "$TDF_REVIEW_DATABASE_URL" -v ON_ERROR_STOP=1 "$@"
+  }
+  apply_file() {
+    PGOPTIONS='-c statement_timeout=10000' \
+      psql "$TDF_REVIEW_DATABASE_URL" -v ON_ERROR_STOP=1 \
+      < "$TDF_REVIEW_ROOT/$1" >/dev/null
+  }
+else
+  TDF_REVIEW_USE_DOCKER="true"
+  docker run --rm -d \
+    --name "$TDF_REVIEW_CONTAINER" \
+    -e POSTGRES_PASSWORD=experience-review-test \
+    -e POSTGRES_DB="$TDF_REVIEW_DATABASE" \
+    postgres:17-alpine >/dev/null
+
+  attempt=0
+  until docker exec "$TDF_REVIEW_CONTAINER" \
+    psql -v ON_ERROR_STOP=1 -U postgres -d "$TDF_REVIEW_DATABASE" -Atqc 'SELECT 1' \
+    >/dev/null 2>&1; do
+    attempt=$((attempt + 1))
+    if [ "$attempt" -ge 30 ]; then
+      echo "Experience review migration database did not become ready" >&2
+      exit 1
+    fi
+    sleep 1
+  done
+
+  psql_exec() {
+    docker exec -i -e "PGOPTIONS=-c statement_timeout=10000" "$TDF_REVIEW_CONTAINER" \
+      psql -v ON_ERROR_STOP=1 -U postgres -d "$TDF_REVIEW_DATABASE" "$@"
+  }
+  apply_file() {
+    docker exec -i -e "PGOPTIONS=-c statement_timeout=10000" "$TDF_REVIEW_CONTAINER" \
+      psql -v ON_ERROR_STOP=1 -U postgres -d "$TDF_REVIEW_DATABASE" \
+      < "$TDF_REVIEW_ROOT/$1" >/dev/null
+  }
+fi
+
+assert_equal() {
+  actual=$1
+  expected=$2
+  label=$3
+  if [ "$actual" != "$expected" ]; then
+    echo "$label: expected '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
+
+psql_exec <<'SQL' >/dev/null
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE party (
+  id BIGINT PRIMARY KEY,
+  display_name TEXT NOT NULL,
+  primary_email TEXT
+);
+CREATE TABLE social_event (
+  id BIGINT PRIMARY KEY,
+  title TEXT NOT NULL,
+  start_time TIMESTAMPTZ NOT NULL,
+  end_time TIMESTAMPTZ
+);
+CREATE TABLE event_ticket_order (
+  id BIGINT PRIMARY KEY,
+  event_id BIGINT NOT NULL,
+  buyer_party_id BIGINT,
+  status TEXT NOT NULL
+);
+CREATE TABLE event_ticket_checkout_runtime (
+  order_id BIGINT PRIMARY KEY,
+  payment_status TEXT NOT NULL,
+  fulfillment_status TEXT NOT NULL
+);
+
+CREATE TABLE marketplace_listing (
+  id UUID PRIMARY KEY,
+  title TEXT NOT NULL
+);
+CREATE TABLE marketplace_order (
+  id UUID PRIMARY KEY,
+  buyer_email TEXT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE TABLE marketplace_order_item (
+  id UUID PRIMARY KEY,
+  order_id UUID NOT NULL,
+  listing_id UUID NOT NULL
+);
+CREATE TABLE marketplace_sale_order_runtime (
+  order_id UUID PRIMARY KEY,
+  fulfillment_status TEXT NOT NULL,
+  delivered_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE TABLE marketplace_rental_order_runtime (
+  order_id UUID PRIMARY KEY,
+  rental_status TEXT NOT NULL,
+  returned_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE service_offering (
+  id UUID PRIMARY KEY,
+  name_es TEXT NOT NULL,
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  deprecated_at TIMESTAMPTZ
+);
+CREATE TABLE booking (
+  id BIGINT PRIMARY KEY,
+  party_id BIGINT,
+  service_offering_id UUID,
+  status TEXT NOT NULL,
+  ends_at TIMESTAMPTZ NOT NULL
+);
+CREATE TABLE service_booking_checkout_runtime (
+  booking_id BIGINT PRIMARY KEY,
+  fulfillment_status TEXT NOT NULL,
+  completed_at TIMESTAMPTZ
+);
+
+CREATE TABLE service_storefront_package (
+  id UUID PRIMARY KEY,
+  name TEXT NOT NULL,
+  active BOOLEAN NOT NULL DEFAULT TRUE
+);
+CREATE TABLE service_storefront_order (
+  id UUID PRIMARY KEY,
+  package_id UUID NOT NULL,
+  buyer_email TEXT NOT NULL,
+  status TEXT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE directory_rate_limit (
+  scope TEXT NOT NULL,
+  subject_hash TEXT NOT NULL,
+  window_started_at TIMESTAMPTZ NOT NULL,
+  count INTEGER NOT NULL DEFAULT 1,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY(scope,subject_hash,window_started_at),
+  CONSTRAINT directory_rate_limit_scope_check CHECK (
+    scope IN ('search','profile_create','classified_publish','application','invitation','contact','report','review')
+  ),
+  CHECK (count > 0)
+);
+SQL
+
+apply_file tdf-hq/sql/2026-08-20_verified_experience_reviews.sql
+apply_file tdf-hq/sql/2026-08-20_verified_experience_reviews.sql
+
+psql_exec <<'SQL' >/dev/null
+INSERT INTO party VALUES (1,'Verified reviewer','reviewer@example.test');
+
+INSERT INTO social_event VALUES (101,'Past event',NOW()-INTERVAL '2 days',NOW()-INTERVAL '1 day');
+INSERT INTO event_ticket_order VALUES (201,101,1,'paid');
+INSERT INTO event_ticket_checkout_runtime VALUES (201,'paid','issued');
+
+INSERT INTO marketplace_listing VALUES ('10000000-0000-4000-8000-000000000001','Verified listing');
+INSERT INTO marketplace_order VALUES ('20000000-0000-4000-8000-000000000001','reviewer@example.test',NOW());
+INSERT INTO marketplace_order_item VALUES (
+  '30000000-0000-4000-8000-000000000001',
+  '20000000-0000-4000-8000-000000000001',
+  '10000000-0000-4000-8000-000000000001'
+);
+INSERT INTO marketplace_sale_order_runtime VALUES (
+  '20000000-0000-4000-8000-000000000001','delivered',NOW(),NOW()
+);
+
+INSERT INTO service_offering VALUES ('40000000-0000-4000-8000-000000000001','Sesión verificada',TRUE,NULL);
+INSERT INTO booking VALUES (
+  501,1,'40000000-0000-4000-8000-000000000001','Completed',NOW()-INTERVAL '1 day'
+);
+INSERT INTO service_booking_checkout_runtime VALUES (501,'completed',NOW()-INTERVAL '1 day');
+
+INSERT INTO service_storefront_package VALUES (
+  '60000000-0000-4000-8000-000000000001','Paquete verificado',TRUE
+);
+INSERT INTO service_storefront_order VALUES (
+  '70000000-0000-4000-8000-000000000001',
+  '60000000-0000-4000-8000-000000000001',
+  'reviewer@example.test','completed',NOW()
+);
+
+INSERT INTO directory_rate_limit(scope,subject_hash,window_started_at)
+VALUES ('experience-review','reviewer',date_trunc('day',NOW()));
+SQL
+
+eligible_count=$(psql_exec -Atqc "
+  SELECT count(*) FROM (VALUES
+    (experience_review_source_is_eligible('event','101','event_ticket_order','201',1)),
+    (experience_review_source_is_eligible(
+      'marketplace_listing','10000000-0000-4000-8000-000000000001',
+      'marketplace_order','20000000-0000-4000-8000-000000000001',1)),
+    (experience_review_source_is_eligible(
+      'service_offering','40000000-0000-4000-8000-000000000001',
+      'service_booking','501',1)),
+    (experience_review_source_is_eligible(
+      'service_package','60000000-0000-4000-8000-000000000001',
+      'service_storefront_order','70000000-0000-4000-8000-000000000001',1))
+  ) result(eligible) WHERE eligible;
+")
+assert_equal "$eligible_count" "4" "all completed interaction kinds are eligible"
+
+psql_exec <<'SQL' >/dev/null
+INSERT INTO experience_review(target_kind,target_id,source_kind,source_id,author_party_id,rating,body)
+VALUES
+  ('event','101','event_ticket_order','201',1,5,'Una experiencia verificada.'),
+  ('marketplace_listing','10000000-0000-4000-8000-000000000001','marketplace_order','20000000-0000-4000-8000-000000000001',1,4,NULL),
+  ('service_offering','40000000-0000-4000-8000-000000000001','service_booking','501',1,5,NULL),
+  ('service_package','60000000-0000-4000-8000-000000000001','service_storefront_order','70000000-0000-4000-8000-000000000001',1,5,NULL);
+SQL
+
+review_count=$(psql_exec -Atqc 'SELECT count(*) FROM experience_review;')
+assert_equal "$review_count" "4" "eligible reviews inserted"
+
+if psql_exec -c "
+  INSERT INTO experience_review(target_kind,target_id,source_kind,source_id,author_party_id,rating)
+  VALUES ('event','101','event_ticket_order','999',1,5);
+" >/dev/null 2>&1; then
+  echo "Ineligible review evidence was accepted" >&2
+  exit 1
+fi
+
+event_review_id=$(psql_exec -Atqc "SELECT id FROM experience_review WHERE target_kind='event';")
+if psql_exec -c "UPDATE experience_review SET rating=1 WHERE id='$event_review_id';" >/dev/null 2>&1; then
+  echo "Published review content was mutable" >&2
+  exit 1
+fi
+psql_exec -c "UPDATE experience_review SET status='hidden' WHERE id='$event_review_id';" >/dev/null
+hidden_count=$(psql_exec -Atqc "SELECT count(*) FROM experience_review WHERE status='hidden';")
+assert_equal "$hidden_count" "1" "moderation status remains mutable"
+
+apply_file tdf-hq/sql/2026-08-20_verified_experience_reviews_rollback.sql
+table_count=$(psql_exec -Atqc "SELECT count(*) FROM pg_class WHERE relname='experience_review' AND relkind='r';")
+assert_equal "$table_count" "0" "rollback removes review table"
+rate_rows=$(psql_exec -Atqc "SELECT count(*) FROM directory_rate_limit WHERE scope='experience-review';")
+assert_equal "$rate_rows" "1" "rollback preserves abuse-control evidence"
+
+apply_file tdf-hq/sql/2026-08-20_verified_experience_reviews.sql
+apply_file tdf-hq/sql/2026-08-20_verified_experience_reviews.sql
+
+echo "Verified experience review migration passed eligibility, integrity, retry, and rollback checks"

--- a/tdf-hq-ui/src/__tests__/MarketplaceOrderTrackingPage.test.tsx
+++ b/tdf-hq-ui/src/__tests__/MarketplaceOrderTrackingPage.test.tsx
@@ -27,6 +27,10 @@ jest.unstable_mockModule('../utils/logger', () => ({
   logger: { warn: jest.fn() },
 }));
 
+jest.unstable_mockModule('../components/reviews/ExperienceReviews', () => ({
+  default: () => null,
+}));
+
 const { default: MarketplaceOrderTrackingPage } = await import('../pages/MarketplaceOrderTrackingPage');
 
 const orderFixture = (manualStatus: string): MarketplaceOrderDTO => ({

--- a/tdf-hq-ui/src/api/generated/types.ts
+++ b/tdf-hq-ui/src/api/generated/types.ts
@@ -4040,6 +4040,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/directory/party-profiles/{partyId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Resolve an artist's public directory profile without exposing Party data in the response */
+        get: operations["getPublicDirectoryProfileByParty"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/directory/profiles/{slug}/reviews": {
         parameters: {
             query?: never;
@@ -4514,6 +4531,57 @@ export interface paths {
         get?: never;
         put?: never;
         post: operations["mergeDirectoryProfiles"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/reviews/{targetKind}/{targetId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List public reviews backed by completed interactions */
+        get: operations["listPublicExperienceReviews"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/reviews/eligibility": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List this account's completed, not-yet-reviewed interactions */
+        get: operations["listExperienceReviewEligibility"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/reviews": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Publish one review for an eligible completed interaction */
+        post: operations["createExperienceReview"];
         delete?: never;
         options?: never;
         head?: never;
@@ -9129,6 +9197,64 @@ export interface components {
             targetProfileId: string;
             reason: string;
         };
+        /** @enum {string} */
+        ExperienceReviewTargetKind: "event" | "marketplace_listing" | "service_offering" | "service_package";
+        ExperienceReviewSummary: {
+            targetKind: components["schemas"]["ExperienceReviewTargetKind"];
+            targetId: string;
+            average?: number | null;
+            /** Format: int64 */
+            count: number;
+        };
+        /** @enum {string} */
+        ExperienceReviewSourceKind: "event_ticket_order" | "marketplace_order" | "service_booking" | "service_storefront_order";
+        ExperienceReviewAuthor: {
+            name: string;
+            /** Format: uri */
+            avatarUrl?: string | null;
+        };
+        ExperienceReview: {
+            /** Format: uuid */
+            id: string;
+            targetKind: components["schemas"]["ExperienceReviewTargetKind"];
+            targetId: string;
+            rating: number;
+            body?: string | null;
+            /** @enum {string} */
+            status: "published" | "hidden" | "removed";
+            /** Format: date-time */
+            createdAt: string;
+            /** @enum {boolean} */
+            verified: true;
+            sourceKind: components["schemas"]["ExperienceReviewSourceKind"];
+            author: components["schemas"]["ExperienceReviewAuthor"];
+        };
+        /** @description Public projection; the private source identifier is never returned. */
+        PublicExperienceReview: components["schemas"]["ExperienceReview"];
+        ExperienceReviewPage: {
+            summary: components["schemas"]["ExperienceReviewSummary"];
+            items: components["schemas"]["PublicExperienceReview"][];
+            /** Format: uuid */
+            nextCursor?: string | null;
+        };
+        ExperienceReviewEligibility: {
+            targetKind: components["schemas"]["ExperienceReviewTargetKind"];
+            targetId: string;
+            targetTitle: string;
+            sourceKind: components["schemas"]["ExperienceReviewSourceKind"];
+            /** @description Private evidence identifier; available only to the eligible account. */
+            sourceId: string;
+            /** Format: date-time */
+            completedAt: string;
+        };
+        ExperienceReviewCreate: {
+            targetKind: components["schemas"]["ExperienceReviewTargetKind"];
+            targetId: string;
+            sourceKind: components["schemas"]["ExperienceReviewSourceKind"];
+            sourceId: string;
+            rating: number;
+            body?: string | null;
+        };
     };
     responses: {
         /** @description Invalid input */
@@ -9193,6 +9319,8 @@ export interface components {
         ClassifiedId: string;
         TargetKind: components["schemas"]["DirectoryEntityType"];
         TargetId: string;
+        "parameters-TargetKind": components["schemas"]["ExperienceReviewTargetKind"];
+        "parameters-TargetId": string;
     };
     requestBodies: never;
     headers: never;
@@ -17078,6 +17206,29 @@ export interface operations {
             404: components["responses"]["NotFound"];
         };
     };
+    getPublicDirectoryProfileByParty: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                partyId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Safe public profile projection */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PublicDirectoryProfile"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
     listPublicDirectoryReviews: {
         parameters: {
             query?: {
@@ -17910,6 +18061,137 @@ export interface operations {
         responses: {
             /** @description Non-destructive */
             201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    listPublicExperienceReviews: {
+        parameters: {
+            query?: {
+                cursor?: string;
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                targetKind: components["parameters"]["parameters-TargetKind"];
+                targetId: components["parameters"]["parameters-TargetId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Stable page of published verified reviews and its aggregate */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExperienceReviewPage"];
+                };
+            };
+            /** @description Invalid target kind or identifier */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Review target not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    listExperienceReviewEligibility: {
+        parameters: {
+            query?: {
+                targetKind?: components["schemas"]["ExperienceReviewTargetKind"];
+                targetId?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Private eligibility evidence for the authenticated account */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExperienceReviewEligibility"][];
+                };
+            };
+            /** @description Invalid or incomplete target filter */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Authentication required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    createExperienceReview: {
+        parameters: {
+            query?: never;
+            header: {
+                "Idempotency-Key": string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ExperienceReviewCreate"];
+            };
+        };
+        responses: {
+            /** @description Idempotent published verified review */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExperienceReview"];
+                };
+            };
+            /** @description Invalid review payload */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Authentication required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Interaction is ineligible */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Daily review limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/tdf-hq-ui/src/api/reviews.test.ts
+++ b/tdf-hq-ui/src/api/reviews.test.ts
@@ -1,0 +1,43 @@
+import { jest } from '@jest/globals';
+
+const mockGet = jest.fn();
+const mockPost = jest.fn();
+
+jest.unstable_mockModule('./client', () => ({
+  get: (...args: unknown[]) => mockGet(...args),
+  post: (...args: unknown[]) => mockPost(...args),
+}));
+
+const { Reviews } = await import('./reviews');
+
+describe('Reviews API', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('encodes public review targets and cursors', async () => {
+    mockGet.mockResolvedValue({});
+    await Reviews.list('marketplace_listing', 'listing / uno', '11111111-1111-4111-8111-111111111111', 10);
+    expect(mockGet).toHaveBeenCalledWith(
+      '/reviews/marketplace_listing/listing%20%2F%20uno?limit=10&cursor=11111111-1111-4111-8111-111111111111',
+    );
+  });
+
+  it('keeps eligibility evidence protected and sends an idempotency key on create', async () => {
+    mockGet.mockResolvedValue([]);
+    mockPost.mockResolvedValue({});
+    await Reviews.eligibility('event', '42');
+    expect(mockGet).toHaveBeenCalledWith('/reviews/eligibility?targetKind=event&targetId=42');
+
+    const request = {
+      targetKind: 'event' as const,
+      targetId: '42',
+      sourceKind: 'event_ticket_order' as const,
+      sourceId: '7',
+      rating: 5,
+      body: 'Una experiencia excelente.',
+    };
+    await Reviews.create(request, 'review-create-1');
+    expect(mockPost).toHaveBeenCalledWith('/reviews', request, {
+      headers: { 'Idempotency-Key': 'review-create-1' },
+    });
+  });
+});

--- a/tdf-hq-ui/src/api/reviews.ts
+++ b/tdf-hq-ui/src/api/reviews.ts
@@ -1,0 +1,31 @@
+import { get, post } from './client';
+import type { components } from './generated/types';
+
+export type ExperienceReviewTargetKind = components['schemas']['ExperienceReviewTargetKind'];
+export type ExperienceReviewPage = components['schemas']['ExperienceReviewPage'];
+export type ExperienceReview = components['schemas']['ExperienceReview'];
+export type ExperienceReviewEligibility = components['schemas']['ExperienceReviewEligibility'];
+export type ExperienceReviewCreate = components['schemas']['ExperienceReviewCreate'];
+
+const idempotencyHeaders = (key?: string) => ({
+  headers: { 'Idempotency-Key': key ?? crypto.randomUUID() },
+});
+
+export const Reviews = {
+  list: (targetKind: ExperienceReviewTargetKind, targetId: string, cursor?: string, limit = 20) => {
+    const params = new URLSearchParams({ limit: String(limit) });
+    if (cursor) params.set('cursor', cursor);
+    return get<ExperienceReviewPage>(
+      `/reviews/${encodeURIComponent(targetKind)}/${encodeURIComponent(targetId)}?${params.toString()}`,
+    );
+  },
+  eligibility: (targetKind?: ExperienceReviewTargetKind, targetId?: string) => {
+    const params = new URLSearchParams();
+    if (targetKind) params.set('targetKind', targetKind);
+    if (targetId) params.set('targetId', targetId);
+    const query = params.toString();
+    return get<ExperienceReviewEligibility[]>(`/reviews/eligibility${query ? `?${query}` : ''}`);
+  },
+  create: (body: ExperienceReviewCreate, idempotencyKey?: string) =>
+    post<ExperienceReview>('/reviews', body, idempotencyHeaders(idempotencyKey)),
+};

--- a/tdf-hq-ui/src/components/reviews/ExperienceReviews.test.tsx
+++ b/tdf-hq-ui/src/components/reviews/ExperienceReviews.test.tsx
@@ -1,0 +1,97 @@
+import { jest } from '@jest/globals';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ExperienceReviewPage } from '../../api/reviews';
+
+const firstPage: ExperienceReviewPage = {
+  summary: {
+    targetKind: 'event',
+    targetId: '42',
+    average: 4.5,
+    count: 2,
+  },
+  items: [{
+    id: '11111111-1111-4111-8111-111111111111',
+    targetKind: 'event',
+    targetId: '42',
+    rating: 5,
+    body: 'Primera reseña verificada',
+    status: 'published',
+    createdAt: '2030-01-01T00:00:00Z',
+    verified: true,
+    sourceKind: 'event_ticket_order',
+    author: { name: 'Primera autora', avatarUrl: null },
+  }],
+  nextCursor: '22222222-2222-4222-8222-222222222222',
+};
+
+const secondPage: ExperienceReviewPage = {
+  summary: firstPage.summary,
+  items: [{
+    ...firstPage.items[0],
+    id: '33333333-3333-4333-8333-333333333333',
+    body: 'Segunda reseña verificada',
+    author: { name: 'Segunda autora', avatarUrl: null },
+  }],
+  nextCursor: null,
+};
+
+const listMock = jest.fn<(
+  targetKind: 'event',
+  targetId: string,
+  cursor?: string,
+) => Promise<ExperienceReviewPage>>();
+
+jest.unstable_mockModule('../../api/reviews', () => ({
+  Reviews: {
+    list: listMock,
+    eligibility: jest.fn(),
+    create: jest.fn(),
+  },
+}));
+
+jest.unstable_mockModule('../../api/directory', () => ({
+  Directory: { report: jest.fn() },
+}));
+
+jest.unstable_mockModule('../../session/SessionContext', () => ({
+  useSession: () => ({ session: null }),
+}));
+
+const { default: ExperienceReviews } = await import('./ExperienceReviews');
+
+describe('ExperienceReviews pagination', () => {
+  beforeEach(() => {
+    listMock.mockReset()
+      .mockResolvedValueOnce(firstPage)
+      .mockResolvedValueOnce(secondPage);
+  });
+
+  it('loads the next cursor and keeps reviews from earlier pages visible', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const view = render(
+      <QueryClientProvider client={queryClient}>
+        <ExperienceReviews targetKind="event" targetId="42" />
+      </QueryClientProvider>,
+    );
+
+    try {
+      expect(await screen.findByText('Primera reseña verificada')).toBeTruthy();
+      fireEvent.click(screen.getByRole('button', { name: 'Ver más reseñas' }));
+
+      expect(await screen.findByText('Segunda reseña verificada')).toBeTruthy();
+      expect(screen.getByText('Primera reseña verificada')).toBeTruthy();
+      expect(listMock).toHaveBeenNthCalledWith(1, 'event', '42', undefined);
+      expect(listMock).toHaveBeenNthCalledWith(
+        2,
+        'event',
+        '42',
+        '22222222-2222-4222-8222-222222222222',
+      );
+      expect(screen.queryByRole('button', { name: 'Ver más reseñas' })).toBeNull();
+    } finally {
+      view.unmount();
+      queryClient.clear();
+    }
+  });
+});

--- a/tdf-hq-ui/src/components/reviews/ExperienceReviews.tsx
+++ b/tdf-hq-ui/src/components/reviews/ExperienceReviews.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState } from 'react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import FlagOutlinedIcon from '@mui/icons-material/FlagOutlined';
 import VerifiedIcon from '@mui/icons-material/Verified';
 import {
@@ -47,9 +47,11 @@ export default function ExperienceReviews({ targetKind, targetId, title = 'Rese�
   const [body, setBody] = useState('');
   const createAttempt = useRef<{ fingerprint: string; key: string } | null>(null);
 
-  const reviewsQuery = useQuery({
+  const reviewsQuery = useInfiniteQuery({
     queryKey: ['experience-reviews', targetKind, targetId],
-    queryFn: () => Reviews.list(targetKind, targetId),
+    queryFn: ({ pageParam }) => Reviews.list(targetKind, targetId, pageParam),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (page) => page.nextCursor ?? undefined,
     enabled: Boolean(targetId),
   });
   const eligibilityQuery = useQuery({
@@ -97,11 +99,12 @@ export default function ExperienceReviews({ targetKind, targetId, title = 'Rese�
     }),
   });
 
+  const reviews = reviewsQuery.data?.pages.flatMap((page) => page.items) ?? [];
+  const summary = reviewsQuery.data?.pages[0]?.summary;
   const summaryLabel = useMemo(() => {
-    const summary = reviewsQuery.data?.summary;
     if (!summary || summary.count === 0) return 'Aún no hay reseñas';
     return `${Number(summary.average ?? 0).toFixed(1)} de 5 · ${summary.count} ${summary.count === 1 ? 'reseña' : 'reseñas'}`;
-  }, [reviewsQuery.data?.summary]);
+  }, [summary]);
 
   return (
     <Card variant="outlined" component="section" aria-labelledby={`reviews-${targetKind}-${targetId}`}>
@@ -110,7 +113,7 @@ export default function ExperienceReviews({ targetKind, targetId, title = 'Rese�
           <Box>
             <Typography id={`reviews-${targetKind}-${targetId}`} variant="h5" fontWeight={800}>{title}</Typography>
             <Stack direction="row" spacing={1} alignItems="center" mt={0.5}>
-              <Rating value={reviewsQuery.data?.summary.average ?? 0} precision={0.1} readOnly aria-label={summaryLabel} />
+              <Rating value={summary?.average ?? 0} precision={0.1} readOnly aria-label={summaryLabel} />
               <Typography variant="body2" color="text.secondary">{summaryLabel}</Typography>
             </Stack>
           </Box>
@@ -156,7 +159,7 @@ export default function ExperienceReviews({ targetKind, targetId, title = 'Rese�
           {reviewsQuery.isLoading && <CircularProgress size={24} />}
           {reviewsQuery.error && <Alert severity="error">No se pudieron cargar las reseñas.</Alert>}
 
-          {reviewsQuery.data?.items.map((review, index) => (
+          {reviews.map((review, index) => (
             <Box key={review.id}>
               {index > 0 && <Divider sx={{ mb: 2 }} />}
               <Stack direction="row" spacing={1.25} alignItems="flex-start">
@@ -187,6 +190,16 @@ export default function ExperienceReviews({ targetKind, targetId, title = 'Rese�
               </Stack>
             </Box>
           ))}
+          {reviewsQuery.hasNextPage && (
+            <Button
+              variant="outlined"
+              onClick={() => { void reviewsQuery.fetchNextPage(); }}
+              disabled={reviewsQuery.isFetchingNextPage}
+              sx={{ alignSelf: 'flex-start' }}
+            >
+              {reviewsQuery.isFetchingNextPage ? 'Cargando…' : 'Ver más reseñas'}
+            </Button>
+          )}
           {reportMutation.isSuccess && <Alert severity="success">Gracias. La reseña fue enviada a moderación.</Alert>}
         </Stack>
       </CardContent>

--- a/tdf-hq-ui/src/components/reviews/ExperienceReviews.tsx
+++ b/tdf-hq-ui/src/components/reviews/ExperienceReviews.tsx
@@ -1,0 +1,195 @@
+import { useMemo, useRef, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import FlagOutlinedIcon from '@mui/icons-material/FlagOutlined';
+import VerifiedIcon from '@mui/icons-material/Verified';
+import {
+  Alert,
+  Avatar,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Divider,
+  IconButton,
+  Rating,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { Directory } from '../../api/directory';
+import {
+  Reviews,
+  type ExperienceReviewEligibility,
+  type ExperienceReviewTargetKind,
+} from '../../api/reviews';
+import { useSession } from '../../session/SessionContext';
+
+interface Props {
+  targetKind: ExperienceReviewTargetKind;
+  targetId: string;
+  title?: string;
+}
+
+const sourceLabel: Record<ExperienceReviewEligibility['sourceKind'], string> = {
+  event_ticket_order: 'Compra de entrada verificada',
+  marketplace_order: 'Pedido de marketplace verificado',
+  service_booking: 'Reserva completada',
+  service_storefront_order: 'Servicio completado',
+};
+
+export default function ExperienceReviews({ targetKind, targetId, title = 'Reseñas' }: Props) {
+  const { session } = useSession();
+  const queryClient = useQueryClient();
+  const [rating, setRating] = useState<number | null>(null);
+  const [body, setBody] = useState('');
+  const createAttempt = useRef<{ fingerprint: string; key: string } | null>(null);
+
+  const reviewsQuery = useQuery({
+    queryKey: ['experience-reviews', targetKind, targetId],
+    queryFn: () => Reviews.list(targetKind, targetId),
+    enabled: Boolean(targetId),
+  });
+  const eligibilityQuery = useQuery({
+    queryKey: ['experience-review-eligibility', targetKind, targetId],
+    queryFn: () => Reviews.eligibility(targetKind, targetId),
+    enabled: Boolean(session && targetId),
+  });
+  const eligibility = eligibilityQuery.data?.[0];
+  const normalizedBody = body.trim();
+  const bodyValid = normalizedBody.length === 0 || normalizedBody.length >= 10;
+
+  const createMutation = useMutation({
+    mutationFn: () => {
+      if (!eligibility || !rating) throw new Error('No hay una interacción elegible para reseñar.');
+      const request = {
+        targetKind,
+        targetId,
+        sourceKind: eligibility.sourceKind,
+        sourceId: eligibility.sourceId,
+        rating,
+        body: normalizedBody || undefined,
+      };
+      const fingerprint = JSON.stringify(request);
+      if (createAttempt.current?.fingerprint !== fingerprint) {
+        createAttempt.current = { fingerprint, key: crypto.randomUUID() };
+      }
+      return Reviews.create(request, createAttempt.current.key);
+    },
+    onSuccess: async () => {
+      createAttempt.current = null;
+      setRating(null);
+      setBody('');
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['experience-reviews', targetKind, targetId] }),
+        queryClient.invalidateQueries({ queryKey: ['experience-review-eligibility', targetKind, targetId] }),
+      ]);
+    },
+  });
+
+  const reportMutation = useMutation({
+    mutationFn: (reviewId: string) => Directory.report({
+      targetKind: 'review',
+      targetId: reviewId,
+      reasonCode: 'inappropriate_content',
+    }),
+  });
+
+  const summaryLabel = useMemo(() => {
+    const summary = reviewsQuery.data?.summary;
+    if (!summary || summary.count === 0) return 'Aún no hay reseñas';
+    return `${Number(summary.average ?? 0).toFixed(1)} de 5 · ${summary.count} ${summary.count === 1 ? 'reseña' : 'reseñas'}`;
+  }, [reviewsQuery.data?.summary]);
+
+  return (
+    <Card variant="outlined" component="section" aria-labelledby={`reviews-${targetKind}-${targetId}`}>
+      <CardContent>
+        <Stack spacing={2}>
+          <Box>
+            <Typography id={`reviews-${targetKind}-${targetId}`} variant="h5" fontWeight={800}>{title}</Typography>
+            <Stack direction="row" spacing={1} alignItems="center" mt={0.5}>
+              <Rating value={reviewsQuery.data?.summary.average ?? 0} precision={0.1} readOnly aria-label={summaryLabel} />
+              <Typography variant="body2" color="text.secondary">{summaryLabel}</Typography>
+            </Stack>
+          </Box>
+
+          {session && eligibility && (
+            <Stack spacing={1.25} sx={{ p: 2, borderRadius: 2, bgcolor: 'action.hover' }}>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <VerifiedIcon color="success" fontSize="small" />
+                <Typography fontWeight={700}>{sourceLabel[eligibility.sourceKind]}</Typography>
+              </Stack>
+              <Rating
+                value={rating}
+                onChange={(_, value) => setRating(value)}
+                size="large"
+                aria-label="Calificación de una a cinco estrellas"
+              />
+              <TextField
+                label="Cuéntanos cómo fue (opcional)"
+                value={body}
+                onChange={(event) => setBody(event.target.value)}
+                multiline
+                minRows={3}
+                inputProps={{ minLength: 10, maxLength: 2000 }}
+                error={!bodyValid}
+                helperText={!bodyValid ? 'Escribe al menos 10 caracteres o deja el comentario vacío.' : `${normalizedBody.length}/2000`}
+              />
+              {createMutation.error && <Alert severity="error">{createMutation.error instanceof Error ? createMutation.error.message : 'No se pudo publicar la reseña.'}</Alert>}
+              <Button
+                variant="contained"
+                onClick={() => createMutation.mutate()}
+                disabled={!rating || !bodyValid || createMutation.isPending}
+                sx={{ alignSelf: 'flex-start' }}
+              >
+                {createMutation.isPending ? <CircularProgress size={20} color="inherit" /> : 'Publicar reseña verificada'}
+              </Button>
+            </Stack>
+          )}
+
+          {session && eligibilityQuery.isSuccess && !eligibility && (
+            <Alert severity="info">Podrás reseñar después de completar una compra, asistencia o servicio relacionado.</Alert>
+          )}
+          {!session && <Alert severity="info">Inicia sesión para publicar una reseña después de completar una interacción.</Alert>}
+          {reviewsQuery.isLoading && <CircularProgress size={24} />}
+          {reviewsQuery.error && <Alert severity="error">No se pudieron cargar las reseñas.</Alert>}
+
+          {reviewsQuery.data?.items.map((review, index) => (
+            <Box key={review.id}>
+              {index > 0 && <Divider sx={{ mb: 2 }} />}
+              <Stack direction="row" spacing={1.25} alignItems="flex-start">
+                <Avatar src={review.author.avatarUrl ?? undefined}>{review.author.name.slice(0, 1).toUpperCase()}</Avatar>
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Stack direction={{ xs: 'column', sm: 'row' }} spacing={0.75} alignItems={{ sm: 'center' }}>
+                    <Typography fontWeight={700}>{review.author.name}</Typography>
+                    <Chip icon={<VerifiedIcon />} label="Interacción verificada" size="small" color="success" variant="outlined" />
+                  </Stack>
+                  <Rating value={review.rating} readOnly size="small" aria-label={`${review.rating} de 5 estrellas`} />
+                  {review.body && <Typography sx={{ mt: 0.5, whiteSpace: 'pre-wrap' }}>{review.body}</Typography>}
+                  <Typography variant="caption" color="text.secondary">
+                    {new Date(review.createdAt).toLocaleDateString()}
+                  </Typography>
+                </Box>
+                {session && (
+                  <Tooltip title="Reportar reseña">
+                    <IconButton
+                      size="small"
+                      aria-label={`Reportar reseña de ${review.author.name}`}
+                      onClick={() => reportMutation.mutate(review.id)}
+                      disabled={reportMutation.isPending}
+                    >
+                      <FlagOutlinedIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                )}
+              </Stack>
+            </Box>
+          ))}
+          {reportMutation.isSuccess && <Alert severity="success">Gracias. La reseña fue enviada a moderación.</Alert>}
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}

--- a/tdf-hq-ui/src/pages/MarketplaceOrderTrackingPage.tsx
+++ b/tdf-hq-ui/src/pages/MarketplaceOrderTrackingPage.tsx
@@ -33,6 +33,7 @@ import {
   loadMarketplaceLookupToken,
 } from '../api/marketplace';
 import { getOrderStatusMeta } from '../utils/marketplace';
+import ExperienceReviews from '../components/reviews/ExperienceReviews';
 
 const requestLabels: Record<MarketplaceCustomerRequestType, string> = {
   sale_cancellation: 'Cancelar antes de la entrega',
@@ -442,6 +443,15 @@ export default function MarketplaceOrderTrackingPage() {
                 </Stack>
               </CardContent>
             </Card>
+
+            {Array.from(new Map(order.moItems.map((item) => [item.moiListingId, item])).values()).map((item) => (
+              <ExperienceReviews
+                key={item.moiListingId}
+                targetKind="marketplace_listing"
+                targetId={item.moiListingId}
+                title={`Reseñas de ${item.moiTitle || 'este artículo'}`}
+              />
+            ))}
 
             {fulfillmentTimeline.length > 0 && (
               <Card variant="outlined">

--- a/tdf-hq-ui/src/pages/MarketplacePage.tsx
+++ b/tdf-hq-ui/src/pages/MarketplacePage.tsx
@@ -71,6 +71,7 @@ import { buildPublicContentUrl, type DriveFileInfo } from '../services/googleDri
 import { buildAccessibleModuleSet } from '../utils/accessControl';
 import { assertNever } from '../utils/assertNever';
 import { formatCurrencyForUser, resolveRuntimeCurrency } from '../utils/formatters';
+import ExperienceReviews from '../components/reviews/ExperienceReviews';
 
 const API_BASE = (import.meta.env?.VITE_API_BASE && import.meta.env.VITE_API_BASE.trim() !== ''
   ? import.meta.env.VITE_API_BASE
@@ -3120,6 +3121,11 @@ export default function MarketplacePage() {
                   Copiar detalle
                 </Button>
               </Stack>
+              <ExperienceReviews
+                targetKind="marketplace_listing"
+                targetId={selectedListing.miListingId}
+                title="Reseñas verificadas"
+              />
             </Stack>
           )}
         </DialogContent>

--- a/tdf-hq-ui/src/pages/MixingMasteringPage.test.tsx
+++ b/tdf-hq-ui/src/pages/MixingMasteringPage.test.tsx
@@ -75,6 +75,10 @@ jest.unstable_mockModule('../api/serviceStorefront', () => ({
   },
 }));
 
+jest.unstable_mockModule('../components/reviews/ExperienceReviews', () => ({
+  default: () => null,
+}));
+
 const { default: MixingMasteringPage } = await import('./MixingMasteringPage');
 
 const renderPage = () => {

--- a/tdf-hq-ui/src/pages/MixingMasteringPage.tsx
+++ b/tdf-hq-ui/src/pages/MixingMasteringPage.tsx
@@ -54,6 +54,7 @@ import {
   type ServiceStorefrontOrderDTO,
   type ServiceStorefrontPackageDTO,
 } from '../api/serviceStorefront';
+import ExperienceReviews from '../components/reviews/ExperienceReviews';
 
 const IMPORT_META_ENV = (import.meta as unknown as { env?: Record<string, string | undefined> }).env ?? {};
 
@@ -595,7 +596,8 @@ export default function MixingMasteringPage() {
 
       {/* Step 2: Order Details */}
       {currentStep === 'details' && selectedPackage && (
-        <Paper sx={{ p: 4, maxWidth: 600, mx: 'auto' }}>
+        <Stack spacing={3} sx={{ maxWidth: 700, mx: 'auto' }}>
+          <Paper sx={{ p: 4 }}>
           <Typography variant="h5" gutterBottom fontWeight={600}>
             Detalles del Proyecto
           </Typography>
@@ -685,7 +687,13 @@ export default function MixingMasteringPage() {
               Continuar al pago
             </Button>
           </Stack>
-        </Paper>
+          </Paper>
+          <ExperienceReviews
+            targetKind="service_package"
+            targetId={selectedPackage.id}
+            title={`Reseñas de ${selectedPackage.name}`}
+          />
+        </Stack>
       )}
 
       {/* Step 3: Payment */}

--- a/tdf-hq-ui/src/pages/PublicBookingOrderTrackingPage.tsx
+++ b/tdf-hq-ui/src/pages/PublicBookingOrderTrackingPage.tsx
@@ -18,6 +18,7 @@ import {
   type PublicBookingCheckoutDTO,
 } from '../api/bookings';
 import { useMetaTags } from '../hooks/useMetaTags';
+import ExperienceReviews from '../components/reviews/ExperienceReviews';
 
 const paidStatuses = new Set(['paid', 'partially_refunded', 'refunded']);
 
@@ -127,9 +128,10 @@ export default function PublicBookingOrderTrackingPage() {
 
   return (
     <Box sx={{ minHeight: '70vh', display: 'flex', alignItems: 'center', justifyContent: 'center', py: 5 }}>
-      <Card sx={{ width: '100%', maxWidth: 720, borderRadius: 3 }}>
-        <CardContent sx={{ p: { xs: 3, md: 5 } }}>
-          <Stack spacing={2.5}>
+      <Stack sx={{ width: '100%', maxWidth: 720 }} spacing={3}>
+        <Card sx={{ borderRadius: 3 }}>
+          <CardContent sx={{ p: { xs: 3, md: 5 } }}>
+            <Stack spacing={2.5}>
             <Stack spacing={0.5}>
               <Typography variant="overline" color="text.secondary">Reserva TDF</Typography>
               <Typography variant="h4" fontWeight={800}>Estado de tu orden</Typography>
@@ -194,9 +196,17 @@ export default function PublicBookingOrderTrackingPage() {
                 Nueva reserva
               </Button>
             </Stack>
-          </Stack>
-        </CardContent>
-      </Card>
+            </Stack>
+          </CardContent>
+        </Card>
+        {order?.booking.serviceOfferingId ? (
+          <ExperienceReviews
+            targetKind="service_offering"
+            targetId={order.booking.serviceOfferingId}
+            title={`Reseñas de ${order.booking.title}`}
+          />
+        ) : null}
+      </Stack>
     </Box>
   );
 }

--- a/tdf-hq-ui/src/pages/PublicBookingPage.tsx
+++ b/tdf-hq-ui/src/pages/PublicBookingPage.tsx
@@ -52,6 +52,7 @@ import { mergeServiceTypes, type ServiceType } from '../utils/serviceTypesStore'
 import { env } from '../utils/env';
 import { useSession } from '../session/SessionContext';
 import { resolveRuntimeCurrency } from '../utils/formatters';
+import ExperienceReviews from '../components/reviews/ExperienceReviews';
 
 interface FormState {
   fullName: string;
@@ -2427,6 +2428,15 @@ export default function PublicBookingPage({ preset }: PublicBookingPageProps = {
           </Stack>
         </CardContent>
       </Card>
+      {form.serviceOfferingId && (
+        <Box sx={{ mt: 3 }}>
+          <ExperienceReviews
+            targetKind="service_offering"
+            targetId={form.serviceOfferingId}
+            title="Reseñas del servicio"
+          />
+        </Box>
+      )}
       <Snackbar
         open={snackbar.open}
         message={snackbar.message}

--- a/tdf-hq-ui/src/pages/ServiceOrderTrackingPage.tsx
+++ b/tdf-hq-ui/src/pages/ServiceOrderTrackingPage.tsx
@@ -3,6 +3,7 @@ import { Alert, Box, Button, Card, CardContent, Chip, CircularProgress, Divider,
 import { useQuery } from '@tanstack/react-query';
 import { Link as RouterLink, useParams } from 'react-router-dom';
 import { ServiceStorefront } from '../api/serviceStorefront';
+import ExperienceReviews from '../components/reviews/ExperienceReviews';
 
 const readFragmentToken = (): string => {
   if (typeof window === 'undefined') return '';
@@ -94,6 +95,11 @@ export default function ServiceOrderTrackingPage() {
             </Stack>
           </CardContent>
         </Card>
+        <ExperienceReviews
+          targetKind="service_package"
+          targetId={order.ssoPackageId}
+          title={`Reseñas de ${order.ssoServiceKind} ${order.ssoTier}`}
+        />
         <Button component={RouterLink} to="/mezcla-mastering" variant="outlined">Volver a servicios</Button>
       </Stack>
     </Box>

--- a/tdf-hq-ui/src/pages/SocialEventDetailPage.tsx
+++ b/tdf-hq-ui/src/pages/SocialEventDetailPage.tsx
@@ -12,6 +12,7 @@ import { Catalogs } from '../api/catalogs';
 import { useSession } from '../session/SessionContext';
 import { useLocalePreferences } from '../contexts/LocalePreferencesContext';
 import { formatCurrency } from '../utils/formatters';
+import ExperienceReviews from '../components/reviews/ExperienceReviews';
 
 const formatDate = (value: string | null | undefined, locale: string, timezone: string) => {
   if (!value) return '';
@@ -178,6 +179,8 @@ export default function SocialEventDetailPage() {
             </Stack>
           </CardContent>
         </Card>
+
+        {event && <ExperienceReviews targetKind="event" targetId={eventId} title="Reseñas del evento" />}
 
         <Card variant="outlined">
           <CardContent>

--- a/tdf-hq/docs/openapi/api.yaml
+++ b/tdf-hq/docs/openapi/api.yaml
@@ -5151,6 +5151,7 @@ paths:
   /directory/suggestions: { $ref: './directory.yaml#/paths/~1directory~1suggestions' }
   /directory/taxonomies: { $ref: './directory.yaml#/paths/~1directory~1taxonomies' }
   /directory/profiles/{slug}: { $ref: './directory.yaml#/paths/~1directory~1profiles~1{slug}' }
+  /directory/party-profiles/{partyId}: { $ref: './directory.yaml#/paths/~1directory~1party-profiles~1{partyId}' }
   /directory/profiles/{slug}/reviews: { $ref: './directory.yaml#/paths/~1directory~1profiles~1{slug}~1reviews' }
   /directory/classifieds/{slug}: { $ref: './directory.yaml#/paths/~1directory~1classifieds~1{slug}' }
   /directory/events/{eventId}: { $ref: './directory.yaml#/paths/~1directory~1events~1{eventId}' }
@@ -5181,6 +5182,9 @@ paths:
   /directory/admin/moderation: { $ref: './directory.yaml#/paths/~1directory~1admin~1moderation' }
   /directory/admin/moderation/{caseId}/decisions: { $ref: './directory.yaml#/paths/~1directory~1admin~1moderation~1{caseId}~1decisions' }
   /directory/admin/merges: { $ref: './directory.yaml#/paths/~1directory~1admin~1merges' }
+  /reviews/{targetKind}/{targetId}: { $ref: './reviews.yaml#/paths/~1reviews~1{targetKind}~1{targetId}' }
+  /reviews/eligibility: { $ref: './reviews.yaml#/paths/~1reviews~1eligibility' }
+  /reviews: { $ref: './reviews.yaml#/paths/~1reviews' }
 
   /public/events/{eventId}/tickets:
     get:

--- a/tdf-hq/docs/openapi/directory.yaml
+++ b/tdf-hq/docs/openapi/directory.yaml
@@ -54,6 +54,17 @@ paths:
       responses:
         '200': { description: Safe public profile projection, content: { application/json: { schema: { $ref: '#/components/schemas/PublicDirectoryProfile' } } } }
         '404': { $ref: '#/components/responses/NotFound' }
+  /directory/party-profiles/{partyId}:
+    get:
+      tags: [Music directory]
+      operationId: getPublicDirectoryProfileByParty
+      summary: Resolve an artist's public directory profile without exposing Party data in the response
+      security: []
+      parameters:
+        - { name: partyId, in: path, required: true, schema: { type: integer, format: int64, minimum: 1 } }
+      responses:
+        '200': { description: Safe public profile projection, content: { application/json: { schema: { $ref: '#/components/schemas/PublicDirectoryProfile' } } } }
+        '404': { $ref: '#/components/responses/NotFound' }
   /directory/profiles/{slug}/reviews:
     get:
       tags: [Music directory trust]

--- a/tdf-hq/docs/openapi/reviews.yaml
+++ b/tdf-hq/docs/openapi/reviews.yaml
@@ -1,0 +1,138 @@
+openapi: 3.0.0
+info: { title: TDF Verified Reviews API, version: 1.0.0 }
+paths:
+  /reviews/{targetKind}/{targetId}:
+    get:
+      tags: [Verified reviews]
+      operationId: listPublicExperienceReviews
+      summary: List public reviews backed by completed interactions
+      security: []
+      parameters:
+        - { $ref: '#/components/parameters/TargetKind' }
+        - { $ref: '#/components/parameters/TargetId' }
+        - { name: cursor, in: query, schema: { type: string, format: uuid } }
+        - { name: limit, in: query, schema: { type: integer, minimum: 1, maximum: 50, default: 20 } }
+      responses:
+        '200':
+          description: Stable page of published verified reviews and its aggregate
+          content: { application/json: { schema: { $ref: '#/components/schemas/ExperienceReviewPage' } } }
+        '400': { description: Invalid target kind or identifier }
+        '404': { description: Review target not found }
+  /reviews/eligibility:
+    get:
+      tags: [Verified reviews]
+      operationId: listExperienceReviewEligibility
+      summary: List this account's completed, not-yet-reviewed interactions
+      parameters:
+        - { name: targetKind, in: query, schema: { $ref: '#/components/schemas/ExperienceReviewTargetKind' } }
+        - { name: targetId, in: query, schema: { type: string } }
+      responses:
+        '200':
+          description: Private eligibility evidence for the authenticated account
+          content:
+            application/json:
+              schema: { type: array, items: { $ref: '#/components/schemas/ExperienceReviewEligibility' } }
+        '400': { description: Invalid or incomplete target filter }
+        '401': { description: Authentication required }
+  /reviews:
+    post:
+      tags: [Verified reviews]
+      operationId: createExperienceReview
+      summary: Publish one review for an eligible completed interaction
+      parameters:
+        - { name: Idempotency-Key, in: header, required: true, schema: { type: string, minLength: 8, maxLength: 160 } }
+      requestBody:
+        required: true
+        content: { application/json: { schema: { $ref: '#/components/schemas/ExperienceReviewCreate' } } }
+      responses:
+        '201':
+          description: Idempotent published verified review
+          content: { application/json: { schema: { $ref: '#/components/schemas/ExperienceReview' } } }
+        '400': { description: Invalid review payload }
+        '401': { description: Authentication required }
+        '409': { description: Interaction is ineligible, already reviewed, or the idempotency key conflicts }
+        '429': { description: Daily review limit exceeded }
+components:
+  parameters:
+    TargetKind:
+      name: targetKind
+      in: path
+      required: true
+      schema: { $ref: '#/components/schemas/ExperienceReviewTargetKind' }
+    TargetId:
+      name: targetId
+      in: path
+      required: true
+      schema: { type: string }
+  schemas:
+    ExperienceReviewTargetKind:
+      type: string
+      enum: [event, marketplace_listing, service_offering, service_package]
+    ExperienceReviewSourceKind:
+      type: string
+      enum: [event_ticket_order, marketplace_order, service_booking, service_storefront_order]
+    ExperienceReviewAuthor:
+      type: object
+      additionalProperties: false
+      required: [name]
+      properties:
+        name: { type: string }
+        avatarUrl: { type: string, format: uri, nullable: true }
+    ExperienceReview:
+      type: object
+      additionalProperties: false
+      required: [id, targetKind, targetId, rating, status, createdAt, verified, sourceKind, author]
+      properties:
+        id: { type: string, format: uuid }
+        targetKind: { $ref: '#/components/schemas/ExperienceReviewTargetKind' }
+        targetId: { type: string }
+        rating: { type: integer, minimum: 1, maximum: 5 }
+        body: { type: string, nullable: true }
+        status: { type: string, enum: [published, hidden, removed] }
+        createdAt: { type: string, format: date-time }
+        verified: { type: boolean, enum: [true] }
+        sourceKind: { $ref: '#/components/schemas/ExperienceReviewSourceKind' }
+        author: { $ref: '#/components/schemas/ExperienceReviewAuthor' }
+    PublicExperienceReview:
+      allOf:
+        - { $ref: '#/components/schemas/ExperienceReview' }
+      description: Public projection; the private source identifier is never returned.
+    ExperienceReviewSummary:
+      type: object
+      additionalProperties: false
+      required: [targetKind, targetId, count]
+      properties:
+        targetKind: { $ref: '#/components/schemas/ExperienceReviewTargetKind' }
+        targetId: { type: string }
+        average: { type: number, minimum: 1, maximum: 5, nullable: true }
+        count: { type: integer, format: int64, minimum: 0 }
+    ExperienceReviewPage:
+      type: object
+      additionalProperties: false
+      required: [summary, items]
+      properties:
+        summary: { $ref: '#/components/schemas/ExperienceReviewSummary' }
+        items: { type: array, items: { $ref: '#/components/schemas/PublicExperienceReview' } }
+        nextCursor: { type: string, format: uuid, nullable: true }
+    ExperienceReviewEligibility:
+      type: object
+      additionalProperties: false
+      required: [targetKind, targetId, targetTitle, sourceKind, sourceId, completedAt]
+      properties:
+        targetKind: { $ref: '#/components/schemas/ExperienceReviewTargetKind' }
+        targetId: { type: string }
+        targetTitle: { type: string }
+        sourceKind: { $ref: '#/components/schemas/ExperienceReviewSourceKind' }
+        sourceId: { type: string, description: Private evidence identifier; available only to the eligible account. }
+        completedAt: { type: string, format: date-time }
+    ExperienceReviewCreate:
+      type: object
+      additionalProperties: false
+      required: [targetKind, targetId, sourceKind, sourceId, rating]
+      properties:
+        targetKind: { $ref: '#/components/schemas/ExperienceReviewTargetKind' }
+        targetId: { type: string }
+        sourceKind: { $ref: '#/components/schemas/ExperienceReviewSourceKind' }
+        sourceId: { type: string }
+        rating: { type: integer, minimum: 1, maximum: 5 }
+        body: { type: string, minLength: 10, maxLength: 2000, nullable: true }

--- a/tdf-hq/docs/openapi/reviews.yaml
+++ b/tdf-hq/docs/openapi/reviews.yaml
@@ -23,6 +23,7 @@ paths:
       tags: [Verified reviews]
       operationId: listExperienceReviewEligibility
       summary: List this account's completed, not-yet-reviewed interactions
+      security: [{ bearerAuth: [] }]
       parameters:
         - { name: targetKind, in: query, schema: { $ref: '#/components/schemas/ExperienceReviewTargetKind' } }
         - { name: targetId, in: query, schema: { type: string } }
@@ -39,6 +40,7 @@ paths:
       tags: [Verified reviews]
       operationId: createExperienceReview
       summary: Publish one review for an eligible completed interaction
+      security: [{ bearerAuth: [] }]
       parameters:
         - { name: Idempotency-Key, in: header, required: true, schema: { type: string, minLength: 8, maxLength: 160 } }
       requestBody:

--- a/tdf-hq/sql/2026-08-20_verified_experience_reviews.sql
+++ b/tdf-hq/sql/2026-08-20_verified_experience_reviews.sql
@@ -1,0 +1,170 @@
+-- Verified public reviews for events, marketplace listings, and services.
+--
+-- Orders and bookings are private eligibility evidence. Public review rows keep
+-- only the target and evidence kind/id, and the API never exposes source_id.
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- The directory owns the shared abuse-control table. Keep its closed set of
+-- scopes explicit while allowing experience reviews to use the same durable
+-- daily counter as profile reviews.
+ALTER TABLE directory_rate_limit
+  DROP CONSTRAINT IF EXISTS directory_rate_limit_scope_check;
+ALTER TABLE directory_rate_limit
+  ADD CONSTRAINT directory_rate_limit_scope_check
+  CHECK (scope IN (
+    'search','profile_create','classified_publish','application','invitation',
+    'contact','report','review','experience-review'
+  ));
+
+CREATE TABLE IF NOT EXISTS experience_review (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  target_kind TEXT NOT NULL CHECK (target_kind IN (
+    'event','marketplace_listing','service_offering','service_package'
+  )),
+  target_id TEXT NOT NULL CHECK (length(btrim(target_id)) BETWEEN 1 AND 80),
+  source_kind TEXT NOT NULL CHECK (source_kind IN (
+    'event_ticket_order','marketplace_order','service_booking','service_storefront_order'
+  )),
+  source_id TEXT NOT NULL CHECK (length(btrim(source_id)) BETWEEN 1 AND 80),
+  author_party_id BIGINT NOT NULL REFERENCES party(id) ON DELETE RESTRICT,
+  rating SMALLINT NOT NULL CHECK (rating BETWEEN 1 AND 5),
+  body TEXT CHECK (
+    body IS NULL OR (
+      length(btrim(body)) BETWEEN 10 AND 2000
+      AND body !~ '[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]'
+    )
+  ),
+  status TEXT NOT NULL DEFAULT 'published'
+    CHECK (status IN ('published','hidden','removed')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (source_kind, source_id, target_kind, target_id, author_party_id)
+);
+
+CREATE INDEX IF NOT EXISTS experience_review_target_public_idx
+  ON experience_review(target_kind, target_id, created_at DESC, id DESC)
+  WHERE status = 'published';
+
+CREATE INDEX IF NOT EXISTS experience_review_author_idx
+  ON experience_review(author_party_id, created_at DESC, id DESC);
+
+CREATE OR REPLACE FUNCTION experience_review_source_is_eligible(
+  requested_target_kind TEXT,
+  requested_target_id TEXT,
+  requested_source_kind TEXT,
+  requested_source_id TEXT,
+  requested_author_party_id BIGINT
+) RETURNS BOOLEAN
+LANGUAGE plpgsql
+STABLE
+AS $$
+BEGIN
+  CASE requested_target_kind
+    WHEN 'event' THEN
+      RETURN requested_source_kind = 'event_ticket_order' AND EXISTS (
+        SELECT 1
+        FROM event_ticket_order orders
+        JOIN social_event event ON event.id = orders.event_id
+        LEFT JOIN event_ticket_checkout_runtime runtime ON runtime.order_id = orders.id
+        WHERE orders.id::text = requested_source_id
+          AND orders.event_id::text = requested_target_id
+          AND orders.buyer_party_id = requested_author_party_id
+          AND COALESCE(event.end_time, event.start_time) <= NOW()
+          AND (
+            (runtime.payment_status IN ('paid','partially_refunded')
+              AND runtime.fulfillment_status IN ('issued','transferred','checked_in'))
+            OR (runtime.order_id IS NULL AND lower(orders.status) IN ('paid','completed','fulfilled'))
+          )
+      );
+
+    WHEN 'marketplace_listing' THEN
+      RETURN requested_source_kind = 'marketplace_order' AND EXISTS (
+        SELECT 1
+        FROM marketplace_order orders
+        JOIN marketplace_order_item item ON item.order_id = orders.id
+        JOIN party author ON author.id = requested_author_party_id
+        LEFT JOIN marketplace_sale_order_runtime sale ON sale.order_id = orders.id
+        LEFT JOIN marketplace_rental_order_runtime rental ON rental.order_id = orders.id
+        WHERE orders.id::text = requested_source_id
+          AND item.listing_id::text = requested_target_id
+          AND author.primary_email IS NOT NULL
+          AND lower(btrim(orders.buyer_email)) = lower(btrim(author.primary_email))
+          AND (
+            sale.fulfillment_status IN ('delivered','closed')
+            OR rental.rental_status = 'closed'
+          )
+      );
+
+    WHEN 'service_offering' THEN
+      RETURN requested_source_kind = 'service_booking' AND EXISTS (
+        SELECT 1
+        FROM booking booking
+        LEFT JOIN service_booking_checkout_runtime runtime
+          ON runtime.booking_id = booking.id
+        WHERE booking.id::text = requested_source_id
+          AND booking.party_id = requested_author_party_id
+          AND booking.service_offering_id::text = requested_target_id
+          AND (
+            runtime.fulfillment_status = 'completed'
+            OR (runtime.booking_id IS NULL AND lower(booking.status::text) = 'completed')
+          )
+      );
+
+    WHEN 'service_package' THEN
+      RETURN requested_source_kind = 'service_storefront_order' AND EXISTS (
+        SELECT 1
+        FROM service_storefront_order orders
+        JOIN party author ON author.id = requested_author_party_id
+        WHERE orders.id::text = requested_source_id
+          AND orders.package_id::text = requested_target_id
+          AND orders.status = 'completed'
+          AND author.primary_email IS NOT NULL
+          AND lower(btrim(orders.buyer_email)) = lower(btrim(author.primary_email))
+      );
+
+    ELSE
+      RETURN FALSE;
+  END CASE;
+END $$;
+
+CREATE OR REPLACE FUNCTION experience_review_validate_write()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'UPDATE' THEN
+    IF ROW(
+      NEW.target_kind, NEW.target_id, NEW.source_kind, NEW.source_id,
+      NEW.author_party_id, NEW.rating, NEW.body, NEW.created_at
+    ) IS DISTINCT FROM ROW(
+      OLD.target_kind, OLD.target_id, OLD.source_kind, OLD.source_id,
+      OLD.author_party_id, OLD.rating, OLD.body, OLD.created_at
+    ) THEN
+      RAISE EXCEPTION 'Published review evidence and content are immutable';
+    END IF;
+    NEW.updated_at := NOW();
+    RETURN NEW;
+  END IF;
+
+  IF NOT experience_review_source_is_eligible(
+    NEW.target_kind, NEW.target_id, NEW.source_kind, NEW.source_id, NEW.author_party_id
+  ) THEN
+    RAISE EXCEPTION 'Review requires an eligible completed interaction';
+  END IF;
+
+  RETURN NEW;
+END $$;
+
+DROP TRIGGER IF EXISTS trg_experience_review_validate_write ON experience_review;
+CREATE TRIGGER trg_experience_review_validate_write
+  BEFORE INSERT OR UPDATE ON experience_review
+  FOR EACH ROW EXECUTE FUNCTION experience_review_validate_write();
+
+COMMENT ON TABLE experience_review IS
+  'Public reviews backed by a private completed ticket order, marketplace order, service booking, or storefront order.';
+COMMENT ON COLUMN experience_review.source_id IS
+  'Private eligibility evidence; never include in public API responses.';
+
+COMMIT;

--- a/tdf-hq/sql/2026-08-20_verified_experience_reviews_rollback.sql
+++ b/tdf-hq/sql/2026-08-20_verified_experience_reviews_rollback.sql
@@ -1,0 +1,14 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+DROP TRIGGER IF EXISTS trg_experience_review_validate_write ON experience_review;
+DROP FUNCTION IF EXISTS experience_review_validate_write();
+DROP FUNCTION IF EXISTS experience_review_source_is_eligible(TEXT, TEXT, TEXT, TEXT, BIGINT);
+DROP TABLE IF EXISTS experience_review;
+
+-- `experience-review` is intentionally retained in the shared scope enum.
+-- Existing abuse-control rows remain valid and auditable after application
+-- rollback, matching the directory review rollback policy.
+
+COMMIT;

--- a/tdf-hq/src/TDF/API.hs
+++ b/tdf-hq/src/TDF/API.hs
@@ -69,6 +69,7 @@ import           TDF.API.Catalog (CatalogAPI, PublicCatalogAPI, SecurityGrantRev
 import           TDF.API.ServiceStorefront (ServiceStorefrontPublicAPI, ServiceStorefrontAdminAPI)
 import           TDF.API.CommerceOperations (CommerceOperationsAPI)
 import           TDF.API.Directory (DirectoryPublicAPI, DirectoryProtectedAPI)
+import           TDF.API.Reviews (ReviewsPublicAPI, ReviewsProtectedAPI)
 import           TDF.Operations.API (OperationsAPI)
 
 type InventoryItem = ME.Asset
@@ -602,6 +603,7 @@ type ProtectedAPI =
   :<|> DirectoryProtectedAPI
   :<|> OperationsAPI
   :<|> CommerceOperationsAPI
+  :<|> ReviewsProtectedAPI
 
 type API =
        VersionAPI
@@ -634,6 +636,7 @@ type API =
   :<|> PublicCatalogAPI
   :<|> DirectoryPublicAPI
   :<|> PublicUpcomingEventsAPI
+  :<|> ReviewsPublicAPI
   -- Keep the authenticated marketplace branch ahead of the public one so
   -- /marketplace/orders is not consumed by the public /marketplace/:id capture.
   :<|> AuthProtect "bearer-token" :> ProtectedAPI

--- a/tdf-hq/src/TDF/API/Directory.hs
+++ b/tdf-hq/src/TDF/API/Directory.hs
@@ -281,6 +281,7 @@ type DirectoryPublicAPI = "directory" :>
     :<|> "suggestions" :> QueryParam "q" Text :> QueryParam "cityId" UUID :> Get '[JSON] [DirectorySuggestion]
     :<|> "taxonomies" :> QueryParam "locale" Text :> Get '[JSON] Value
     :<|> "profiles" :> Capture "slug" Text :> Get '[JSON] Value
+    :<|> "party-profiles" :> Capture "partyId" Int64 :> Get '[JSON] Value
     :<|> "profiles" :> Capture "slug" Text :> "reviews" :> QueryParam "cursor" UUID :> QueryParam "limit" Int :> Get '[JSON] DirectoryReviewPage
     :<|> "classifieds" :> Capture "slug" Text :> Get '[JSON] Value
     :<|> "events" :> Capture "eventId" Int64 :> Get '[JSON] Value

--- a/tdf-hq/src/TDF/API/Reviews.hs
+++ b/tdf-hq/src/TDF/API/Reviews.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeOperators #-}
+
+module TDF.API.Reviews where
+
+import Data.Aeson (FromJSON, ToJSON, Value)
+import Data.Text (Text)
+import Data.UUID (UUID)
+import GHC.Generics (Generic)
+import Servant
+
+data ExperienceReviewPage = ExperienceReviewPage
+  { summary :: Value
+  , items :: [Value]
+  , nextCursor :: Maybe UUID
+  } deriving (Show, Generic)
+
+instance ToJSON ExperienceReviewPage
+
+data ExperienceReviewCreateRequest = ExperienceReviewCreateRequest
+  { targetKind :: Text
+  , targetId :: Text
+  , sourceKind :: Text
+  , sourceId :: Text
+  , rating :: Int
+  , body :: Maybe Text
+  } deriving (Show, Generic)
+
+instance FromJSON ExperienceReviewCreateRequest
+instance ToJSON ExperienceReviewCreateRequest
+
+type RequiredReviewIdempotency =
+  Header' '[Required, Strict] "Idempotency-Key" Text
+
+type ReviewsPublicAPI =
+  "reviews"
+    :> Capture "targetKind" Text
+    :> Capture "targetId" Text
+    :> QueryParam "cursor" UUID
+    :> QueryParam "limit" Int
+    :> Get '[JSON] ExperienceReviewPage
+
+type ReviewsProtectedAPI = "reviews" :>
+       ( "eligibility"
+           :> QueryParam "targetKind" Text
+           :> QueryParam "targetId" Text
+           :> Get '[JSON] [Value]
+    :<|> RequiredReviewIdempotency
+           :> ReqBody '[JSON] ExperienceReviewCreateRequest
+           :> PostCreated '[JSON] Value
+       )

--- a/tdf-hq/src/TDF/Server.hs
+++ b/tdf-hq/src/TDF/Server.hs
@@ -188,6 +188,7 @@ import qualified TDF.Commerce.MarketplaceRentals as MarketplaceRentals
 import qualified TDF.Commerce.MarketplaceOperations as MarketplaceOperations
 import qualified TDF.Commerce.ServiceBookings as ServiceBookings
 import qualified TDF.Server.Directory as DirectoryServer
+import qualified TDF.Server.Reviews as ReviewsServer
 import           TDF.ServerFeedback (feedbackServer)
 import qualified TDF.Contracts.Server as Contracts
 import           TDF.ServerProposals (proposalsServer)
@@ -736,6 +737,7 @@ server env =
   :<|> CatalogServer.publicCatalogServer
   :<|> DirectoryServer.directoryPublicServer
   :<|> publicUpcomingEventsServer
+  :<|> ReviewsServer.reviewsPublicServer
   :<|> protectedServer
   :<|> marketplacePublicServer
   :<|> radioPresencePublicServer
@@ -3793,6 +3795,7 @@ protectedServer user =
   :<|> DirectoryServer.directoryProtectedServer user
   :<|> OperationsServer.operationsServer user
   :<|> CommerceOperationsServer.commerceOperationsServer user
+  :<|> ReviewsServer.reviewsProtectedServer user
 
 navigationPreferencesServer :: AuthedUser -> ServerT NavigationPreferencesAPI AppM
 navigationPreferencesServer user =

--- a/tdf-hq/src/TDF/Server/Directory.hs
+++ b/tdf-hq/src/TDF/Server/Directory.hs
@@ -80,6 +80,7 @@ directoryPublicServer =
   :<|> suggestDirectory
   :<|> directoryTaxonomies
   :<|> publicProfile
+  :<|> publicProfileByParty
   :<|> publicProfileReviews
   :<|> publicClassified
   :<|> publicEvent
@@ -280,6 +281,22 @@ publicProfile slugValue =
    <> "'reputation',jsonb_build_object('completeness',profile.completeness_score,'responseRate',profile.response_rate,'medianResponseMinutes',profile.median_response_minutes,'completed',profile.completed_interactions,'reviewAverage',profile.review_average,'reviewCount',profile.review_count),"
    <> "'canonicalUrl','/directorio/'||profile.slug) FROM directory_public_profile_resolution profile WHERE profile.requested_slug=?" )
     [PersistText (T.toLower (T.strip slugValue))]
+
+-- Artist detail already exposes its Party identifier. This resolver only
+-- returns the same safe public profile projection as the slug route and never
+-- adds the Party identifier to that projection.
+publicProfileByParty :: Int64 -> AppM Value
+publicProfileByParty partyId = do
+  canonicalSlug <- jsonOne err404
+    ( "SELECT to_jsonb(resolved.slug) FROM directory_profile source "
+   <> "JOIN directory_public_profile_resolution resolved "
+   <> "ON resolved.requested_slug=source.slug "
+   <> "WHERE source.subject_party_id=? "
+   <> "ORDER BY (source.id=resolved.id) DESC,source.updated_at DESC,source.id LIMIT 1" )
+    [PersistInt64 partyId]
+  case canonicalSlug of
+    String slugValue -> publicProfile slugValue
+    _ -> throwError err500
 
 publicProfileReviews slugValue mCursor mLimit = do
   let limit = min 50 (max 1 (fromMaybe 20 mLimit))
@@ -1209,8 +1226,9 @@ applyModerationTarget (Object values) action = case (KeyMap.lookup "kind" values
   (Just (String "classified"),Just (String targetId)) | action `elem` ["pause","remove"] -> do
     rawExecute "UPDATE classified SET status=CASE WHEN ?='pause' THEN 'paused' ELSE 'moderated' END,moderation_status=CASE WHEN ?='pause' THEN moderation_status ELSE 'blocked' END,updated_at=now() WHERE id::text=?" [PersistText action,PersistText action,PersistText targetId]
     rawExecute "DELETE FROM directory_search_document WHERE entity_kind='classified' AND entity_id=?" [PersistText targetId]
-  (Just (String "review"),Just (String targetId)) | action `elem` ["pause","remove"] ->
+  (Just (String "review"),Just (String targetId)) | action `elem` ["pause","remove"] -> do
     rawExecute "UPDATE directory_review SET status=CASE WHEN ?='pause' THEN 'hidden' ELSE 'removed' END,updated_at=now() WHERE id::text=?" [PersistText action,PersistText targetId]
+    rawExecute "UPDATE experience_review SET status=CASE WHEN ?='pause' THEN 'hidden' ELSE 'removed' END,updated_at=now() WHERE id::text=?" [PersistText action,PersistText targetId]
   _ -> pure ()
 applyModerationTarget _ _ = pure ()
 

--- a/tdf-hq/src/TDF/Server/Reviews.hs
+++ b/tdf-hq/src/TDF/Server/Reviews.hs
@@ -1,0 +1,348 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module TDF.Server.Reviews
+  ( reviewsPublicServer
+  , reviewsProtectedServer
+  ) where
+
+import Control.Monad (unless, when)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Reader (ReaderT, asks)
+import Crypto.Hash (Digest, SHA256, hash)
+import Data.Aeson (ToJSON, Value(..), encode, object, (.=))
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy as BL
+import Data.Char (isControl)
+import Data.Maybe (fromMaybe, listToMaybe)
+import Data.Text (Text)
+import qualified Data.Text as T
+import Data.UUID (UUID)
+import qualified Data.UUID as UUID
+import Data.UUID.V4 (nextRandom)
+import Database.Persist (PersistValue(..), toPersistValue)
+import Database.Persist.Sql
+  (Single(..), SqlPersistT, fromSqlKey, rawExecute, rawSql, runSqlPool)
+import Servant
+import Text.Read (readMaybe)
+
+import TDF.API.Reviews
+import TDF.Auth (AuthedUser(..))
+import qualified TDF.CMS.Models as CMS
+import TDF.DB (Env(..))
+import TDF.Server.SocialEventsHandlers (postgresVisibleImportedMetadataClause)
+
+type AppM = ReaderT Env Handler
+
+runDB :: SqlPersistT IO a -> AppM a
+runDB action = do
+  pool <- asks envPool
+  liftIO (runSqlPool action pool)
+
+jsonRows :: Text -> [PersistValue] -> AppM [Value]
+jsonRows statement params = do
+  rows <- runDB (rawSql statement params :: SqlPersistT IO [Single CMS.AesonValue])
+  pure [CMS.unAesonValue value | Single value <- rows]
+
+reviewsPublicServer :: ServerT ReviewsPublicAPI AppM
+reviewsPublicServer = listPublicReviews
+
+reviewsProtectedServer :: AuthedUser -> ServerT ReviewsProtectedAPI AppM
+reviewsProtectedServer user =
+       listReviewEligibility user
+  :<|> createReview user
+
+listPublicReviews :: Text -> Text -> Maybe UUID -> Maybe Int -> AppM ExperienceReviewPage
+listPublicReviews rawTargetKind rawTargetId cursor requestedLimit = do
+  (targetKind, targetId) <- validateTarget rawTargetKind rawTargetId
+  ensurePublicTarget targetKind targetId
+  let limit = min 50 (max 1 (fromMaybe 20 requestedLimit))
+  summaryRows <- jsonRows
+    ( "SELECT jsonb_build_object('targetKind',?::text,'targetId',?::text,"
+   <> "'average',round(avg(rating)::numeric,2),'count',count(*)::bigint) "
+   <> "FROM experience_review WHERE target_kind=? AND target_id=? AND status='published'" )
+    [PersistText targetKind, PersistText targetId, PersistText targetKind, PersistText targetId]
+  rows <- jsonRows publicReviewPageSql
+    [ PersistText targetKind, PersistText targetId
+    , maybe PersistNull toPersistValue cursor
+    , PersistInt64 (fromIntegral (limit + 1))
+    ]
+  let visible = take limit rows
+      next = if length rows > limit then visibleReviewId (last visible) else Nothing
+  pure ExperienceReviewPage
+    { summary = fromMaybe (object ["targetKind" .= targetKind, "targetId" .= targetId, "average" .= Null, "count" .= (0 :: Int)]) (listToMaybe summaryRows)
+    , items = visible
+    , nextCursor = next
+    }
+
+publicReviewPageSql :: Text
+publicReviewPageSql =
+  "WITH requested AS (SELECT ?::text target_kind,?::text target_id,?::uuid cursor), " <>
+  "boundary AS (SELECT review.created_at,review.id FROM experience_review review,requested " <>
+  "WHERE review.id=requested.cursor AND review.target_kind=requested.target_kind " <>
+  "AND review.target_id=requested.target_id), " <>
+  "page AS (SELECT review.* FROM experience_review review,requested " <>
+  "WHERE review.target_kind=requested.target_kind AND review.target_id=requested.target_id " <>
+  "AND review.status='published' AND (NOT EXISTS (SELECT 1 FROM boundary) OR EXISTS " <>
+  "(SELECT 1 FROM boundary WHERE review.created_at<boundary.created_at OR " <>
+  "(review.created_at=boundary.created_at AND review.id<boundary.id))) " <>
+  "ORDER BY review.created_at DESC,review.id DESC LIMIT ?) " <>
+  "SELECT jsonb_build_object('id',page.id,'targetKind',page.target_kind,'targetId',page.target_id," <>
+  "'rating',page.rating,'body',page.body,'status',page.status," <>
+  "'createdAt',page.created_at,'verified',TRUE," <>
+  "'sourceKind',page.source_kind,'author',jsonb_build_object(" <>
+  "'name',author.display_name,'avatarUrl',fan.avatar_url)) " <>
+  "FROM page JOIN party author ON author.id=page.author_party_id " <>
+  "LEFT JOIN fan_profile fan ON fan.fan_party_id=author.id " <>
+  "ORDER BY page.created_at DESC,page.id DESC"
+
+visibleReviewId :: Value -> Maybe UUID
+visibleReviewId (Object values) = case KeyMap.lookup "id" values of
+  Just (String value) -> UUID.fromText value
+  _ -> Nothing
+visibleReviewId _ = Nothing
+
+ensurePublicTarget :: Text -> Text -> AppM ()
+ensurePublicTarget targetKind targetId = do
+  rows <- jsonRows statement [PersistText targetId]
+  when (null rows) (throwError err404 {errBody = "review target not found"})
+  where
+    statement = case targetKind of
+      "event" ->
+        ( "SELECT to_jsonb(TRUE) FROM social_event event WHERE event.id::text=? AND ("
+       <> "NOT EXISTS (SELECT 1 FROM external_event_ref source WHERE source.event_id=event.id) OR "
+       <> postgresVisibleImportedMetadataClause "event.metadata"
+       <> ")" )
+      "marketplace_listing" -> "SELECT to_jsonb(TRUE) FROM marketplace_listing WHERE id::text=?"
+      "service_offering" ->
+        "SELECT to_jsonb(TRUE) FROM service_offering WHERE id::text=?"
+      "service_package" ->
+        "SELECT to_jsonb(TRUE) FROM service_storefront_package WHERE id::text=?"
+      _ -> "SELECT to_jsonb(FALSE) WHERE FALSE"
+
+listReviewEligibility :: AuthedUser -> Maybe Text -> Maybe Text -> AppM [Value]
+listReviewEligibility user rawTargetKind rawTargetId = do
+  (targetKind, targetId) <- validateEligibilityFilter rawTargetKind rawTargetId
+  jsonRows eligibilitySql (eligibilityParams user targetKind targetId)
+
+eligibilitySql :: Text
+eligibilitySql =
+  "WITH candidates AS (" <>
+  "SELECT 'event'::text target_kind,event.id::text target_id,event.title target_title," <>
+  "'event_ticket_order'::text source_kind,orders.id::text source_id," <>
+  "coalesce(event.end_time,event.start_time) completed_at " <>
+  "FROM event_ticket_order orders JOIN social_event event ON event.id=orders.event_id " <>
+  "WHERE orders.buyer_party_id=?::bigint AND experience_review_source_is_eligible(" <>
+  "'event',event.id::text,'event_ticket_order',orders.id::text,?::bigint) " <>
+  "UNION ALL " <>
+  "SELECT 'marketplace_listing',listing.id::text,listing.title,'marketplace_order',orders.id::text," <>
+  "coalesce(sale.delivered_at,rental.returned_at,sale.updated_at,rental.updated_at,orders.updated_at) " <>
+  "FROM marketplace_order orders JOIN marketplace_order_item item ON item.order_id=orders.id " <>
+  "JOIN marketplace_listing listing ON listing.id=item.listing_id " <>
+  "LEFT JOIN marketplace_sale_order_runtime sale ON sale.order_id=orders.id " <>
+  "LEFT JOIN marketplace_rental_order_runtime rental ON rental.order_id=orders.id " <>
+  "WHERE experience_review_source_is_eligible('marketplace_listing',listing.id::text," <>
+  "'marketplace_order',orders.id::text,?::bigint) " <>
+  "UNION ALL " <>
+  "SELECT 'service_offering',offering.id::text,offering.name_es,'service_booking',booking.id::text," <>
+  "coalesce(runtime.completed_at,booking.ends_at) " <>
+  "FROM booking booking JOIN service_offering offering ON offering.id=booking.service_offering_id " <>
+  "LEFT JOIN service_booking_checkout_runtime runtime ON runtime.booking_id=booking.id " <>
+  "WHERE booking.party_id=?::bigint AND experience_review_source_is_eligible(" <>
+  "'service_offering',offering.id::text,'service_booking',booking.id::text,?::bigint) " <>
+  "UNION ALL " <>
+  "SELECT 'service_package',package.id::text,package.name,'service_storefront_order',orders.id::text," <>
+  "orders.updated_at FROM service_storefront_order orders " <>
+  "JOIN service_storefront_package package ON package.id=orders.package_id " <>
+  "WHERE experience_review_source_is_eligible('service_package',package.id::text," <>
+  "'service_storefront_order',orders.id::text,?::bigint)), " <>
+  "requested AS (SELECT ?::text target_kind,?::text target_id) " <>
+  "SELECT jsonb_build_object('targetKind',candidate.target_kind,'targetId',candidate.target_id," <>
+  "'targetTitle',candidate.target_title,'sourceKind',candidate.source_kind," <>
+  "'sourceId',candidate.source_id,'completedAt',candidate.completed_at) " <>
+  "FROM candidates candidate CROSS JOIN requested WHERE " <>
+  "(requested.target_kind IS NULL OR candidate.target_kind=requested.target_kind) AND " <>
+  "(requested.target_id IS NULL OR candidate.target_id=requested.target_id) AND NOT EXISTS (" <>
+  "SELECT 1 FROM experience_review review WHERE review.source_kind=candidate.source_kind " <>
+  "AND review.source_id=candidate.source_id AND review.target_kind=candidate.target_kind " <>
+  "AND review.target_id=candidate.target_id AND review.author_party_id=?::bigint) " <>
+  "ORDER BY candidate.completed_at DESC,candidate.target_kind,candidate.target_id,candidate.source_id"
+
+-- The eligibility query uses the authenticated party in each source branch,
+-- then repeats it for the final duplicate guard. Keeping the placeholders
+-- explicit makes accidental cross-account broadening visible in review.
+eligibilityParams :: AuthedUser -> Maybe Text -> Maybe Text -> [PersistValue]
+eligibilityParams user targetKind targetId =
+  replicate 6 (toPersistValue (auPartyId user)) <>
+  [maybe PersistNull PersistText targetKind, maybe PersistNull PersistText targetId, toPersistValue (auPartyId user)]
+
+createReview :: AuthedUser -> Text -> ExperienceReviewCreateRequest -> AppM Value
+createReview user idempotency request@ExperienceReviewCreateRequest
+  { targetKind = rawTargetKind
+  , targetId = rawTargetId
+  , sourceKind = rawSourceKind
+  , sourceId = rawSourceId
+  , rating
+  , body
+  } = do
+  (targetKind, targetId) <- validateTarget rawTargetKind rawTargetId
+  (sourceKind, sourceId) <- validateSource targetKind rawSourceKind rawSourceId
+  when (rating < 1 || rating > 5) $
+    throwError err400 {errBody = "rating must be between 1 and 5"}
+  validateReviewBody body
+  reviewId <- reserveIdempotency user idempotency request
+  prior <- reviewById reviewId
+  case prior of
+    Just value -> pure value
+    Nothing -> do
+      eligible <- runDB
+        (rawSql
+          "SELECT experience_review_source_is_eligible(?,?,?,?,?)"
+          [ PersistText targetKind, PersistText targetId, PersistText sourceKind
+          , PersistText sourceId, toPersistValue (auPartyId user)
+          ] :: SqlPersistT IO [Single Bool])
+      unless (eligible == [Single True]) $
+        throwError err409 {errBody = "review requires an eligible completed interaction owned by this account"}
+      consumeRate user
+      runDB $ rawExecute
+        ( "INSERT INTO experience_review(id,target_kind,target_id,source_kind,source_id,"
+       <> "author_party_id,rating,body,status) VALUES (?,?,?,?,?,?,?,?,'published') "
+       <> "ON CONFLICT(source_kind,source_id,target_kind,target_id,author_party_id) DO NOTHING" )
+        [ toPersistValue reviewId, PersistText targetKind, PersistText targetId
+        , PersistText sourceKind, PersistText sourceId, toPersistValue (auPartyId user)
+        , PersistInt64 (fromIntegral rating), maybe PersistNull (PersistText . T.strip) body
+        ]
+      created <- reviewById reviewId
+      maybe
+        (throwError err409 {errBody = "this completed interaction has already been reviewed"})
+        pure
+        created
+
+reviewById :: UUID -> AppM (Maybe Value)
+reviewById reviewId = listToMaybe <$> jsonRows
+  ( "SELECT jsonb_build_object('id',review.id,'targetKind',review.target_kind,"
+ <> "'targetId',review.target_id,'rating',review.rating,'body',review.body,"
+ <> "'status',review.status,'createdAt',review.created_at,'verified',TRUE,"
+ <> "'sourceKind',review.source_kind,'author',jsonb_build_object("
+ <> "'name',author.display_name,'avatarUrl',fan.avatar_url)) "
+ <> "FROM experience_review review JOIN party author ON author.id=review.author_party_id "
+ <> "LEFT JOIN fan_profile fan ON fan.fan_party_id=author.id WHERE review.id=?" )
+  [toPersistValue reviewId]
+
+reserveIdempotency
+  :: ToJSON request
+  => AuthedUser
+  -> Text
+  -> request
+  -> AppM UUID
+reserveIdempotency user key request = do
+  when (T.length key < 8 || T.length key > 160 || T.any isControl key) $
+    throwError err400 {errBody = "Idempotency-Key must contain 8-160 safe characters"}
+  let fingerprint = requestFingerprint request
+  candidateId <- liftIO nextRandom
+  runDB $ rawExecute
+    ( "INSERT INTO directory_idempotency(actor_party_id,operation,idempotency_key,"
+   <> "request_fingerprint,resource_kind,resource_id,expires_at) "
+   <> "VALUES (?,'experience-review.create',?,?, 'experience_review',?,now()+interval '24 hours') "
+   <> "ON CONFLICT(actor_party_id,operation,idempotency_key) DO UPDATE SET "
+   <> "request_fingerprint=EXCLUDED.request_fingerprint,resource_kind=EXCLUDED.resource_kind,"
+   <> "resource_id=EXCLUDED.resource_id,created_at=now(),expires_at=EXCLUDED.expires_at "
+   <> "WHERE directory_idempotency.expires_at<=now()" )
+    [ toPersistValue (auPartyId user), PersistText key, PersistText fingerprint
+    , PersistText (UUID.toText candidateId)
+    ]
+  stored <- jsonRows
+    ( "SELECT jsonb_build_object('fingerprint',request_fingerprint,'resourceId',resource_id) "
+   <> "FROM directory_idempotency WHERE actor_party_id=? "
+   <> "AND operation='experience-review.create' AND idempotency_key=?" )
+    [toPersistValue (auPartyId user), PersistText key]
+  case listToMaybe stored of
+    Just (Object values) ->
+      case (KeyMap.lookup "fingerprint" values, KeyMap.lookup "resourceId" values) of
+        (Just (String previous), Just (String resourceId)) | previous == fingerprint ->
+          maybe (throwError err500) pure (UUID.fromText resourceId)
+        _ -> throwError err409 {errBody = "Idempotency-Key was already used with a different request"}
+    _ -> throwError err500
+
+requestFingerprint :: ToJSON request => request -> Text
+requestFingerprint request =
+  T.pack (show (hash (BL.toStrict (encode request)) :: Digest SHA256))
+
+consumeRate :: AuthedUser -> AppM ()
+consumeRate user = do
+  allowed <- runDB
+    (rawSql
+      ( "WITH current AS (INSERT INTO directory_rate_limit("
+     <> "scope,subject_hash,window_started_at,count,updated_at) VALUES ("
+     <> "'experience-review',encode(digest(?::text,'sha256'),'hex'),date_trunc('day',now()),1,now()) "
+     <> "ON CONFLICT(scope,subject_hash,window_started_at) DO UPDATE SET "
+     <> "count=directory_rate_limit.count+1,updated_at=now() RETURNING count) "
+     <> "SELECT count<=10 FROM current" )
+      [PersistText (T.pack (show (fromSqlParty user)))] :: SqlPersistT IO [Single Bool])
+  unless (allowed == [Single True]) $
+    throwError err429 {errBody = "review rate limit exceeded"}
+
+fromSqlParty :: AuthedUser -> Integer
+fromSqlParty = fromIntegral . fromSqlKey . auPartyId
+
+validateEligibilityFilter :: Maybe Text -> Maybe Text -> AppM (Maybe Text, Maybe Text)
+validateEligibilityFilter Nothing Nothing = pure (Nothing, Nothing)
+validateEligibilityFilter Nothing (Just _) =
+  throwError err400 {errBody = "targetId requires targetKind"}
+validateEligibilityFilter (Just kind) Nothing = do
+  normalized <- validateTargetKind kind
+  pure (Just normalized, Nothing)
+validateEligibilityFilter (Just kind) (Just identifier) = do
+  (normalizedKind, normalizedId) <- validateTarget kind identifier
+  pure (Just normalizedKind, Just normalizedId)
+
+validateTarget :: Text -> Text -> AppM (Text, Text)
+validateTarget rawKind rawId = do
+  targetKind <- validateTargetKind rawKind
+  let targetId = T.strip rawId
+  validateIdentifier (targetIdType targetKind) "targetId" targetId
+  pure (targetKind, targetId)
+
+validateTargetKind :: Text -> AppM Text
+validateTargetKind rawKind = do
+  let targetKind = T.toLower (T.strip rawKind)
+  unless (targetKind `elem` ["event","marketplace_listing","service_offering","service_package"]) $
+    throwError err400 {errBody = "unsupported review targetKind"}
+  pure targetKind
+
+validateSource :: Text -> Text -> Text -> AppM (Text, Text)
+validateSource targetKind rawKind rawId = do
+  let sourceKind = T.toLower (T.strip rawKind)
+      sourceId = T.strip rawId
+      expected = case targetKind of
+        "event" -> ("event_ticket_order", DecimalId)
+        "marketplace_listing" -> ("marketplace_order", UuidId)
+        "service_offering" -> ("service_booking", DecimalId)
+        "service_package" -> ("service_storefront_order", UuidId)
+        _ -> ("", UuidId)
+  unless (sourceKind == fst expected) $
+    throwError err400 {errBody = "sourceKind does not match targetKind"}
+  validateIdentifier (snd expected) "sourceId" sourceId
+  pure (sourceKind, sourceId)
+
+data IdentifierType = DecimalId | UuidId
+
+targetIdType :: Text -> IdentifierType
+targetIdType "event" = DecimalId
+targetIdType _ = UuidId
+
+validateIdentifier :: IdentifierType -> BL.ByteString -> Text -> AppM ()
+validateIdentifier identifierType field value =
+  unless valid (throwError err400 {errBody = field <> " is invalid"})
+  where
+    valid = case identifierType of
+      UuidId -> maybe False (const True) (UUID.fromText value)
+      DecimalId -> maybe False (> (0 :: Integer)) (readMaybe (T.unpack value))
+
+validateReviewBody :: Maybe Text -> AppM ()
+validateReviewBody Nothing = pure ()
+validateReviewBody (Just value) =
+  when (T.length (T.strip value) < 10 || T.length value > 2000 || T.any unsafeControl value) $
+    throwError err400 {errBody = "review body must contain 10-2000 safe characters"}
+  where
+    unsafeControl character = isControl character && character `notElem` ['\n','\r','\t']

--- a/tdf-hq/tdf-hq.cabal
+++ b/tdf-hq/tdf-hq.cabal
@@ -46,6 +46,7 @@ executable tdf-hq-exe
     TDF.API.WhatsApp
     TDF.API.DDEX
     TDF.API.Directory
+    TDF.API.Reviews
     TDF.API.Catalog
     TDF.API.ServiceStorefront
     TDF.API.ServiceStorefrontTypes
@@ -123,6 +124,7 @@ executable tdf-hq-exe
     TDF.Server.EventResearch
     TDF.Server.DDEX
     TDF.Server.Directory
+    TDF.Server.Reviews
     TDF.Server.Catalog
     TDF.Server.ServiceStorefront
     TDF.ServerLiveSessions


### PR DESCRIPTION
## Summary

- add verified, immutable reviews backed by completed tickets, marketplace orders, bookings, and service orders
- expose public aggregates and cursor pagination while keeping eligibility evidence private
- integrate review composition, display, reporting, and moderation across web surfaces
- update the mobile submodule to diegueins680/TDF-mobile#25

## Validation

- backend executable and full test-suite compilation passed
- web typecheck and 8 targeted tests passed
- production release contract passed 43/43 tests
- migration eligibility, integrity, retry, and rollback rehearsal passed
- targeted mobile ESLint passed