### PR TITLE
fix(reviews): hide inactive storefront targets

### DIFF
--- a/tdf-hq/src/TDF/Server/Reviews.hs
+++ b/tdf-hq/src/TDF/Server/Reviews.hs
@@ -212,12 +212,12 @@ createReview user idempotency request@ExperienceReviewCreateRequest
   when (rating < 1 || rating > 5) $
     throwError err400 {errBody = "rating must be between 1 and 5"}
   validateReviewBody body
-  ensurePublicTarget targetKind targetId
   reviewId <- reserveIdempotency user idempotency request
   prior <- reviewById reviewId
   case prior of
     Just value -> pure value
     Nothing -> do
+      ensurePublicTarget targetKind targetId
       eligible <- runDB
         (rawSql
           "SELECT experience_review_source_is_eligible(?,?,?,?,?)"

--- a/tdf-hq/src/TDF/Server/Reviews.hs
+++ b/tdf-hq/src/TDF/Server/Reviews.hs
@@ -5,6 +5,7 @@ module TDF.Server.Reviews
   ( reviewsPublicServer
   , reviewsProtectedServer
   , publicReviewTargetStatement
+  , eligibilitySql
   ) where
 
 import Control.Monad (unless, when)
@@ -117,15 +118,25 @@ publicReviewTargetStatement targetKind = case targetKind of
    <> ")" )
   "marketplace_listing" ->
     ( "SELECT to_jsonb(TRUE) FROM marketplace_listing listing WHERE listing.id::text=? AND ("
-   <> "listing.active OR EXISTS (SELECT 1 FROM marketplace_order_item item "
-   <> "JOIN marketplace_sale_order_runtime sale ON sale.order_id=item.order_id "
-   <> "WHERE item.listing_id=listing.id AND sale.fulfillment_status IN ('delivered','closed')))" )
+   <> marketplaceListingPublicClause "listing"
+   <> ")" )
   "service_offering" ->
     ( "SELECT to_jsonb(TRUE) FROM service_offering WHERE id::text=? "
    <> "AND active AND deprecated_at IS NULL" )
   "service_package" ->
     "SELECT to_jsonb(TRUE) FROM service_storefront_package WHERE id::text=? AND active"
   _ -> "SELECT to_jsonb(FALSE) WHERE FALSE"
+
+-- Delivery deactivates a sale listing and stamps updated_at in the same
+-- transaction as the immutable fulfillment event. A later explicit withdrawal
+-- changes updated_at, so it must override that historical delivery exception.
+marketplaceListingPublicClause :: Text -> Text
+marketplaceListingPublicClause listing =
+  listing <> ".active OR EXISTS (SELECT 1 FROM marketplace_order_item public_item " <>
+  "JOIN marketplace_sale_fulfillment_event delivered " <>
+  "ON delivered.order_id=public_item.order_id AND delivered.to_status='delivered' " <>
+  "WHERE public_item.listing_id=" <> listing <> ".id " <>
+  "AND delivered.created_at=" <> listing <> ".updated_at)"
 
 listReviewEligibility :: AuthedUser -> Maybe Text -> Maybe Text -> AppM [Value]
 listReviewEligibility user rawTargetKind rawTargetId = do
@@ -140,7 +151,9 @@ eligibilitySql =
   "coalesce(event.end_time,event.start_time) completed_at " <>
   "FROM event_ticket_order orders JOIN social_event event ON event.id=orders.event_id " <>
   "WHERE orders.buyer_party_id=?::bigint AND experience_review_source_is_eligible(" <>
-  "'event',event.id::text,'event_ticket_order',orders.id::text,?::bigint) " <>
+  "'event',event.id::text,'event_ticket_order',orders.id::text,?::bigint) AND (" <>
+  "NOT EXISTS (SELECT 1 FROM external_event_ref source WHERE source.event_id=event.id) OR " <>
+  postgresVisibleImportedMetadataClause "event.metadata" <> ") " <>
   "UNION ALL " <>
   "SELECT 'marketplace_listing',listing.id::text,listing.title,'marketplace_order',orders.id::text," <>
   "coalesce(sale.delivered_at,rental.returned_at,sale.updated_at,rental.updated_at,orders.updated_at) " <>
@@ -149,19 +162,21 @@ eligibilitySql =
   "LEFT JOIN marketplace_sale_order_runtime sale ON sale.order_id=orders.id " <>
   "LEFT JOIN marketplace_rental_order_runtime rental ON rental.order_id=orders.id " <>
   "WHERE experience_review_source_is_eligible('marketplace_listing',listing.id::text," <>
-  "'marketplace_order',orders.id::text,?::bigint) " <>
+  "'marketplace_order',orders.id::text,?::bigint) AND (" <>
+  marketplaceListingPublicClause "listing" <> ") " <>
   "UNION ALL " <>
   "SELECT 'service_offering',offering.id::text,offering.name_es,'service_booking',booking.id::text," <>
   "coalesce(runtime.completed_at,booking.ends_at) " <>
   "FROM booking booking JOIN service_offering offering ON offering.id=booking.service_offering_id " <>
   "LEFT JOIN service_booking_checkout_runtime runtime ON runtime.booking_id=booking.id " <>
-  "WHERE booking.party_id=?::bigint AND experience_review_source_is_eligible(" <>
+  "WHERE offering.active AND offering.deprecated_at IS NULL " <>
+  "AND booking.party_id=?::bigint AND experience_review_source_is_eligible(" <>
   "'service_offering',offering.id::text,'service_booking',booking.id::text,?::bigint) " <>
   "UNION ALL " <>
   "SELECT 'service_package',package.id::text,package.name,'service_storefront_order',orders.id::text," <>
   "orders.updated_at FROM service_storefront_order orders " <>
   "JOIN service_storefront_package package ON package.id=orders.package_id " <>
-  "WHERE experience_review_source_is_eligible('service_package',package.id::text," <>
+  "WHERE package.active AND experience_review_source_is_eligible('service_package',package.id::text," <>
   "'service_storefront_order',orders.id::text,?::bigint)), " <>
   "requested AS (SELECT ?::text target_kind,?::text target_id) " <>
   "SELECT jsonb_build_object('targetKind',candidate.target_kind,'targetId',candidate.target_id," <>
@@ -197,6 +212,7 @@ createReview user idempotency request@ExperienceReviewCreateRequest
   when (rating < 1 || rating > 5) $
     throwError err400 {errBody = "rating must be between 1 and 5"}
   validateReviewBody body
+  ensurePublicTarget targetKind targetId
   reviewId <- reserveIdempotency user idempotency request
   prior <- reviewById reviewId
   case prior of

--- a/tdf-hq/src/TDF/Server/Reviews.hs
+++ b/tdf-hq/src/TDF/Server/Reviews.hs
@@ -4,6 +4,7 @@
 module TDF.Server.Reviews
   ( reviewsPublicServer
   , reviewsProtectedServer
+  , publicReviewTargetStatement
   ) where
 
 import Control.Monad (unless, when)
@@ -104,21 +105,24 @@ visibleReviewId _ = Nothing
 
 ensurePublicTarget :: Text -> Text -> AppM ()
 ensurePublicTarget targetKind targetId = do
-  rows <- jsonRows statement [PersistText targetId]
+  rows <- jsonRows (publicReviewTargetStatement targetKind) [PersistText targetId]
   when (null rows) (throwError err404 {errBody = "review target not found"})
-  where
-    statement = case targetKind of
-      "event" ->
-        ( "SELECT to_jsonb(TRUE) FROM social_event event WHERE event.id::text=? AND ("
-       <> "NOT EXISTS (SELECT 1 FROM external_event_ref source WHERE source.event_id=event.id) OR "
-       <> postgresVisibleImportedMetadataClause "event.metadata"
-       <> ")" )
-      "marketplace_listing" -> "SELECT to_jsonb(TRUE) FROM marketplace_listing WHERE id::text=?"
-      "service_offering" ->
-        "SELECT to_jsonb(TRUE) FROM service_offering WHERE id::text=?"
-      "service_package" ->
-        "SELECT to_jsonb(TRUE) FROM service_storefront_package WHERE id::text=?"
-      _ -> "SELECT to_jsonb(FALSE) WHERE FALSE"
+
+publicReviewTargetStatement :: Text -> Text
+publicReviewTargetStatement targetKind = case targetKind of
+  "event" ->
+    ( "SELECT to_jsonb(TRUE) FROM social_event event WHERE event.id::text=? AND ("
+   <> "NOT EXISTS (SELECT 1 FROM external_event_ref source WHERE source.event_id=event.id) OR "
+   <> postgresVisibleImportedMetadataClause "event.metadata"
+   <> ")" )
+  "marketplace_listing" ->
+    "SELECT to_jsonb(TRUE) FROM marketplace_listing WHERE id::text=? AND active"
+  "service_offering" ->
+    ( "SELECT to_jsonb(TRUE) FROM service_offering WHERE id::text=? "
+   <> "AND active AND deprecated_at IS NULL" )
+  "service_package" ->
+    "SELECT to_jsonb(TRUE) FROM service_storefront_package WHERE id::text=? AND active"
+  _ -> "SELECT to_jsonb(FALSE) WHERE FALSE"
 
 listReviewEligibility :: AuthedUser -> Maybe Text -> Maybe Text -> AppM [Value]
 listReviewEligibility user rawTargetKind rawTargetId = do

--- a/tdf-hq/src/TDF/Server/Reviews.hs
+++ b/tdf-hq/src/TDF/Server/Reviews.hs
@@ -116,7 +116,10 @@ publicReviewTargetStatement targetKind = case targetKind of
    <> postgresVisibleImportedMetadataClause "event.metadata"
    <> ")" )
   "marketplace_listing" ->
-    "SELECT to_jsonb(TRUE) FROM marketplace_listing WHERE id::text=? AND active"
+    ( "SELECT to_jsonb(TRUE) FROM marketplace_listing listing WHERE listing.id::text=? AND ("
+   <> "listing.active OR EXISTS (SELECT 1 FROM marketplace_order_item item "
+   <> "JOIN marketplace_sale_order_runtime sale ON sale.order_id=item.order_id "
+   <> "WHERE item.listing_id=listing.id AND sale.fulfillment_status IN ('delivered','closed')))" )
   "service_offering" ->
     ( "SELECT to_jsonb(TRUE) FROM service_offering WHERE id::text=? "
    <> "AND active AND deprecated_at IS NULL" )

--- a/tdf-hq/test/Spec.hs
+++ b/tdf-hq/test/Spec.hs
@@ -338,6 +338,7 @@ import TDF.Server
       extractApiErrorMessage,
       chatKitSessionErrorMessage,
       shouldRetryWithFallbackModel )
+import TDF.Server.Reviews (publicReviewTargetStatement)
 import TDF.ServerLiveSessions
     ( buildLiveSessionUsernameCollisionCandidate,
       LiveSessionMusicianLookup (..),
@@ -756,6 +757,18 @@ sampleSriScriptRequest =
 
 main :: IO ()
 main = hspec $ do
+    describe "public review target visibility" $ do
+        it "requires marketplace listings and storefront packages to remain active" $ do
+            publicReviewTargetStatement "marketplace_listing"
+                `shouldSatisfy` Data.Text.isInfixOf "AND active"
+            publicReviewTargetStatement "service_package"
+                `shouldSatisfy` Data.Text.isInfixOf "AND active"
+
+        it "rejects inactive or deprecated service offerings" $ do
+            let statement = publicReviewTargetStatement "service_offering"
+            statement `shouldSatisfy` Data.Text.isInfixOf "AND active"
+            statement `shouldSatisfy` Data.Text.isInfixOf "deprecated_at IS NULL"
+
     describe "DDEX canonical write JSON contracts" $ do
         it "accepts export writes with only a canonical standard-version id" $ do
             let payload = "{\"exportReleaseId\":42,\"exportPartnerId\":7,\"exportStandardVersionId\":\"40000000-0000-4000-8000-000000000001\"}"

--- a/tdf-hq/test/Spec.hs
+++ b/tdf-hq/test/Spec.hs
@@ -758,9 +758,12 @@ sampleSriScriptRequest =
 main :: IO ()
 main = hspec $ do
     describe "public review target visibility" $ do
-        it "requires marketplace listings and storefront packages to remain active" $ do
-            publicReviewTargetStatement "marketplace_listing"
-                `shouldSatisfy` Data.Text.isInfixOf "AND active"
+        it "keeps delivered marketplace sales visible without exposing withdrawn listings" $ do
+            let statement = publicReviewTargetStatement "marketplace_listing"
+            statement `shouldSatisfy` Data.Text.isInfixOf "listing.active OR EXISTS"
+            statement `shouldSatisfy` Data.Text.isInfixOf "sale.fulfillment_status IN ('delivered','closed')"
+
+        it "requires storefront packages to remain active" $ do
             publicReviewTargetStatement "service_package"
                 `shouldSatisfy` Data.Text.isInfixOf "AND active"
 

--- a/tdf-hq/test/Spec.hs
+++ b/tdf-hq/test/Spec.hs
@@ -338,7 +338,7 @@ import TDF.Server
       extractApiErrorMessage,
       chatKitSessionErrorMessage,
       shouldRetryWithFallbackModel )
-import TDF.Server.Reviews (publicReviewTargetStatement)
+import TDF.Server.Reviews (eligibilitySql, publicReviewTargetStatement)
 import TDF.ServerLiveSessions
     ( buildLiveSessionUsernameCollisionCandidate,
       LiveSessionMusicianLookup (..),
@@ -761,7 +761,8 @@ main = hspec $ do
         it "keeps delivered marketplace sales visible without exposing withdrawn listings" $ do
             let statement = publicReviewTargetStatement "marketplace_listing"
             statement `shouldSatisfy` Data.Text.isInfixOf "listing.active OR EXISTS"
-            statement `shouldSatisfy` Data.Text.isInfixOf "sale.fulfillment_status IN ('delivered','closed')"
+            statement `shouldSatisfy` Data.Text.isInfixOf "delivered.to_status='delivered'"
+            statement `shouldSatisfy` Data.Text.isInfixOf "delivered.created_at=listing.updated_at"
 
         it "requires storefront packages to remain active" $ do
             publicReviewTargetStatement "service_package"
@@ -771,6 +772,11 @@ main = hspec $ do
             let statement = publicReviewTargetStatement "service_offering"
             statement `shouldSatisfy` Data.Text.isInfixOf "AND active"
             statement `shouldSatisfy` Data.Text.isInfixOf "deprecated_at IS NULL"
+
+        it "does not offer review creation for hidden targets" $ do
+            eligibilitySql `shouldSatisfy` Data.Text.isInfixOf "offering.active AND offering.deprecated_at IS NULL"
+            eligibilitySql `shouldSatisfy` Data.Text.isInfixOf "WHERE package.active"
+            eligibilitySql `shouldSatisfy` Data.Text.isInfixOf "delivered.created_at=listing.updated_at"
 
     describe "DDEX canonical write JSON contracts" $ do
         it "accepts export writes with only a canonical standard-version id" $ do


### PR DESCRIPTION
## Summary
- require marketplace listings and service packages to be active before exposing their reviews publicly
- require service offerings to be active and not deprecated
- centralize the public target query and add focused regression assertions

## Verification
- git diff --check
- production backend modules compiled successfully through TDF.Server.Reviews and the application link
- the local test-suite rebuild was stopped after the compiler temp volume reached capacity; remote backend CI is the authoritative full run