### PR TITLE
fix(web): expose legacy events alias publicly

### DIFF
--- a/tdf-hq-ui/src/features/featureRegistry.test.ts
+++ b/tdf-hq-ui/src/features/featureRegistry.test.ts
@@ -35,6 +35,8 @@ describe('featureRegistry', () => {
     expect(getFeatureByPath('/label/ddex/documents/42/import')?.id).toBe('label.ddex.import');
     expect(getFeatureByPath('/social/eventos/nuevo')?.id).toBe('social.events.create');
     expect(getFeatureByPath('/social/eventos/abc')?.id).toBe('social.event.detail');
+    expect(getFeatureByPath('/social/events')?.id).toBe('social.events');
+    expect(getFeatureByPath('/social/events/abc')?.id).toBe('social.events');
     expect(getFeatureByPath('/practicas/tareas/task-123')?.id).toBe('internships');
     expect(getFeatureByPath('/not-a-real-route')).toBeNull();
   });

--- a/tdf-hq-ui/src/features/featureRegistry.ts
+++ b/tdf-hq-ui/src/features/featureRegistry.ts
@@ -229,6 +229,7 @@ function routePatternToRegex(pattern: string): RegExp {
   if (pattern === '/') return /^\/$/;
   const segments = pattern.split('/').filter(Boolean);
   const body = segments.map((segment) => {
+    if (segment === '*') return '(?:/.*)?';
     if (!segment.startsWith(':')) return `/${escapeRegex(segment)}`;
     return segment.endsWith('?') ? '(?:/[^/]+)?' : '/[^/]+';
   }).join('');

--- a/tdf-hq-ui/src/routes/AppShell.test.tsx
+++ b/tdf-hq-ui/src/routes/AppShell.test.tsx
@@ -3,6 +3,7 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { expectNoSeriousAccessibilityViolations } from '../test/accessibility';
+import { canonicalizeLegacySocialEventsPath } from '../utils/socialEventRoutes';
 
 const session = {
   username: 'admin',
@@ -48,7 +49,7 @@ jest.unstable_mockModule('./RouteLoadingFallback', () => ({
   default: () => <div data-testid="route-loading" />,
 }));
 
-const { Shell, canonicalizeLegacySocialEventsPath } = await import('./AppShell');
+const { Shell } = await import('./AppShell');
 
 const flushPromises = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 

--- a/tdf-hq-ui/src/routes/AppShell.tsx
+++ b/tdf-hq-ui/src/routes/AppShell.tsx
@@ -20,23 +20,9 @@ import UpcomingEventsPublicPage from '../pages/UpcomingEventsPublicPage';
 import { evaluatePathAccess } from '../features/featureRegistry';
 import { useNavigationPreferences } from '../hooks/useNavigationPreferences';
 import { getAnalyticsClient } from '../analytics/posthog';
+import { canonicalizeLegacySocialEventsPath } from '../utils/socialEventRoutes';
 
 const DESKTOP_NAV_MIN_WIDTH = 1024;
-const LEGACY_SOCIAL_EVENTS_PATH = '/social/events';
-
-export function canonicalizeLegacySocialEventsPath(
-  pathname: string,
-  search = '',
-  hash = '',
-) {
-  const isLegacyEventsPath =
-    pathname === LEGACY_SOCIAL_EVENTS_PATH
-    || pathname.startsWith(`${LEGACY_SOCIAL_EVENTS_PATH}/`);
-  if (!isLegacyEventsPath) return null;
-
-  const suffix = pathname.slice(LEGACY_SOCIAL_EVENTS_PATH.length);
-  return `/social/eventos${suffix}${search}${hash}`;
-}
 
 export function Shell() {
   const theme = useTheme();

--- a/tdf-hq-ui/src/routes/publicRoutes.test.tsx
+++ b/tdf-hq-ui/src/routes/publicRoutes.test.tsx
@@ -1,0 +1,52 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+
+import { renderPublicRoutes } from './publicRoutes';
+
+const flushPromises = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+function LocationProbe() {
+  const location = useLocation();
+  return (
+    <output data-testid="location">
+      {`${location.pathname}${location.search}${location.hash}`}
+    </output>
+  );
+}
+
+describe('public routes', () => {
+  beforeAll(() => {
+    (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  it('redirects the legacy events URL before the public wildcard route', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    let root: Root | null = createRoot(container);
+
+    try {
+      await act(async () => {
+        root?.render(
+          <MemoryRouter initialEntries={['/social/events?city=Quito#agenda']}>
+            <Routes>
+              {renderPublicRoutes()}
+              <Route path="/social/eventos/*" element={<LocationProbe />} />
+            </Routes>
+          </MemoryRouter>,
+        );
+        await flushPromises();
+      });
+
+      expect(container.querySelector('[data-testid="location"]')?.textContent)
+        .toBe('/social/eventos?city=Quito#agenda');
+    } finally {
+      await act(async () => {
+        root?.unmount();
+        await flushPromises();
+      });
+      root = null;
+      document.body.removeChild(container);
+    }
+  });
+});

--- a/tdf-hq-ui/src/routes/publicRoutes.tsx
+++ b/tdf-hq-ui/src/routes/publicRoutes.tsx
@@ -1,7 +1,8 @@
 import { lazyWithReload as lazy } from '../utils/lazyWithReload';
-import { Navigate, Route } from 'react-router-dom';
+import { Navigate, Route, useLocation } from 'react-router-dom';
 
 import PublicBranding from '../components/PublicBranding';
+import { canonicalizeLegacySocialEventsPath } from '../utils/socialEventRoutes';
 
 const ArtistOnboardingPage = lazy(() => import('../pages/ArtistOnboardingPage'));
 const ArtistPublicPage = lazy(() => import('../pages/ArtistPublicPage'));
@@ -39,6 +40,16 @@ const RecordsPublicPage = lazy(() => import('../pages/RecordsPublicPage'));
 const ResetPasswordPage = lazy(() => import('../pages/ResetPasswordPage'));
 const TrialsPage = lazy(() => import('../pages/TrialsPage'));
 const TdfPlatformPage = lazy(() => import('../pages/TdfPlatformPage'));
+
+export function LegacySocialEventsRedirect() {
+  const location = useLocation();
+  const target = canonicalizeLegacySocialEventsPath(
+    location.pathname,
+    location.search,
+    location.hash,
+  );
+  return <Navigate to={target ?? '/social/eventos'} replace />;
+}
 
 export function renderPublicRoutes() {
   return (
@@ -86,6 +97,7 @@ export function renderPublicRoutes() {
       <Route path="/whatsapp/consentimiento" element={<PublicBranding><PublicWhatsAppConsentPage /></PublicBranding>} />
       <Route path="/whatsapp/ok" element={<PublicBranding><PublicWhatsAppConsentSuccessPage /></PublicBranding>} />
       <Route path="/records" element={<PublicBranding><RecordsPublicPage /></PublicBranding>} />
+      <Route path="/social/events/*" element={<LegacySocialEventsRedirect />} />
       <Route path="/inventario/scan/:token" element={<PublicBranding><InventoryScanPage /></PublicBranding>} />
       <Route path="/donar" element={<PublicBranding><DonationPage /></PublicBranding>} />
       <Route path="/reservar" element={<PublicBranding><PublicBookingPage /></PublicBranding>} />

--- a/tdf-hq-ui/src/utils/socialEventRoutes.ts
+++ b/tdf-hq-ui/src/utils/socialEventRoutes.ts
@@ -1,0 +1,15 @@
+const LEGACY_SOCIAL_EVENTS_PATH = '/social/events';
+
+export function canonicalizeLegacySocialEventsPath(
+  pathname: string,
+  search = '',
+  hash = '',
+) {
+  const isLegacyEventsPath =
+    pathname === LEGACY_SOCIAL_EVENTS_PATH
+    || pathname.startsWith(`${LEGACY_SOCIAL_EVENTS_PATH}/`);
+  if (!isLegacyEventsPath) return null;
+
+  const suffix = pathname.slice(LEGACY_SOCIAL_EVENTS_PATH.length);
+  return `/social/eventos${suffix}${search}${hash}`;
+}

--- a/tdf-hq/assets/feature-registry.json
+++ b/tdf-hq/assets/feature-registry.json
@@ -705,6 +705,7 @@
       "globalMenu": true,
       "permissions": { "discover": {}, "view": {}, "create": {}, "edit": { "recordScope": "owner-or-admin" }, "delete": { "recordScope": "owner-or-admin" }, "publish": { "recordScope": "owner-or-admin" } },
       "mobilePresentation": { "kind": "native", "destination": "/(tabs)/events", "documentedException": null },
+      "aliases": ["/social/events/*"],
       "apiScopes": [{ "pathPrefix": "/social-events/events", "methods": { "GET": "view", "POST": "create", "PUT": "edit", "PATCH": "edit", "DELETE": "delete" } }, { "pathPrefix": "/social-events/me/city-subscriptions", "methods": { "GET": "view", "PUT": "edit" } }]
     },
     {


### PR DESCRIPTION
## Summary
- register /social/events as an explicit public route ahead of the catch-all
- redirect legacy event paths to /social/eventos while preserving suffixes, query strings, and hashes
- share canonicalization between public routing and the authenticated shell
- add an app-router regression test for the anonymous legacy URL

## Verification
- npm test -- --runInBand src/routes/publicRoutes.test.tsx src/routes/AppShell.test.tsx
- npx eslint src/routes/publicRoutes.tsx src/routes/publicRoutes.test.tsx src/routes/AppShell.tsx src/routes/AppShell.test.tsx src/utils/socialEventRoutes.ts
- npm run typecheck
- npm run build