### PR TITLE
fix(release): use guarded deploy lane for rollback

### DIFF
--- a/scripts/__tests__/production-release.test.mjs
+++ b/scripts/__tests__/production-release.test.mjs
@@ -6,6 +6,7 @@ import { readFileSync } from 'node:fs';
 import {
   buildDatabaseSqlInvocation,
   buildDeployPlan,
+  buildMachineDeployArgs,
   buildMachineRollbackImage,
   buildMigrationBatchSql,
   buildReleaseSteps,
@@ -564,6 +565,26 @@ test('buildMachineRollbackImage removes Fly Docker Hub mirror and duplicate dige
   assert.equal(buildMachineRollbackImage({
     image_ref: `docker-hub-mirror.fly.io/diegueins680/tdf-hq@${digest}@${digest}`,
   }), `diegueins680/tdf-hq@${digest}`);
+});
+
+test('buildMachineDeployArgs uses the guarded deploy lane for digest rollbacks', () => {
+  const digest = `sha256:${'b'.repeat(64)}`;
+  const image = `diegueins680/tdf-hq@${digest}`;
+  const args = buildMachineDeployArgs({
+    app: 'tdf-hq',
+    image,
+    sha: normalizedReleaseSha,
+    onlyMachine: 'canary-machine',
+  });
+
+  assert.deepEqual(args.slice(0, 3), ['flyctl', 'deploy', '.']);
+  assert.equal(args[args.indexOf('--image') + 1], image);
+  assert.equal(args.filter((value) => value === digest).length, 0);
+  assert.equal(args.filter((value) => value === image).length, 1);
+  assert.deepEqual(args.slice(-2), ['--only-machines', 'canary-machine']);
+  assert.ok(args.includes('--update-only'));
+  assert.ok(!args.includes('machine'));
+  assert.ok(!args.includes('update'));
 });
 
 test('validateFlyConfig requires an HTTP readiness check on /health', () => {

--- a/scripts/lib/production-release.mjs
+++ b/scripts/lib/production-release.mjs
@@ -2100,7 +2100,7 @@ END
 $verify$;`;
 }
 
-function deployCommand({ app, image, sha, onlyMachine, excludeMachine }) {
+export function buildMachineDeployArgs({ app, image, sha, onlyMachine, excludeMachine }) {
   const args = [
     'flyctl', 'deploy', '.',
     '--app', app,
@@ -2158,7 +2158,7 @@ export function buildReleaseSteps(options = {}) {
     id: 'rollback-canary',
     mutating: true,
     beforeStep: 'deploy-remaining',
-    command: deployCommand({
+    command: buildMachineDeployArgs({
       app,
       image: previousImage,
       sha: previousSha,
@@ -2171,7 +2171,7 @@ export function buildReleaseSteps(options = {}) {
       id: `deploy-remaining-${index + 1}`,
       machineId,
       mutating: true,
-      command: deployCommand({ app, image, sha, onlyMachine: machineId }),
+      command: buildMachineDeployArgs({ app, image, sha, onlyMachine: machineId }),
     },
     { id: `smoke-remaining-${index + 1}`, machineId, mutating: false },
   ]);
@@ -2184,7 +2184,7 @@ export function buildReleaseSteps(options = {}) {
     {
       id: 'deploy-canary',
       mutating: true,
-      command: deployCommand({ app, image, sha, onlyMachine: canary }),
+      command: buildMachineDeployArgs({ app, image, sha, onlyMachine: canary }),
     },
     { id: 'smoke-canary', mutating: false, onFailure: [rollbackCanary] },
     ...remainingSteps,

--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -11,6 +11,7 @@ import { promisify } from 'node:util';
 import {
   buildDatabaseSqlInvocation,
   buildDeployPlan,
+  buildMachineDeployArgs,
   buildMachineRollbackImage,
   buildMigrationBatchSql,
   buildSchemaPreflightSql,
@@ -529,26 +530,6 @@ async function smokeMachine(context, machineId, expectedSha = context.sha) {
   }
 }
 
-function deployArgs(context, selector, machineId, image = context.image, sha = context.sha) {
-  return [
-    'flyctl', 'deploy', '.',
-    '--app', context.app,
-    '--config', 'fly.toml',
-    '--image', image,
-    '--env', `SOURCE_COMMIT=${sha}`,
-    '--env', `GIT_SHA=${sha}`,
-    '--env', 'RUN_MIGRATIONS=false',
-    '--env', 'AUTO_APPLY_PRODUCTION_MIGRATIONS=true',
-    '--env', 'EVENT_DISCOVERY_ENABLED=false',
-    '--strategy', 'rolling',
-    '--max-unavailable', '1',
-    '--wait-timeout', '10m',
-    '--update-only',
-    '--yes',
-    selector, machineId,
-  ];
-}
-
 function previousImage(machine) {
   return buildMachineRollbackImage(machine);
 }
@@ -568,17 +549,14 @@ async function rollbackMachine(context, machine) {
   const image = machine.releaseSnapshot?.image ?? previousImage(machine);
   const sha = previousSha(machine);
   if (!image || !sha) throw new Error(`Cannot construct rollback for Machine ${machine.id}.`);
-  await run([
-    'flyctl', 'machine', 'update', machine.id,
-    '--app', context.app,
-    '--image', image,
-    '--env', `SOURCE_COMMIT=${sha}`,
-    '--env', `GIT_SHA=${sha}`,
-    '--env', 'RUN_MIGRATIONS=false',
-    '--env', 'AUTO_APPLY_PRODUCTION_MIGRATIONS=true',
-    '--env', 'EVENT_DISCOVERY_ENABLED=false',
-    '--yes',
-  ]);
+  // Keep rollback on the same deploy lane as rollout. `flyctl machine update`
+  // duplicates Docker Hub digest references as repo@digest@digest before the API call.
+  await run(buildMachineDeployArgs({
+    app: context.app,
+    image,
+    sha,
+    onlyMachine: machine.id,
+  }));
   const restored = (await readMachines(context.app)).find(({ id }) => id === machine.id);
   if (!restored) throw new Error(`Rolled-back Machine ${machine.id} disappeared.`);
   if (restored.image_ref?.digest !== machine.releaseSnapshot?.imageDigest) {
@@ -816,7 +794,12 @@ async function executeRelease(context) {
 
     await assertUntouchedSnapshots(context, originalMachines, touchedMachines);
     touchedMachines.add(canary.id);
-    await run(deployArgs(context, '--only-machines', canary.id, context.resolvedImage));
+    await run(buildMachineDeployArgs({
+      app: context.app,
+      image: context.resolvedImage,
+      sha: context.sha,
+      onlyMachine: canary.id,
+    }));
     try {
       report.canary = await verifyTargetMachine(context, canary.id);
     } catch (error) {
@@ -829,7 +812,12 @@ async function executeRelease(context) {
       await heartbeatReleaseLease(context, leaseToken);
       await assertUntouchedSnapshots(context, originalMachines, touchedMachines);
       touchedMachines.add(machine.id);
-      await run(deployArgs(context, '--only-machines', machine.id, context.resolvedImage));
+      await run(buildMachineDeployArgs({
+        app: context.app,
+        image: context.resolvedImage,
+        sha: context.sha,
+        onlyMachine: machine.id,
+      }));
       report.rollout.push(await verifyTargetMachine(context, machine.id));
     }
     report.fleet = await verifyFleet(context, originalMachines);


### PR DESCRIPTION
## Summary
- route production rollback through the same single-Machine flyctl deploy lane used by canary rollout
- share the deploy argv builder between executable releases and dry-run plans
- regress the observed Docker Hub digest case so the image reference is passed exactly once

## Root cause
The failed release artifact shows a correct repo@digest argument entering flyctl machine update, which rewrote it internally as repo@digest@digest. flyctl deploy --only-machines already handles the same immutable reference successfully.

## Validation
- npm run quality:repo
- npm run test:production-release (46/46)
- release:backend:plan dry run
- node syntax checks
- git diff --check

## Safety
No deployment, migration, or production mutation was performed. The current production fleet was inspected read-only and remains on the expected healthy digest.