### PR TITLE
fix(web): redirect legacy public events route

### DIFF
--- a/tdf-hq-ui/src/routes/AppShell.test.tsx
+++ b/tdf-hq-ui/src/routes/AppShell.test.tsx
@@ -48,7 +48,7 @@ jest.unstable_mockModule('./RouteLoadingFallback', () => ({
   default: () => <div data-testid="route-loading" />,
 }));
 
-const { Shell } = await import('./AppShell');
+const { Shell, canonicalizeLegacySocialEventsPath } = await import('./AppShell');
 
 const flushPromises = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
@@ -71,6 +71,8 @@ const renderShell = async (container: HTMLElement, initialEntry: string) => {
             <Route path="/operacion/ordenes-marketplace" element={<div>Marketplace orders admin body</div>} />
             <Route path="/configuracion/estado" element={<div>System status body</div>} />
             <Route path="/inicio" element={<div>Home body</div>} />
+            <Route path="/social/eventos" element={<div>Public events body</div>} />
+            <Route path="/social/events" element={<div>Legacy events body</div>} />
           </Route>
         </Routes>
       </MemoryRouter>,
@@ -98,6 +100,27 @@ describe('Shell', () => {
 
   beforeEach(() => {
     window.localStorage.clear();
+  });
+
+  it('canonicalizes the legacy social events route and preserves deep links', () => {
+    expect(canonicalizeLegacySocialEventsPath('/social/events', '?city=Quito', '#agenda'))
+      .toBe('/social/eventos?city=Quito#agenda');
+    expect(canonicalizeLegacySocialEventsPath('/social/events/94'))
+      .toBe('/social/eventos/94');
+    expect(canonicalizeLegacySocialEventsPath('/social/events-descubiertos'))
+      .toBeNull();
+  });
+
+  it('redirects the legacy social events route to the canonical agenda', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const { cleanup } = await renderShell(container, '/social/events?city=Quito#agenda');
+
+    try {
+      expect(container.textContent).toContain('Public events body');
+    } finally {
+      await cleanup();
+    }
   });
 
   it('hides global floating helpers on the dense course registrations admin page', async () => {

--- a/tdf-hq-ui/src/routes/AppShell.tsx
+++ b/tdf-hq-ui/src/routes/AppShell.tsx
@@ -22,12 +22,32 @@ import { useNavigationPreferences } from '../hooks/useNavigationPreferences';
 import { getAnalyticsClient } from '../analytics/posthog';
 
 const DESKTOP_NAV_MIN_WIDTH = 1024;
+const LEGACY_SOCIAL_EVENTS_PATH = '/social/events';
+
+export function canonicalizeLegacySocialEventsPath(
+  pathname: string,
+  search = '',
+  hash = '',
+) {
+  const isLegacyEventsPath =
+    pathname === LEGACY_SOCIAL_EVENTS_PATH
+    || pathname.startsWith(`${LEGACY_SOCIAL_EVENTS_PATH}/`);
+  if (!isLegacyEventsPath) return null;
+
+  const suffix = pathname.slice(LEGACY_SOCIAL_EVENTS_PATH.length);
+  return `/social/eventos${suffix}${search}${hash}`;
+}
 
 export function Shell() {
   const theme = useTheme();
   const isDesktop = useMediaQuery(theme.breakpoints.up('lg'));
   const { session, loading } = useSession();
   const location = useLocation();
+  const legacyEventsTarget = canonicalizeLegacySocialEventsPath(
+    location.pathname,
+    location.search,
+    location.hash,
+  );
   const sidebarToggleRef = useRef<HTMLButtonElement | null>(null);
   const recordedPathRef = useRef('');
   const navigationPreferences = useNavigationPreferences(Boolean(session));
@@ -106,7 +126,7 @@ export function Shell() {
   }, [isDesktop, sidebarCollapsed]);
 
   useEffect(() => {
-    if (!session || loading) return;
+    if (!session || loading || legacyEventsTarget) return;
     const decision = evaluatePathAccess(location.pathname, {
       authenticated: true,
       roles: session.roles,
@@ -130,10 +150,14 @@ export function Shell() {
         route_registered: false,
       });
     }
-  }, [loading, location.pathname, navigationPreferences.visit, session]);
+  }, [legacyEventsTarget, loading, location.pathname, navigationPreferences.visit, session]);
 
   if (loading) {
     return <RouteLoadingFallback />;
+  }
+
+  if (legacyEventsTarget) {
+    return <Navigate to={legacyEventsTarget} replace />;
   }
 
   if (!session) {


### PR DESCRIPTION
## Summary
- redirect the legacy /social/events route to /social/eventos
- preserve query strings, hashes, and legacy deep-link suffixes
- cover canonicalization and the router redirect

## Verification
- npm test -- --runInBand src/routes/AppShell.test.tsx
- npx eslint src/routes/AppShell.tsx src/routes/AppShell.test.tsx
- npm run typecheck
- npm run build