### PR TITLE
fix: repair raced legacy UI merge markers

### DIFF
--- a/archives/tdf-root-ui-legacy/App.tsx
+++ b/archives/tdf-root-ui-legacy/App.tsx
@@ -26,6 +26,7 @@ import ResetPasswordPage from './pages/public/ResetPasswordPage';
 import ChangePasswordPage from './pages/account/ChangePasswordPage';
 import TrialQueuePage from './pages/trials/TrialQueuePage';
 import StudentProfilePage from './pages/students/StudentProfilePage';
+import StudentDashboard from './pages/students/StudentDashboard';
 import PackageListLite from './features/packages/PackageList';
 import Payments from './features/payments/Payments';
 import ReceiptView from './features/receipts/ReceiptView';
@@ -118,10 +119,7 @@ export default function App() {
               <Route path="cohortes" element={<Placeholder title="Escuela · Cohortes" />} />
               <Route path="estudiantes" element={<Placeholder title="Escuela · Estudiantes" description="Lista de estudiantes matriculados. Click en un estudiante para ver su perfil y progreso." />} />
               <Route path="estudiantes/:id" element={<StudentProfilePage />} />
-<<<<<<< HEAD:archives/tdf-root-ui-legacy/App.tsx
-=======
               <Route path="estudiante/:studentId/dashboard" element={<StudentDashboard />} />
->>>>>>> tdf-ui/main:src/App.tsx
               <Route path="inscripciones" element={<Placeholder title="Escuela · Inscripciones" />} />
               <Route path="pagos" element={<Placeholder title="Escuela · Pagos" />} />
             </Route>

--- a/archives/tdf-root-ui-legacy/routes/AppRoutes.tsx
+++ b/archives/tdf-root-ui-legacy/routes/AppRoutes.tsx
@@ -6,10 +6,7 @@ import { normalizeRoles } from '../config/menu';
 import MetadataPage from '../pages/Metadata';
 import { METADATA_ROUTES } from '../features/metadata/routes';
 import SessionInputList from '../pages/SessionInputList';
-<<<<<<< HEAD:archives/tdf-root-ui-legacy/routes/AppRoutes.tsx
 import ArtistsPage from '../pages/ArtistsPage';
-=======
->>>>>>> tdf-ui/main:src/routes/AppRoutes.tsx
 
 export type Role =
   | 'admin' | 'finanzas' | 'booker' | 'ingeniero' | 'productor'


### PR DESCRIPTION
Repairs the root main merge that was raced by the background continuous-improvement supervisor. Removes committed conflict markers from the archived legacy UI, restores the StudentDashboard import, and preserves the later ArtistsPage/auth routing. The supervisor launchd job has been unloaded to prevent another concurrent write.