### PR TITLE
feat(web): show images on directory and event cards

### DIFF
--- a/tdf-hq-ui/public/directory-fallback.svg
+++ b/tdf-hq-ui/public/directory-fallback.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-labelledby="title description">
+  <title id="title">Imagen de directorio no disponible</title>
+  <desc id="description">Fondo abstracto de TDF con una lupa y una nota musical.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#17112d"/>
+      <stop offset="0.55" stop-color="#3b1d66"/>
+      <stop offset="1" stop-color="#0e6470"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="52%" cy="42%" r="48%">
+      <stop offset="0" stop-color="#c4b5fd" stop-opacity=".3"/>
+      <stop offset="1" stop-color="#c4b5fd" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#background)"/>
+  <rect width="1200" height="800" fill="url(#glow)"/>
+  <g fill="none" stroke="#ede9fe" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="525" cy="350" r="170" stroke-width="30" opacity=".88"/>
+    <path d="m655 480 150 150" stroke-width="42" opacity=".88"/>
+    <path d="M555 245v170c0 48-43 85-94 85-43 0-75-25-75-59 0-37 39-67 86-67 19 0 37 5 51 13V271l150-34" stroke-width="24" opacity=".78"/>
+  </g>
+  <text x="64" y="720" fill="#f5f3ff" font-family="system-ui, sans-serif" font-size="48" font-weight="700" letter-spacing="10">TDF</text>
+</svg>

--- a/tdf-hq-ui/public/event-fallback.svg
+++ b/tdf-hq-ui/public/event-fallback.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-labelledby="title description">
+  <title id="title">Afiche de evento no disponible</title>
+  <desc id="description">Escenario abstracto de TDF iluminado en tonos violeta y turquesa.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#100b21"/>
+      <stop offset="0.58" stop-color="#392064"/>
+      <stop offset="1" stop-color="#075d68"/>
+    </linearGradient>
+    <radialGradient id="spotlight" cx="50%" cy="15%" r="62%">
+      <stop offset="0" stop-color="#ddd6fe" stop-opacity=".42"/>
+      <stop offset="1" stop-color="#ddd6fe" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#background)"/>
+  <rect width="1200" height="800" fill="url(#spotlight)"/>
+  <g fill="none" stroke="#ede9fe" stroke-linecap="round" stroke-linejoin="round" opacity=".84">
+    <path d="M310 575h580M375 575V345h450v230M335 345h530l-60-95H395z" stroke-width="26"/>
+    <path d="M480 345 410 575M600 345v230M720 345l70 230" stroke-width="18" opacity=".55"/>
+    <circle cx="430" cy="286" r="18" fill="#ede9fe" stroke="none"/>
+    <circle cx="600" cy="286" r="18" fill="#ede9fe" stroke="none"/>
+    <circle cx="770" cy="286" r="18" fill="#ede9fe" stroke="none"/>
+  </g>
+  <text x="600" y="720" text-anchor="middle" fill="#f5f3ff" font-family="system-ui, sans-serif" font-size="48" font-weight="700" letter-spacing="10">AGENDA TDF</text>
+</svg>

--- a/tdf-hq-ui/src/pages/DirectorySearchPage.test.tsx
+++ b/tdf-hq-ui/src/pages/DirectorySearchPage.test.tsx
@@ -14,8 +14,14 @@ const searchResponse = {
     imageUrl: 'https://images.example.test/synthetic-bassist.webp',
     location: { city: 'Quito', countryCode: 'EC', precision: 'city' },
     sponsored: false, score: 0.8,
+  }, {
+    id: '44444444-4444-4444-8444-444444444444', type: 'profile', slug: 'profile-without-photo',
+    title: 'Profile Without Photo', summary: 'Fixture sin una foto cargada.',
+    imageUrl: null,
+    location: { city: 'Quito', countryCode: 'EC', precision: 'city' },
+    sponsored: false, score: 0.7,
   }],
-  sponsoredItems: [], facets: { entityTypes: { profile: 1 }, cities: [], total: 1 },
+  sponsoredItems: [], facets: { entityTypes: { profile: 2 }, cities: [], total: 2 },
 };
 
 jest.unstable_mockModule('../api/directory', () => ({
@@ -65,6 +71,8 @@ describe('DirectorySearchPage', () => {
       await waitFor(() => {
         const profileImage = container.querySelector<HTMLImageElement>('img[alt="Foto de Synthetic Bassist"]');
         expect(profileImage?.src).toBe('https://images.example.test/synthetic-bassist.webp');
+        const fallbackImage = container.querySelector<HTMLImageElement>('img[alt="Imagen de referencia de Profile Without Photo"]');
+        expect(fallbackImage?.src).toBe('http://localhost/artist-fallback.svg');
       });
       await expectNoSeriousAccessibilityViolations(container);
     } finally {

--- a/tdf-hq-ui/src/pages/DirectorySearchPage.tsx
+++ b/tdf-hq-ui/src/pages/DirectorySearchPage.tsx
@@ -55,6 +55,13 @@ const resolveImageUrl = (value: string | null | undefined): string | undefined =
   try { return new URL(value, API_BASE_URL || window.location.origin).toString(); } catch { return undefined; }
 };
 
+const DIRECTORY_IMAGE_FALLBACKS: Record<DirectoryEntityType, string> = {
+  profile: '/artist-fallback.svg',
+  classified: '/directory-fallback.svg',
+  event: '/event-fallback.svg',
+  venue: '/directory-fallback.svg',
+};
+
 const CITY_STORAGE_KEY = 'tdf.directory.cityId';
 const ENTITY_LABELS: Record<DirectoryEntityType | 'all', string> = {
   all: 'Todo',
@@ -329,6 +336,8 @@ export default function DirectorySearchPage() {
 
 function ResultCard({ item, sessionActive, layout }: { item: DirectorySearchItem; sessionActive: boolean; layout: 'list' | 'grid' }) {
   const path = resultPath(item);
+  const fallbackImageUrl = new URL(DIRECTORY_IMAGE_FALLBACKS[item.type], window.location.origin).toString();
+  const imageUrl = resolveImageUrl(item.imageUrl) ?? fallbackImageUrl;
   const favorite = useMutation({
     mutationFn: () => Directory.addFavorite(item.type, item.id),
   });
@@ -347,22 +356,23 @@ function ResultCard({ item, sessionActive, layout }: { item: DirectorySearchItem
         overflow: 'hidden',
       }}
     >
-      {resolveImageUrl(item.imageUrl) && (
-        <CardMedia
-          component="img"
-          image={resolveImageUrl(item.imageUrl)}
-          alt={`Foto de ${item.title}`}
-          loading="lazy"
-          sx={{
-            width: layout === 'grid' ? '100%' : { xs: '100%', sm: 220 },
-            height: layout === 'grid' ? 220 : { xs: 240, sm: 'auto' },
-            minHeight: layout === 'list' ? { sm: 220 } : undefined,
-            objectFit: 'cover',
-            objectPosition: 'center',
-            flexShrink: 0,
-          }}
-        />
-      )}
+      <CardMedia
+        component="img"
+        image={imageUrl}
+        alt={item.imageUrl ? `Foto de ${item.title}` : `Imagen de referencia de ${item.title}`}
+        loading="lazy"
+        onError={(event) => {
+          if (event.currentTarget.src !== fallbackImageUrl) event.currentTarget.src = fallbackImageUrl;
+        }}
+        sx={{
+          width: layout === 'grid' ? '100%' : { xs: '100%', sm: 220 },
+          height: layout === 'grid' ? 220 : { xs: 240, sm: 'auto' },
+          minHeight: layout === 'list' ? { sm: 220 } : undefined,
+          objectFit: 'cover',
+          objectPosition: 'center',
+          flexShrink: 0,
+        }}
+      />
       <Box sx={{ display: 'flex', flex: 1, flexDirection: 'column', minWidth: 0 }}>
         <CardContent sx={{ flex: 1 }}>
           <Stack direction="row" justifyContent="space-between" gap={2}>

--- a/tdf-hq-ui/src/pages/UpcomingEventsPublicPage.test.tsx
+++ b/tdf-hq-ui/src/pages/UpcomingEventsPublicPage.test.tsx
@@ -44,4 +44,33 @@ describe('UpcomingEventsPublicPage', () => {
       expect.objectContaining({ city: 'Quito', limit: 50 }),
     ));
   });
+
+  it('renders each event with its poster or the event fallback', async () => {
+    listPublicUpcomingEventsMock.mockResolvedValue([
+      {
+        publicUpcomingEventId: '94',
+        publicUpcomingEventTitle: 'Erick Brian en Quito – Tour 2026',
+        publicUpcomingEventDescription: 'Una noche de música en Quito.',
+        publicUpcomingEventStart: '2026-08-27T23:00:00Z',
+        publicUpcomingEventCity: 'Quito',
+        publicUpcomingEventImageUrl: 'https://images.example.test/erick-brian.jpeg',
+        publicUpcomingEventWorkflowStateCode: 'published',
+      },
+      {
+        publicUpcomingEventId: '84',
+        publicUpcomingEventTitle: 'Evento sin afiche',
+        publicUpcomingEventStart: '2026-08-28T23:00:00Z',
+        publicUpcomingEventCity: 'Quito',
+        publicUpcomingEventImageUrl: null,
+        publicUpcomingEventWorkflowStateCode: 'published',
+      },
+    ]);
+
+    renderPage();
+
+    const poster = await screen.findByRole('img', { name: 'Afiche de Erick Brian en Quito – Tour 2026' });
+    expect(poster.getAttribute('src')).toBe('https://images.example.test/erick-brian.jpeg');
+    const fallback = screen.getByRole('img', { name: 'Imagen de referencia para Evento sin afiche' });
+    expect(fallback.getAttribute('src')).toBe('http://localhost/event-fallback.svg');
+  });
 });

--- a/tdf-hq-ui/src/pages/UpcomingEventsPublicPage.tsx
+++ b/tdf-hq-ui/src/pages/UpcomingEventsPublicPage.tsx
@@ -7,6 +7,7 @@ import {
   Box,
   Card,
   CardContent,
+  CardMedia,
   CircularProgress,
   InputAdornment,
   Stack,
@@ -15,8 +16,16 @@ import {
 } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 import { DateTime } from 'luxon';
+import { API_BASE_URL } from '../api/client';
 import { SocialEventsAPI, type PublicUpcomingEventDTO } from '../api/socialEvents';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
+
+const EVENT_IMAGE_FALLBACK = '/event-fallback.svg';
+
+const resolveEventImageUrl = (value: string | null | undefined): string | undefined => {
+  if (!value) return undefined;
+  try { return new URL(value, API_BASE_URL || window.location.origin).toString(); } catch { return undefined; }
+};
 
 const formatEventDate = (value?: string | null) => {
   if (!value) return 'Fecha por confirmar';
@@ -85,17 +94,61 @@ export default function UpcomingEventsPublicPage() {
       {eventsQuery.isError && <Alert severity="error">No pudimos cargar los próximos eventos. Intenta de nuevo.</Alert>}
       {eventsQuery.isSuccess && events.length === 0 && <Alert severity="info">No hay eventos próximos para esa ciudad.</Alert>}
       <Stack spacing={2}>
-        {events.map((event) => (
-          <Card key={event.publicUpcomingEventId} component={RouterLink} to={eventPath(event)} sx={{ textDecoration: 'none', color: 'inherit', '&:hover': { boxShadow: 5 } }}>
-            <CardContent>
-              <Typography variant="h6" component="h2" fontWeight={750}>{event.publicUpcomingEventTitle}</Typography>
-              <Typography color="primary" sx={{ mt: 0.75 }}>{formatEventDate(event.publicUpcomingEventStart)}</Typography>
-              {event.publicUpcomingEventCity && <Typography color="text.secondary" sx={{ mt: 0.5 }}>{event.publicUpcomingEventCity}</Typography>}
-              {event.publicUpcomingEventDescription && <Typography color="text.secondary" sx={{ mt: 1 }}>{event.publicUpcomingEventDescription}</Typography>}
-            </CardContent>
-          </Card>
-        ))}
+        {events.map((event) => <EventCard key={event.publicUpcomingEventId} event={event} />)}
       </Stack>
     </Box>
+  );
+}
+
+function EventCard({ event }: { event: PublicUpcomingEventDTO }) {
+  const fallbackImageUrl = new URL(EVENT_IMAGE_FALLBACK, window.location.origin).toString();
+  const imageUrl = resolveEventImageUrl(event.publicUpcomingEventImageUrl) ?? fallbackImageUrl;
+
+  return (
+    <Card
+      component={RouterLink}
+      to={eventPath(event)}
+      sx={{
+        display: 'flex',
+        flexDirection: { xs: 'column', sm: 'row' },
+        overflow: 'hidden',
+        textDecoration: 'none',
+        color: 'inherit',
+        '&:hover': { boxShadow: 5 },
+      }}
+    >
+      <CardMedia
+        component="img"
+        image={imageUrl}
+        alt={event.publicUpcomingEventImageUrl
+          ? `Afiche de ${event.publicUpcomingEventTitle}`
+          : `Imagen de referencia para ${event.publicUpcomingEventTitle}`}
+        loading="lazy"
+        onError={(loadEvent) => {
+          if (loadEvent.currentTarget.src !== fallbackImageUrl) loadEvent.currentTarget.src = fallbackImageUrl;
+        }}
+        sx={{
+          width: { xs: '100%', sm: 240 },
+          height: { xs: 220, sm: 'auto' },
+          minHeight: { sm: 220 },
+          objectFit: 'cover',
+          objectPosition: 'center',
+          flexShrink: 0,
+        }}
+      />
+      <CardContent sx={{ minWidth: 0, alignSelf: 'center' }}>
+        <Typography variant="h6" component="h2" fontWeight={750}>{event.publicUpcomingEventTitle}</Typography>
+        <Typography color="primary" sx={{ mt: 0.75 }}>{formatEventDate(event.publicUpcomingEventStart)}</Typography>
+        {event.publicUpcomingEventCity && <Typography color="text.secondary" sx={{ mt: 0.5 }}>{event.publicUpcomingEventCity}</Typography>}
+        {event.publicUpcomingEventDescription && (
+          <Typography
+            color="text.secondary"
+            sx={{ mt: 1, display: '-webkit-box', WebkitLineClamp: 4, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}
+          >
+            {event.publicUpcomingEventDescription}
+          </Typography>
+        )}
+      </CardContent>
+    </Card>
   );
 }


### PR DESCRIPTION
Adds responsive images to every public directory result and upcoming-event card. Uses the corresponding API image when available, with accessible TDF fallbacks for missing or broken media. Also clamps long event summaries to keep the list scannable.\n\nValidation:\n- Focused Jest: 3 tests passed\n- ESLint passed\n- UI typecheck passed\n- Production build and bundle budget passed\n- Headless desktop visual check passed\n- SVG validation passed