### PR TITLE
fix: guard standalone report retests

### DIFF
--- a/docs/catalog-persistence/catalog-list-decisions.json
+++ b/docs/catalog-persistence/catalog-list-decisions.json
@@ -8794,7 +8794,7 @@
       "reviewed": true
     },
     {
-      "id": "9f4aa6a01ef44ecef6db",
+      "id": "df860f9215f11dd1f668",
       "classification": "dynamic-business-catalog",
       "disposition": "consumer-update",
       "specializedModel": "workflow_definition, workflow_state, workflow_transition",

--- a/scripts/test-studio-internship-audit-api-e2e.mjs
+++ b/scripts/test-studio-internship-audit-api-e2e.mjs
@@ -911,6 +911,21 @@ const standaloneAfterRejectedRetest = await request(`/feedback/internal/${standa
   token: admin.token,
 });
 assert.equal(standaloneAfterRejectedRetest.ifrSummary.ifsState, 'in_progress');
+const verifiedStandalone = await request(`/feedback/internal/${standaloneReportId}`, {
+  token: admin.token,
+  method: 'PATCH',
+  json: { ifuState: 'verified' },
+});
+assert.equal(verifiedStandalone.ifrSummary.ifsState, 'verified');
+const closedStandalone = await request(`/feedback/internal/${standaloneReportId}`, {
+  token: admin.token,
+  method: 'PATCH',
+  json: {
+    ifuState: 'closed',
+    ifuClosureReason: 'La idea independiente se revisó sin requerir un retest.',
+  },
+});
+assert.equal(closedStandalone.ifrSummary.ifsState, 'closed');
 
 await request(`/feedback/internal/${reportId}`, {
   token: intern.token,

--- a/scripts/test-studio-internship-audit-api-e2e.mjs
+++ b/scripts/test-studio-internship-audit-api-e2e.mjs
@@ -876,6 +876,42 @@ assert.equal(executionOnlyAdminDraft.ifrSummary.ifsTestCaseId, testCase.itcId);
 assert.equal(executionOnlyAdminDraft.ifrSummary.ifsTestExecutionId, failedExecution.itexId);
 assert.equal(executionOnlyAdminDraft.ifrAuditPlanMutable, true);
 
+const standaloneAdminDraft = await request('/feedback/internal', {
+  token: admin.token,
+  method: 'POST',
+  expected: 201,
+  json: {
+    ...reportCreate,
+    ifcTitle: 'Reporte administrativo sin caso de prueba vinculado',
+    ifcCategoryId: ideaCategory.id,
+    ifcReportType: 'idea',
+    ifcInternshipProjectId: null,
+    ifcInternshipTaskId: null,
+    ifcTestCaseId: null,
+    ifcTestExecutionId: null,
+  },
+});
+const standaloneReportId = standaloneAdminDraft.ifrSummary.ifsId;
+assert.equal(standaloneAdminDraft.ifrSummary.ifsTestCaseId, null);
+await request(`/feedback/internal/${standaloneReportId}/submit`, { token: admin.token, method: 'POST' });
+for (const nextState of ['confirmed', 'in_progress']) {
+  await request(`/feedback/internal/${standaloneReportId}`, {
+    token: admin.token,
+    method: 'PATCH',
+    json: { ifuState: nextState },
+  });
+}
+await request(`/feedback/internal/${standaloneReportId}`, {
+  token: admin.token,
+  method: 'PATCH',
+  expected: 409,
+  json: { ifuState: 'ready_for_retest' },
+});
+const standaloneAfterRejectedRetest = await request(`/feedback/internal/${standaloneReportId}`, {
+  token: admin.token,
+});
+assert.equal(standaloneAfterRejectedRetest.ifrSummary.ifsState, 'in_progress');
+
 await request(`/feedback/internal/${reportId}`, {
   token: intern.token,
   method: 'PATCH',

--- a/tdf-hq-ui/src/pages/InternalFeedbackPage.tsx
+++ b/tdf-hq-ui/src/pages/InternalFeedbackPage.tsx
@@ -31,7 +31,12 @@ import type { InternalReportState, InternalReportType } from '../api/types';
 import PageShell, { EmptyState } from '../components/PageShell';
 import { useSession } from '../session/SessionContext';
 import { hasInternshipsAdminAccess } from '../utils/accessControl';
-import { internalReportContextDefaults, internalReportMutationsAllowed } from './internalFeedbackLogic';
+import {
+  internalReportAdminTransitions,
+  internalReportContextDefaults,
+  internalReportMutationsAllowed,
+  internalReportRetestAllowed,
+} from './internalFeedbackLogic';
 
 const CATEGORY_CATALOG = 'feedback-categories';
 const SEVERITY_CATALOG = 'feedback-severities';
@@ -71,21 +76,6 @@ const STATE_LABELS: Record<InternalReportState, string> = {
   closed: 'Cerrado',
   duplicate: 'Duplicado',
   discarded: 'Descartado',
-};
-
-const ADMIN_TRANSITIONS: Record<InternalReportState, InternalReportState[]> = {
-  draft: [],
-  submitted: [],
-  received: ['needs_information', 'confirmed', 'duplicate', 'discarded'],
-  needs_information: ['received', 'confirmed', 'discarded'],
-  confirmed: ['prioritized', 'in_progress', 'duplicate', 'discarded'],
-  prioritized: ['in_progress', 'discarded'],
-  in_progress: ['ready_for_retest', 'discarded'],
-  ready_for_retest: ['verified', 'in_progress'],
-  verified: ['closed', 'in_progress'],
-  closed: ['received'],
-  duplicate: ['received'],
-  discarded: ['received'],
 };
 
 const publishedItems = (page?: CatalogPage): CatalogItem[] =>
@@ -388,7 +378,7 @@ function ReportDetail({ reportId }: { reportId: string }) {
           </Stack></CardContent></Card></Grid>
         </Grid>
 
-        {reportIsMutable && summary.ifsState === 'ready_for_retest' && <Card variant="outlined"><CardContent><Stack spacing={2}>
+        {internalReportRetestAllowed(summary.ifsState, summary.ifsTestCaseId, report.ifrAuditPlanMutable) && <Card variant="outlined"><CardContent><Stack spacing={2}>
           <Typography variant="h6">Registrar retest</Typography>
           <TextField select label="Resultado" value={retestResult} onChange={(event) => setRetestResult(event.target.value)}><MenuItem value="passed">Aprobado</MenuItem><MenuItem value="failed">Fallido</MenuItem><MenuItem value="blocked">Bloqueado</MenuItem></TextField>
           <TextField label="Qué comprobaste y evidencia" value={retestNotes} onChange={(event) => setRetestNotes(event.target.value)} multiline minRows={3} />
@@ -398,7 +388,7 @@ function ReportDetail({ reportId }: { reportId: string }) {
         {isAdmin && reportIsMutable && <Card variant="outlined"><CardContent><Stack spacing={2}>
           <Typography variant="h6">Triage administrativo</Typography>
           <Grid container spacing={2}>
-            <Grid item xs={12} md={4}><TextField select label="Nuevo estado" value={adminUpdate.ifuState ?? ''} onChange={(event) => setAdminUpdate((current) => ({ ...current, ifuState: event.target.value as InternalReportState }))} fullWidth><MenuItem value="">Sin cambio</MenuItem>{ADMIN_TRANSITIONS[summary.ifsState].map((state) => <MenuItem key={state} value={state}>{STATE_LABELS[state]}</MenuItem>)}</TextField></Grid>
+            <Grid item xs={12} md={4}><TextField select label="Nuevo estado" value={adminUpdate.ifuState ?? ''} onChange={(event) => setAdminUpdate((current) => ({ ...current, ifuState: event.target.value as InternalReportState }))} fullWidth><MenuItem value="">Sin cambio</MenuItem>{internalReportAdminTransitions(summary.ifsState, summary.ifsTestCaseId).map((state) => <MenuItem key={state} value={state}>{STATE_LABELS[state]}</MenuItem>)}</TextField></Grid>
             <Grid item xs={12} md={4}><TextField select label="Severidad administrativa" value={adminUpdate.ifuAuthoritativeSeverityId ?? ''} onChange={(event) => setAdminUpdate((current) => ({ ...current, ifuAuthoritativeSeverityId: event.target.value || null }))} fullWidth><MenuItem value="">Sin cambio</MenuItem>{catalogs.severities.map((item) => <MenuItem key={item.id} value={item.id}>{item.name}</MenuItem>)}</TextField></Grid>
             <Grid item xs={12} md={4}><TextField select label="Prioridad" value={adminUpdate.ifuPriority ?? ''} onChange={(event) => setAdminUpdate((current) => ({ ...current, ifuPriority: event.target.value || null }))} fullWidth><MenuItem value="">Sin cambio</MenuItem><MenuItem value="low">Baja</MenuItem><MenuItem value="medium">Media</MenuItem><MenuItem value="high">Alta</MenuItem><MenuItem value="urgent">Urgente</MenuItem></TextField></Grid>
             <Grid item xs={12}><TextField label="Resolución" value={adminUpdate.ifuResolution ?? ''} onChange={(event) => setAdminUpdate((current) => ({ ...current, ifuResolution: event.target.value || null }))} fullWidth multiline /></Grid>

--- a/tdf-hq-ui/src/pages/internalFeedbackLogic.test.ts
+++ b/tdf-hq-ui/src/pages/internalFeedbackLogic.test.ts
@@ -1,4 +1,9 @@
-import { internalReportContextDefaults, internalReportMutationsAllowed } from './internalFeedbackLogic';
+import {
+  internalReportAdminTransitions,
+  internalReportContextDefaults,
+  internalReportMutationsAllowed,
+  internalReportRetestAllowed,
+} from './internalFeedbackLogic';
 
 describe('internal report context defaults', () => {
   it('prefers the audit case role and environment over the first session role', () => {
@@ -31,5 +36,21 @@ describe('internal report mutation controls', () => {
 
   it('makes reports read-only after the owning audit is finalized', () => {
     expect(internalReportMutationsAllowed(false)).toBe(false);
+  });
+});
+
+describe('internal report retest controls', () => {
+  it('does not offer the retest-only state to standalone reports', () => {
+    expect(internalReportAdminTransitions('in_progress', null)).toEqual(['discarded']);
+    expect(internalReportAdminTransitions('in_progress', 'case-1')).toEqual([
+      'ready_for_retest',
+      'discarded',
+    ]);
+  });
+
+  it('only enables retesting for mutable reports linked to a test case', () => {
+    expect(internalReportRetestAllowed('ready_for_retest', null, true)).toBe(false);
+    expect(internalReportRetestAllowed('ready_for_retest', 'case-1', false)).toBe(false);
+    expect(internalReportRetestAllowed('ready_for_retest', 'case-1', true)).toBe(true);
   });
 });

--- a/tdf-hq-ui/src/pages/internalFeedbackLogic.test.ts
+++ b/tdf-hq-ui/src/pages/internalFeedbackLogic.test.ts
@@ -40,8 +40,8 @@ describe('internal report mutation controls', () => {
 });
 
 describe('internal report retest controls', () => {
-  it('does not offer the retest-only state to standalone reports', () => {
-    expect(internalReportAdminTransitions('in_progress', null)).toEqual(['discarded']);
+  it('offers standalone reports a direct completion path instead of retesting', () => {
+    expect(internalReportAdminTransitions('in_progress', null)).toEqual(['verified', 'discarded']);
     expect(internalReportAdminTransitions('in_progress', 'case-1')).toEqual([
       'ready_for_retest',
       'discarded',

--- a/tdf-hq-ui/src/pages/internalFeedbackLogic.ts
+++ b/tdf-hq-ui/src/pages/internalFeedbackLogic.ts
@@ -20,8 +20,10 @@ export const internalReportMutationsAllowed = (auditPlanMutable: boolean) => aud
 export const internalReportAdminTransitions = (
   state: InternalReportState,
   testCaseId: string | null | undefined,
-) => ADMIN_TRANSITIONS[state].filter((nextState) =>
-  nextState !== 'ready_for_retest' || Boolean(testCaseId));
+): InternalReportState[] => {
+  if (state === 'in_progress' && !testCaseId) return ['verified', 'discarded'];
+  return ADMIN_TRANSITIONS[state];
+};
 
 export const internalReportRetestAllowed = (
   state: InternalReportState,

--- a/tdf-hq-ui/src/pages/internalFeedbackLogic.ts
+++ b/tdf-hq-ui/src/pages/internalFeedbackLogic.ts
@@ -1,4 +1,33 @@
+import type { InternalReportState } from '../api/types';
+
+const ADMIN_TRANSITIONS: Record<InternalReportState, InternalReportState[]> = {
+  draft: [],
+  submitted: [],
+  received: ['needs_information', 'confirmed', 'duplicate', 'discarded'],
+  needs_information: ['received', 'confirmed', 'discarded'],
+  confirmed: ['prioritized', 'in_progress', 'duplicate', 'discarded'],
+  prioritized: ['in_progress', 'discarded'],
+  in_progress: ['ready_for_retest', 'discarded'],
+  ready_for_retest: ['verified', 'in_progress'],
+  verified: ['closed', 'in_progress'],
+  closed: ['received'],
+  duplicate: ['received'],
+  discarded: ['received'],
+};
+
 export const internalReportMutationsAllowed = (auditPlanMutable: boolean) => auditPlanMutable;
+
+export const internalReportAdminTransitions = (
+  state: InternalReportState,
+  testCaseId: string | null | undefined,
+) => ADMIN_TRANSITIONS[state].filter((nextState) =>
+  nextState !== 'ready_for_retest' || Boolean(testCaseId));
+
+export const internalReportRetestAllowed = (
+  state: InternalReportState,
+  testCaseId: string | null | undefined,
+  auditPlanMutable: boolean,
+) => auditPlanMutable && state === 'ready_for_retest' && Boolean(testCaseId);
 
 export const internalReportContextDefaults = (
   searchParams: URLSearchParams,

--- a/tdf-hq/src/TDF/ServerFeedback.hs
+++ b/tdf-hq/src/TDF/ServerFeedback.hs
@@ -21,6 +21,7 @@ module TDF.ServerFeedback
   , internalReportTypeForCategoryCode
   , validateInternalReportState
   , validateStateTransition
+  , validateReportStateTransition
   , validatePriority
   , validateEnvironment
   , validateExternalEvidenceUrl
@@ -449,7 +450,9 @@ internalFeedbackServer user =
       resolutionUpdate <- validateNestedInternalText "resolution" 10000 ifuResolution
       retestResultUpdate <- validateNestedInternalText "retestResult" 5000 ifuRetestResult
       closureReasonUpdate <- validateNestedInternalText "closureReason" 5000 ifuClosureReason
-      stateUpdate <- traverse (validateStateTransition state) ifuState
+      stateUpdate <- traverse
+        (validateReportStateTransition (isJust (ME.internalFeedbackReportTestCaseId report)) state)
+        ifuState
       authoritativeSeverityUpdate <- traverse (traverse resolvePublishedFeedbackSeverityFor) ifuAuthoritativeSeverityId
       priorityUpdate <- traverse (traverse validatePriority) ifuPriority
       assignedToUpdate <- traverse (traverse (validatePositiveParty "assignedTo")) ifuAssignedTo
@@ -1445,6 +1448,13 @@ validateStateTransition previous rawNext = do
   if next == previous || next `elem` allowed
     then pure next
     else throwError err409 { errBody = "Unsupported report state transition" }
+
+validateReportStateTransition :: MonadError ServerError m => Bool -> Text -> Text -> m Text
+validateReportStateTransition hasTestCase previous rawNext = do
+  next <- validateStateTransition previous rawNext
+  when (next == "ready_for_retest" && not hasTestCase) $
+    throwError err409 { errBody = "Ready-for-retest reports require a linked test case" }
+  pure next
 
 validatePriority :: MonadError ServerError m => Text -> m Text
 validatePriority = validateChoice "priority" ["low", "medium", "high", "urgent"]

--- a/tdf-hq/src/TDF/ServerFeedback.hs
+++ b/tdf-hq/src/TDF/ServerFeedback.hs
@@ -584,6 +584,7 @@ internalFeedbackServer user =
                             (\value -> [ME.InternalFeedbackReportDuplicateOf =. value])
                             resolvedDuplicateUpdate
                       retestPassed <- if stateUpdate == Just "verified"
+                        && isJust (ME.internalFeedbackReportTestCaseId lockedReport)
                         then do
                           latestReadyCycle <- selectFirst
                             [ ME.InternalFeedbackHistoryReportId ==. reportKey
@@ -1451,10 +1452,14 @@ validateStateTransition previous rawNext = do
 
 validateReportStateTransition :: MonadError ServerError m => Bool -> Text -> Text -> m Text
 validateReportStateTransition hasTestCase previous rawNext = do
-  next <- validateStateTransition previous rawNext
-  when (next == "ready_for_retest" && not hasTestCase) $
-    throwError err409 { errBody = "Ready-for-retest reports require a linked test case" }
-  pure next
+  next <- validateInternalReportState "state" rawNext
+  if not hasTestCase && previous == "in_progress" && next == "verified"
+    then pure next
+    else do
+      validatedNext <- validateStateTransition previous next
+      when (validatedNext == "ready_for_retest" && not hasTestCase) $
+        throwError err409 { errBody = "Ready-for-retest reports require a linked test case" }
+      pure validatedNext
 
 validatePriority :: MonadError ServerError m => Text -> m Text
 validatePriority = validateChoice "priority" ["low", "medium", "high", "urgent"]

--- a/tdf-hq/test/Spec.hs
+++ b/tdf-hq/test/Spec.hs
@@ -13179,6 +13179,11 @@ main = hspec $ do
                     errHTTPCode err `shouldBe` 409
                     BL.unpack (errBody err) `shouldContain` "linked test case"
                 Right value -> expectationFailure ("Expected unlinked transition rejection, got " <> show value)
+            (validateReportStateTransition False "in_progress" "verified" :: Either ServerError Text)
+                `shouldBe` Right "verified"
+            case (validateReportStateTransition True "in_progress" "verified" :: Either ServerError Text) of
+                Left err -> errHTTPCode err `shouldBe` 409
+                Right value -> expectationFailure ("Expected linked verification rejection, got " <> show value)
             (validateReportStateTransition False "in_progress" "discarded" :: Either ServerError Text)
                 `shouldBe` Right "discarded"
 

--- a/tdf-hq/test/Spec.hs
+++ b/tdf-hq/test/Spec.hs
@@ -290,6 +290,7 @@ import TDF.ServerFeedback
       validateInternalReportState,
       validateOptionalFeedbackContactEmail,
       validatePriority,
+      validateReportStateTransition,
       validateReportType,
       validateStateTransition,
       validateVideoLinks )
@@ -13169,6 +13170,17 @@ main = hspec $ do
             case (validateStateTransition "received" "closed" :: Either ServerError Text) of
                 Left err -> errHTTPCode err `shouldBe` 409
                 Right value -> expectationFailure ("Expected transition rejection, got " <> show value)
+
+        it "keeps standalone reports out of the retest-only state" $ do
+            (validateReportStateTransition True "in_progress" "ready_for_retest" :: Either ServerError Text)
+                `shouldBe` Right "ready_for_retest"
+            case (validateReportStateTransition False "in_progress" "ready_for_retest" :: Either ServerError Text) of
+                Left err -> do
+                    errHTTPCode err `shouldBe` 409
+                    BL.unpack (errBody err) `shouldContain` "linked test case"
+                Right value -> expectationFailure ("Expected unlinked transition rejection, got " <> show value)
+            (validateReportStateTransition False "in_progress" "discarded" :: Either ServerError Text)
+                `shouldBe` Right "discarded"
 
         it "requires known states and public HTTPS evidence links" $ do
             (validateInternalReportState "state" "ready_for_retest" :: Either ServerError Text)


### PR DESCRIPTION
Prevents standalone internal reports from entering the retest-only workflow state.

- rejects ready_for_retest transitions without a linked test case
- removes the invalid transition and retest controls from the UI
- adds backend, UI, and disposable API E2E regression coverage

Validated locally with focused Haskell tests, UI unit tests, lint, typecheck, production build, and the studio internship audit API E2E flow.