### PR TITLE
fix(events): paginate public upcoming filters

### DIFF
--- a/tdf-hq-ui/src/api/client.test.ts
+++ b/tdf-hq-ui/src/api/client.test.ts
@@ -129,6 +129,21 @@ describe('api client', () => {
     expect(getPendingApiRequestCount()).toBe(0);
   });
 
+  it('propagates caller cancellation without converting it into a timeout', async () => {
+    fetchMock.mockImplementationOnce((_path, init) => new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener('abort', () => {
+        reject(new DOMException('Request cancelled', 'AbortError'));
+      }, { once: true });
+    }));
+    const controller = new AbortController();
+
+    const request = get('/superseded-search', { signal: controller.signal });
+    controller.abort();
+
+    await expect(request).rejects.toMatchObject({ name: 'AbortError' });
+    expect(getPendingApiRequestCount()).toBe(0);
+  });
+
   it('parses JSON when successful responses include a payload', async () => {
     fetchMock.mockResolvedValueOnce(buildResponse({ body: '{"ok":true,"version":"1.0"}' }));
 

--- a/tdf-hq-ui/src/api/client.ts
+++ b/tdf-hq-ui/src/api/client.ts
@@ -131,6 +131,13 @@ async function api<T>(path: string, init: RequestInit = {}): Promise<T> {
 
     let res: Response;
     const controller = new AbortController();
+    const callerSignal = init.signal;
+    const abortForCaller = () => controller.abort();
+    if (callerSignal?.aborted) {
+      controller.abort();
+    } else {
+      callerSignal?.addEventListener('abort', abortForCaller, { once: true });
+    }
     const timeoutId = setTimeout(() => controller.abort(), 30_000);
 
     try {
@@ -141,7 +148,10 @@ async function api<T>(path: string, init: RequestInit = {}): Promise<T> {
         signal: controller.signal,
       });
     } catch (err) {
-      if (err instanceof DOMException && err.name === 'AbortError') {
+      if (callerSignal?.aborted) {
+        throw err;
+      }
+      if (controller.signal.aborted || (err instanceof DOMException && err.name === 'AbortError')) {
         throw new ApiError(
           'La solicitud tardó demasiado. Verifica tu conexión e inténtalo de nuevo.',
           HTTP_STATUS_REQUEST_TIMEOUT,
@@ -150,6 +160,7 @@ async function api<T>(path: string, init: RequestInit = {}): Promise<T> {
       throw normalizeNetworkError(err);
     } finally {
       clearTimeout(timeoutId);
+      callerSignal?.removeEventListener('abort', abortForCaller);
     }
 
     if (!res.ok) {

--- a/tdf-hq-ui/src/api/socialEvents.test.ts
+++ b/tdf-hq-ui/src/api/socialEvents.test.ts
@@ -1,6 +1,6 @@
 import { jest } from '@jest/globals';
 
-const getMock = jest.fn<(path: string) => Promise<unknown>>();
+const getMock = jest.fn<(path: string, init?: RequestInit) => Promise<unknown>>();
 const postMock = jest.fn<(path: string, body: unknown) => Promise<unknown>>();
 const postFormMock = jest.fn<(path: string, body: FormData) => Promise<unknown>>();
 const putMock = jest.fn<(path: string, body: unknown) => Promise<unknown>>();
@@ -70,6 +70,22 @@ describe('SocialEventsAPI', () => {
     });
 
     expect(getMock).toHaveBeenCalledWith('/social-events/events?city=Quito&event_type_id=31000000-0000-4000-8000-000000000001&workflow_state_id=00000000-0000-4000-8000-000000000233&artistId=42');
+  });
+
+  it('forwards cancellation for public upcoming event searches', async () => {
+    const controller = new AbortController();
+
+    await SocialEventsAPI.listPublicUpcomingEvents({
+      city: ' Guayaquil ',
+      startAfter: '2030-01-01T00:00:00.000Z',
+      limit: 50,
+      signal: controller.signal,
+    });
+
+    expect(getMock).toHaveBeenLastCalledWith(
+      '/social-events/upcoming?city=Guayaquil&startAfter=2030-01-01T00%3A00%3A00.000Z&limit=50',
+      { signal: controller.signal },
+    );
   });
 
   it('removes waitlist entries through the shared API client', async () => {

--- a/tdf-hq-ui/src/api/socialEvents.ts
+++ b/tdf-hq-ui/src/api/socialEvents.ts
@@ -454,10 +454,11 @@ export interface TicketWithQRDTO {
 }
 
 type RequestWithoutBody = (path: string) => Promise<unknown>;
+type GetRequest = (path: string, init?: RequestInit) => Promise<unknown>;
 type RequestWithBody = (path: string, body: unknown) => Promise<unknown>;
 type FormRequest = (path: string, form: FormData) => Promise<unknown>;
 
-const getUnknown: RequestWithoutBody = get;
+const getUnknown: GetRequest = get;
 const delUnknown: RequestWithoutBody = del;
 const postUnknown: RequestWithBody = post;
 const putUnknown: RequestWithBody = put;
@@ -501,9 +502,10 @@ const buildQuery = (params: QueryParams) => {
 };
 
 export const SocialEventsAPI = {
-  listPublicUpcomingEvents: async (opts?: { city?: string; startAfter?: string; limit?: number }) => {
+  listPublicUpcomingEvents: async (opts?: { city?: string; startAfter?: string; limit?: number; signal?: AbortSignal }) => {
     const qs = buildQuery({ city: opts?.city, startAfter: opts?.startAfter, limit: opts?.limit });
-    return await getUnknown(`/social-events/upcoming${qs}`) as PublicUpcomingEventDTO[];
+    const path = `/social-events/upcoming${qs}`;
+    return await (opts?.signal ? getUnknown(path, { signal: opts.signal }) : getUnknown(path)) as PublicUpcomingEventDTO[];
   },
   listEvents: async (opts?: { city?: string; startAfter?: string; eventTypeId?: string; workflowStateId?: string; artistId?: string; venueId?: string }) => {
     const qs = buildQuery({

--- a/tdf-hq-ui/src/pages/UpcomingEventsPublicPage.test.tsx
+++ b/tdf-hq-ui/src/pages/UpcomingEventsPublicPage.test.tsx
@@ -1,0 +1,47 @@
+import { jest } from '@jest/globals';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import type { PublicUpcomingEventDTO } from '../api/socialEvents';
+
+const listPublicUpcomingEventsMock = jest.fn<
+  (opts?: { city?: string; startAfter?: string; limit?: number }) => Promise<PublicUpcomingEventDTO[]>
+>();
+
+jest.unstable_mockModule('../api/socialEvents', () => ({
+  SocialEventsAPI: {
+    listPublicUpcomingEvents: listPublicUpcomingEventsMock,
+  },
+}));
+
+const { default: UpcomingEventsPublicPage } = await import('./UpcomingEventsPublicPage');
+
+const renderPage = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <UpcomingEventsPublicPage />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+};
+
+describe('UpcomingEventsPublicPage', () => {
+  beforeEach(() => {
+    listPublicUpcomingEventsMock.mockReset().mockResolvedValue([]);
+  });
+
+  it('includes the trimmed city in the query sent to the API', async () => {
+    renderPage();
+
+    await waitFor(() => expect(listPublicUpcomingEventsMock).toHaveBeenCalledTimes(1));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Filtrar próximos eventos por ciudad' }), {
+      target: { value: '  Quito  ' },
+    });
+
+    await waitFor(() => expect(listPublicUpcomingEventsMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ city: 'Quito', limit: 50 }),
+    ));
+  });
+});

--- a/tdf-hq-ui/src/pages/UpcomingEventsPublicPage.test.tsx
+++ b/tdf-hq-ui/src/pages/UpcomingEventsPublicPage.test.tsx
@@ -5,7 +5,7 @@ import { MemoryRouter } from 'react-router-dom';
 import type { PublicUpcomingEventDTO } from '../api/socialEvents';
 
 const listPublicUpcomingEventsMock = jest.fn<
-  (opts?: { city?: string; startAfter?: string; limit?: number }) => Promise<PublicUpcomingEventDTO[]>
+  (opts?: { city?: string; startAfter?: string; limit?: number; signal?: AbortSignal }) => Promise<PublicUpcomingEventDTO[]>
 >();
 
 jest.unstable_mockModule('../api/socialEvents', () => ({

--- a/tdf-hq-ui/src/pages/UpcomingEventsPublicPage.tsx
+++ b/tdf-hq-ui/src/pages/UpcomingEventsPublicPage.tsx
@@ -30,10 +30,15 @@ export default function UpcomingEventsPublicPage() {
   useDocumentTitle('Próximos eventos');
   const [city, setCity] = useState('');
   const startAfter = useMemo(() => new Date().toISOString(), []);
+  const cityFilter = city.trim();
 
   const eventsQuery = useQuery({
-    queryKey: ['public-upcoming-events', startAfter],
-    queryFn: () => SocialEventsAPI.listPublicUpcomingEvents({ startAfter, limit: 50 }),
+    queryKey: ['public-upcoming-events', startAfter, cityFilter],
+    queryFn: () => SocialEventsAPI.listPublicUpcomingEvents({
+      city: cityFilter || undefined,
+      startAfter,
+      limit: 50,
+    }),
     staleTime: 60_000,
   });
 

--- a/tdf-hq-ui/src/pages/UpcomingEventsPublicPage.tsx
+++ b/tdf-hq-ui/src/pages/UpcomingEventsPublicPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import SearchIcon from '@mui/icons-material/Search';
@@ -29,25 +29,31 @@ const eventPath = (event: PublicUpcomingEventDTO) => `/eventos/${encodeURICompon
 export default function UpcomingEventsPublicPage() {
   useDocumentTitle('Próximos eventos');
   const [city, setCity] = useState('');
+  const [cityFilter, setCityFilter] = useState('');
   const startAfter = useMemo(() => new Date().toISOString(), []);
-  const cityFilter = city.trim();
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => setCityFilter(city.trim()), 350);
+    return () => window.clearTimeout(timeoutId);
+  }, [city]);
 
   const eventsQuery = useQuery({
     queryKey: ['public-upcoming-events', startAfter, cityFilter],
-    queryFn: () => SocialEventsAPI.listPublicUpcomingEvents({
+    queryFn: ({ signal }) => SocialEventsAPI.listPublicUpcomingEvents({
       city: cityFilter || undefined,
       startAfter,
       limit: 50,
+      signal,
     }),
     staleTime: 60_000,
   });
 
   const events = useMemo(() => {
-    const needle = city.trim().toLocaleLowerCase();
+    const needle = cityFilter.toLocaleLowerCase();
     return (eventsQuery.data ?? [])
       .filter((event) => !needle || (event.publicUpcomingEventCity ?? '').toLocaleLowerCase().includes(needle))
       .sort((a, b) => a.publicUpcomingEventStart.localeCompare(b.publicUpcomingEventStart));
-  }, [city, eventsQuery.data]);
+  }, [cityFilter, eventsQuery.data]);
 
   return (
     <Box component="main" id="main-content" sx={{ maxWidth: 1100, mx: 'auto', px: { xs: 2, md: 4 }, py: { xs: 4, md: 7 } }}>

--- a/tdf-hq/src/TDF/Server/SocialEventsHandlers.hs
+++ b/tdf-hq/src/TDF/Server/SocialEventsHandlers.hs
@@ -291,7 +291,12 @@ publicUpcomingEventsServer mCity mStartAfter mLimit = do
         runSqlPool
             ( do
                 rows <- selectPublicUpcomingSocialEvents mCity startAfter limit
-                catMaybes <$> mapM (publicUpcomingEventRow Nothing) rows
+                catMaybes
+                    <$> mapM
+                        (\(eventEntity, Single canonicalCity) ->
+                            publicUpcomingEventRow canonicalCity eventEntity
+                        )
+                        rows
             )
             envPool
 
@@ -302,7 +307,7 @@ selectPublicUpcomingSocialEvents ::
     Maybe T.Text ->
     UTCTime ->
     Int ->
-    SqlPersistT IO [Entity SocialEvent]
+    SqlPersistT IO [(Entity SocialEvent, Single (Maybe T.Text))]
 selectPublicUpcomingSocialEvents mCity startAfter limit = do
     backend <- ask :: SqlPersistT IO SqlBackend
     eventTable <- getEscapedRawName "social_event"
@@ -328,7 +333,7 @@ selectPublicUpcomingSocialEvents mCity startAfter limit = do
                     , [PersistText (T.strip rawCity)]
                     )
         orderedQuery =
-            "SELECT ?? FROM "
+            "SELECT ??,directory_event.city_name FROM "
                 <> eventTable
                 <> " INNER JOIN "
                 <> publicEventView
@@ -371,17 +376,16 @@ collectMatchingRows requestedLimit requestedPageSize loadPage matchRow
                 else go (offset + length rows) nextMatches
 
 publicUpcomingEventRow :: Maybe T.Text -> Entity SocialEvent -> SqlPersistT IO (Maybe PublicUpcomingEventDTO)
-publicUpcomingEventRow mCity (Entity eventKey eventRow) = do
+publicUpcomingEventRow canonicalCity (Entity eventKey eventRow) = do
     metadataResult <- pure (decodeStoredEventMetadata (socialEventMetadata eventRow))
     venue <- maybe (pure Nothing) get (socialEventVenueId eventRow)
     case (metadataResult, socialEventWorkflowStateId eventRow) of
         (Right metadata, Just workflowStateId) -> do
             workflow <- EventLifecycle.loadActiveSocialEventState workflowStateId
             publicListable <- EventLifecycle.socialEventStateHasCapability workflowStateId "public-listable"
-            let city = venue >>= SM.venueCity
-                cityMatches = maybe True (\needle -> maybe False (T.isInfixOf (T.toCaseFold (T.strip needle)) . T.toCaseFold) city) mCity
+            let city = canonicalCity
             pure $
-                if publicListable && emIsPublic metadata /= Just False && cityMatches
+                if publicListable && emIsPublic metadata /= Just False
                     then do
                         (stateCode, _, _) <- workflow
                         Just PublicUpcomingEventDTO

--- a/tdf-hq/src/TDF/Server/SocialEventsHandlers.hs
+++ b/tdf-hq/src/TDF/Server/SocialEventsHandlers.hs
@@ -6,6 +6,7 @@
 
 module TDF.Server.SocialEventsHandlers (
     publicUpcomingEventsServer,
+    collectMatchingRows,
     socialEventsServer,
     stripeWebhookServer,
     validateRsvpStatus,
@@ -287,9 +288,39 @@ publicUpcomingEventsServer mCity mStartAfter mLimit = do
     let startAfter = fromMaybe now mStartAfter
         limit = min 200 (max 1 (fromMaybe 50 mLimit))
         filters = [SocialEventStartTime >=. startAfter]
-    rows <- liftIO $ runSqlPool (selectVisibleSocialEvents filters (Asc SocialEventStartTime) (limit * 3) 0) envPool
-    events <- liftIO $ runSqlPool (catMaybes <$> mapM (publicUpcomingEventRow mCity) rows) envPool
-    pure (take limit events)
+        pageSize = max 50 (limit * 3)
+    liftIO $
+        runSqlPool
+            ( collectMatchingRows
+                limit
+                pageSize
+                (selectVisibleSocialEvents filters (Asc SocialEventStartTime))
+                (publicUpcomingEventRow mCity)
+            )
+            envPool
+
+collectMatchingRows ::
+    Monad m =>
+    Int ->
+    Int ->
+    (Int -> Int -> m [a]) ->
+    (a -> m (Maybe b)) ->
+    m [b]
+collectMatchingRows requestedLimit requestedPageSize loadPage matchRow
+    | requestedLimit <= 0 = pure []
+    | otherwise = go 0 []
+  where
+    pageSize = max 1 requestedPageSize
+
+    go offset matches
+        | length matches >= requestedLimit = pure (take requestedLimit matches)
+        | otherwise = do
+            rows <- loadPage pageSize offset
+            pageMatches <- catMaybes <$> mapM matchRow rows
+            let nextMatches = matches <> pageMatches
+            if length rows < pageSize
+                then pure (take requestedLimit nextMatches)
+                else go (offset + length rows) nextMatches
 
 publicUpcomingEventRow :: Maybe T.Text -> Entity SocialEvent -> SqlPersistT IO (Maybe PublicUpcomingEventDTO)
 publicUpcomingEventRow mCity (Entity eventKey eventRow) = do
@@ -8603,7 +8634,7 @@ selectVisibleSocialEvents filters dateOrder limit offset = do
             "SELECT ?? FROM "
                 <> eventTable
                 <> combinedFilterClause
-                <> orderClause (Just PrefixTableName) backend [dateOrder]
+                <> orderClause (Just PrefixTableName) backend [dateOrder, Asc SocialEventId]
     query <- getConnLimitOffset (limit, offset) orderedQuery
     rawSql query filterValues
 

--- a/tdf-hq/src/TDF/Server/SocialEventsHandlers.hs
+++ b/tdf-hq/src/TDF/Server/SocialEventsHandlers.hs
@@ -287,17 +287,65 @@ publicUpcomingEventsServer mCity mStartAfter mLimit = do
     now <- liftIO getCurrentTime
     let startAfter = fromMaybe now mStartAfter
         limit = min 200 (max 1 (fromMaybe 50 mLimit))
-        filters = [SocialEventStartTime >=. startAfter]
-        pageSize = max 50 (limit * 3)
     liftIO $
         runSqlPool
-            ( collectMatchingRows
-                limit
-                pageSize
-                (selectVisibleSocialEvents filters (Asc SocialEventStartTime))
-                (publicUpcomingEventRow mCity)
+            ( do
+                rows <- selectPublicUpcomingSocialEvents mCity startAfter limit
+                catMaybes <$> mapM (publicUpcomingEventRow Nothing) rows
             )
             envPool
+
+-- Apply every anonymous-listing predicate before LIMIT. In particular, city
+-- and lifecycle eligibility must not be evaluated by recursively loading the
+-- complete future-event table when a city has few or no matches.
+selectPublicUpcomingSocialEvents ::
+    Maybe T.Text ->
+    UTCTime ->
+    Int ->
+    SqlPersistT IO [Entity SocialEvent]
+selectPublicUpcomingSocialEvents mCity startAfter limit = do
+    backend <- ask :: SqlPersistT IO SqlBackend
+    eventTable <- getEscapedRawName "social_event"
+    eventIdField <- getEscapedRawName "id"
+    eventStartField <- getEscapedRawName "start_time"
+    eventMetadataField <- getEscapedRawName "metadata"
+    publicEventView <- getEscapedRawName "directory_public_event"
+    backendName <- T.toCaseFold <$> getRDBMS
+    let eventIdColumn = eventTable <> "." <> eventIdField
+        eventStartColumn = eventTable <> "." <> eventStartField
+        eventMetadataColumn = eventTable <> "." <> eventMetadataField
+        metadataClause = visibleImportedMetadataClause backendName eventMetadataColumn
+        (cityClause, cityValues) = case mCity of
+            Nothing -> ("", [])
+            Just rawCity ->
+                let matchClause
+                        | "postgres" `T.isInfixOf` backendName =
+                            "position(lower(?) in lower(directory_event.city_name))>0"
+                        | "sqlite" `T.isInfixOf` backendName =
+                            "instr(lower(directory_event.city_name),lower(?))>0"
+                        | otherwise = "1=0"
+                 in ( " AND directory_event.city_name IS NOT NULL AND " <> matchClause
+                    , [PersistText (T.strip rawCity)]
+                    )
+        orderedQuery =
+            "SELECT ?? FROM "
+                <> eventTable
+                <> " INNER JOIN "
+                <> publicEventView
+                <> " AS directory_event ON directory_event.id="
+                <> eventIdColumn
+                <> " WHERE "
+                <> eventStartColumn
+                <> ">=? AND "
+                <> metadataClause
+                <> cityClause
+                <> " ORDER BY "
+                <> eventStartColumn
+                <> " ASC,"
+                <> eventIdColumn
+                <> " ASC"
+    query <- getConnLimitOffset (limit, 0) orderedQuery
+    rawSql query (toPersistValue startAfter : cityValues)
 
 collectMatchingRows ::
     Monad m =>

--- a/tdf-hq/test/Spec.hs
+++ b/tdf-hq/test/Spec.hs
@@ -370,6 +370,7 @@ import TDF.Server.SocialSync
       validateSocialSyncPermalink,
       validateSocialSyncMediaUrls )
 import TDF.Server.SocialEventsHandlers (
+    collectMatchingRows,
     normalizeBudgetLineType,
     normalizeFinanceDirection,
     normalizeFinanceEntryStatus,
@@ -756,6 +757,16 @@ sampleSriScriptRequest =
 
 main :: IO ()
 main = hspec $ do
+    describe "public upcoming event pagination" $ do
+        it "continues past filtered pages until the requested limit is filled" $ do
+            let candidates = [1 .. 8 :: Int]
+                loadPage pageSize offset =
+                    pure (take pageSize (drop offset candidates))
+                keepEven candidate =
+                    pure (if even candidate then Just candidate else Nothing)
+            result <- collectMatchingRows 3 2 loadPage keepEven
+            result `shouldBe` [2, 4, 6]
+
     describe "DDEX canonical write JSON contracts" $ do
         it "accepts export writes with only a canonical standard-version id" $ do
             let payload = "{\"exportReleaseId\":42,\"exportPartnerId\":7,\"exportStandardVersionId\":\"40000000-0000-4000-8000-000000000001\"}"


### PR DESCRIPTION
## Summary
- send the selected city to the public upcoming-events API and include it in the query cache key
- continue paging database candidates until the requested number of publicly eligible events is collected
- add stable id ordering plus focused UI/backend regressions

Addresses the two public-upcoming pagination findings raised on #194.

## Validation
- focused UI regression included
- focused backend pagination regression included
- full required CI requested by this PR